### PR TITLE
Add auto-versioning and release generation

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,20 @@ script:
     echo "Not a pull request and/or no secure environment variables, running headless tests...";
     npm run test:polymer:local || travis_terminate 1;
   fi
+after_success:
+- frauci-update-version && export TRAVIS_TAG=$(frauci-get-version)
+deploy:
+  provider: releases
+  api_key: "$GITHUB_RELEASE_TOKEN"
+  on:
+    tags: true
 env:
   global:
+  - OWNER_NAME: Brightspacehypermediacomponents
+  - REPO_NAME: siren-sdk
+  - DEFAULT_INCREMENT: patch
   - SAUCE_USERNAME: Desire2Learn
+  # SAUCE_ACCESS_KEY
   - secure: WiTCzPVsxlRQc6IZ7W7vBU3i6ygfP4AipR2q1pKhndzmUqwKAX/l39E+ShB6eu6O1W6t4JLoL649LIIElMMiw5TljfsG50bq4hLyO7ydN/pie9WqE+u50h1cquzA6PxqpeDUDfGSH4Mn/du7bEUCHT/o8B0pO64jajvmTLD/PjsmSTy0XDucxpnhfRFQb2R7AfKIWBBN4HJL5J8zq/hlL7hWU/fuHcHU+lhDazBPYOvG1eolP7MPtASToqkli2hk5/Z24YlHO7Top88up0NhdRUKuEwBIidkoqU+UH/shFoIeW18aue6c5fHyg/6vT16QK5vRvhUOEB2vTThO0agJpbGT7UHTK8kuv4kFCBSJYZJa2kByPsyrOo7ggj25L3tbBMhZUGgnTb/Zjym+FjpbCaHsh3Sgp0pUkgKRj0p8NEKa+3TGJe0TQ8fFsJibu/3PFgm9pkYVkamz+ttb038ykwkJslPa7BTdO+I8uSDrrVvg+djP8vOh1sOp61Vm39B2PkWKC+ECrKNFdKAGyffH0Q7ojKAGoQPBkMNeZCqTGpz/FeS40ALs/GNCdY1hQj++P2NXuBNqiRa3LomcqFQpeOXNP0uauJJCeDPWnRdLx8/p8C9nIZFfye1eU09JqqAL7fDtCA3FRC6LFekwKkwy9HzBKaN0GQ4kVnQMFjNXZg=
+  # GITHUB_RELEASE_TOKEN (86ea......29c7)
+  - secure: VhT6T6ezigwgVECx3KqERwVk+b++KiSxPbzv21X4fpCz9T9UWNy2wMiPBlwpHI7+ICsg1AJ6qDbANC4USIgV3WONSXiRkuWunCFuaMvgx8tnJEFWzwAb0gNoQ7w0HLf2OsoD0ri7I939ogJMW7Y5KWqHp3TRs8u3RlpdVFG2h92LtpP/mfJwYcKv3pkooZCdtuHw8jGuUn3o1JNFa5iv8eq5yO7EYh0h7rmNgEIoH5hPZKwUnOgBy+fsQooVwS0Oncbotv1s2nSFl+QCIQFSyjmR0pcthJvwo/h9/HP5vym7ndd+izubok07wM5hNXKyDxWSERgXjmegUV5SDyu8e0CG9LKvg+B9UPbZ8IZ8D0PiXvFybaRuNc2o9sT8wlHpB9nAyGVt8e42dmSNrPJwvIzjJbcTu4Xhs4vngGrHZOw3cMqojnW8XhQFuz8TuShhy9mVtP46Ve+XGjwd5qeAaX0v582xrU++AwTBnSTAK2DsaIgmZoCiqDO7TNX5dbSiiQsgfW41NXuO287iYWscv+cAbEKiDFCnjfX/7mat1g4uLdVkzLbPZAiJVr7t0q5siI+i/Iu2ZQJ3m2icvNZ9tRRz0iwa7HTRCkayXWoZsAChsMx4Ktg4dZGI+BDTKmNr4euq9zNanZgMExt2hiyOWKXuf3GZYDnCmpTzjgPfE8M=

--- a/README.md
+++ b/README.md
@@ -11,9 +11,13 @@ Options for getting started:
 * Clone the repo: `git clone https://github.com/BrightspaceHypermediaComponents/siren-sdk.git`.
 * Install with [npm](https://www.npmjs.com/): `npm install siren-sdk`
 
-## Versioning
+## Versioning, Releasing & Deploying
 
 siren-sdk is maintained under [the Semantic Versioning guidelines](http://semver.org/).
+
+By default, when a pull request is merged the patch version in the `package.json` will be incremented, a tag will be created, and a Github release will be created.
+
+Include `[increment major]`, `[increment minor]` or `[skip version]` in your merge commit message to change the default versioning behavior.
 
 ## Contributing
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "siren-sdk",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "",
   "main": "index.js",
   "scripts": {
@@ -29,6 +29,7 @@
     "eslint": "^4.15.0",
     "eslint-config-brightspace": "^0.4.0",
     "eslint-plugin-html": "^4.0.1",
+    "frau-ci": "^1.40.0",
     "jsdoc": "^3.5.5",
     "lie": "^3.3.0",
     "polymer-cli": "^1.9.1",


### PR DESCRIPTION
# Changes
1. Add auto-versioning using `frau-ci` with the default behavior being to bump the patch version if no increment tag is specified in the commit.
1. Add automatic release creation
1. Update the `package.json` version to be consistent with the current release version.
