### PR TITLE
propegate error values from siren store

### DIFF
--- a/src/es6/EntityFactory.js
+++ b/src/es6/EntityFactory.js
@@ -7,16 +7,18 @@ import 'd2l-polymer-siren-behaviors/store/entity-store.js';
  * @param {Function} entityType The type of the entity. For example OrganizationEntity
  * @param {String} href Href of the entity to be created
  * @param {String|Token|Null} token JWT Token for brightspace | a function that returns a JWT token for brightspace | null (defaults to cookie authentication in a browser)
- * @param {Function} onChange Callback function that accepts an {entityType} to be called when entity changes.
+ * @param {Function} onChange Callback function that accepts an {entityType} to be called when entity changes. If there are errors onChange is called with (null, error)
  * @param {Object} entity (Optional) Entity that has already been fetched.
  */
 export function entityFactory(entityType, href, token, onChange, entity) {
 	const entityListener = new EntityListener();
-	const onChangeWrapped = (entity) => {
-		const entityWrapped = new entityType(entity, token, entityListener);
-		onChange(entityWrapped);
+	const onChangeWrapped = (entity, error) => {
+		if (entity) {
+			onChange(new entityType(entity, token, entityListener));
+		} else {
+			onChange(null, error);
+		}
 	};
-
 	// This add the listener then calls the fetch.
 	entityListener.add(href, token, onChangeWrapped, entity);
 }

--- a/test/consortium/ConsortiumTokenCollectionEntity.js
+++ b/test/consortium/ConsortiumTokenCollectionEntity.js
@@ -17,7 +17,7 @@ describe('Consortium entity', () => {
 			'entities': [],
 			'links': [
 				{
-					'rels': ['https://api.brightspace.com/rels/enrollments'],
+					'rel': ['https://api.brightspace.com/rels/enrollments'],
 					'href': '/enrollments.json'
 				},
 				{
@@ -95,14 +95,21 @@ describe('Consortium entity', () => {
 			expect(consortium._consortiumTokenEntities().length).to.equal(2);
 			const tokenEntities = [];
 			const rootEntities = [];
-			consortium.consortiumTokenEntities((entity) => {
+			const errors = [];
+			consortium.consortiumTokenEntities((entity, error) => {
+				if (error) {
+					errors.push(error);
+				}
 				tokenEntities.push(entity);
-				entity.rootOrganizationEntity((root) =>  {
+				entity.rootOrganizationEntity((root, error) =>  {
+					if (error) {
+						errors.push(error);
+					}
 					rootEntities.push(root);
 				});
 			});
 			setTimeout(() => {
-
+				expect(errors.length, 'callback errors, check test data for errors').to.be.equal(0);
 				expect(tokenEntities.length, 'token entities length invalid').to.be.equal(2);
 				for (const entity of tokenEntities) {
 					expect(entity).to.be.an.instanceof(ConsortiumTokenEntity);

--- a/test/es6/EntityFactory.html
+++ b/test/es6/EntityFactory.html
@@ -1,0 +1,20 @@
+<html>
+	<head>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1, user-scalable=yes">
+		<script src="../../../@webcomponents/webcomponentsjs/webcomponents-bundle.js"></script>
+		<script src="../../../wct-browser-legacy/browser.js"></script>
+
+		<script type="module" src="../../../siren-parser/global.js"></script>
+
+		<!-- For IE11 -->
+		<script src="../../../lie/dist/lie.polyfill.min.js"></script>
+		<script src="../../../whatwg-fetch/fetch.js"></script>
+
+
+
+	</head>
+	<body>
+		<script type="module" src="./EntityFactory.js"></script>
+	</body>
+</html>

--- a/test/es6/EntityFactory.js
+++ b/test/es6/EntityFactory.js
@@ -6,8 +6,26 @@ window.D2L.Siren.WhitelistBehavior._testMode(true);
 describe('Entityfactory', () => {
 
 	describe('errors', () => {
+		var sandbox;
+
+		beforeEach(() => {
+			sandbox = sinon.sandbox.create();
+
+			sandbox.stub(window.d2lfetch, 'fetch', () => {
+
+				return Promise.resolve({
+					ok: false,
+					status: 404
+				}
+				);
+			});
+		});
+
+		afterEach(() => {
+			sandbox.restore();
+		});
 		it('bubbles to onchange', done => {
-			entityFactory(Nothing, 'http://localhost:8000/not/a/valid/thing', 'wutsatoken', (entity, err) => {
+			entityFactory(Nothing, 'http://localhost/not/a/valid/thing', 'wutsatoken', (entity, err) => {
 				expect(entity).to.be.null;
 				expect(err).to.be.not.null;
 				expect(err).to.be.equal(404);

--- a/test/es6/EntityFactory.js
+++ b/test/es6/EntityFactory.js
@@ -1,0 +1,19 @@
+import { entityFactory } from '../../src/es6/EntityFactory';
+import { Nothing } from '../nothing-entity';
+
+/* global describe it expect sinon*/
+window.D2L.Siren.WhitelistBehavior._testMode(true);
+describe('Entityfactory', () => {
+
+	describe('errors', () => {
+		it('bubbles to onchange', done => {
+			entityFactory(Nothing, 'http://notadomain.superbadtld', 'wutsatoken', (entity, error) => {
+				expect(entity).to.be.null;
+				expect(error).to.be.not.null;
+				expect(error.message).to.be.equal('Failed to fetch');
+				done();
+			});
+		});
+	});
+});
+

--- a/test/es6/EntityFactory.js
+++ b/test/es6/EntityFactory.js
@@ -1,5 +1,5 @@
-import { entityFactory } from '../../src/es6/EntityFactory';
-import { Nothing } from '../nothing-entity';
+import { entityFactory } from '../../src/es6/EntityFactory.js';
+import { Nothing } from '../nothing-entity.js';
 
 /* global describe it expect sinon*/
 window.D2L.Siren.WhitelistBehavior._testMode(true);
@@ -7,12 +7,13 @@ describe('Entityfactory', () => {
 
 	describe('errors', () => {
 		it('bubbles to onchange', done => {
-			entityFactory(Nothing, 'http://notadomain.superbadtld', 'wutsatoken', (entity, error) => {
+			entityFactory(Nothing, 'http://localhost:8000/not/a/valid/thing', 'wutsatoken', (entity, err) => {
 				expect(entity).to.be.null;
-				expect(error).to.be.not.null;
-				expect(error.message).to.be.equal('Failed to fetch');
+				expect(err).to.be.not.null;
+				expect(err).to.be.equal(404);
 				done();
 			});
+
 		});
 	});
 });

--- a/test/index.html
+++ b/test/index.html
@@ -22,6 +22,7 @@
 			'./consortium/ConsortiumRootEntity.html',
 			'./EnrollmentEntity/EnrollmentEntity.html',
 			'./entity.html',
+			'./es6/EntityFactory.html',
 			'./mixin/entity-mixin-test.html',
 			'./PromotedSearchEntity/PromotedSearchEntity.html',
 			'./root/root.html',


### PR DESCRIPTION
The Siren sdk was eating any errors that the siren entity store was raising which made it impossible to  handle error cases if you were using the entity store.
