### PR TITLE
Add support for an alternate viewer href to the Sequences domain

### DIFF
--- a/src/sequences/SequenceEntity.js
+++ b/src/sequences/SequenceEntity.js
@@ -41,6 +41,15 @@ export class SequenceEntity extends Entity {
 		this._entity.getLinkByRel(sequenceViewerRel).href;
 	}
 
+	alternateViewerHref() {
+		const alternateViewerRel = 'alternate';
+		return (
+			this._entity &&
+			this._entity.hasLinkByRel(alternateViewerRel) &&
+			this._entity.getLinkByRel(alternateViewerRel).href
+		);
+	}
+
 	onSubSequencesChange(onChange) {
 		const subSequences = this._subSequences();
 

--- a/test/SequenceEntity/SequenceEntity.js
+++ b/test/SequenceEntity/SequenceEntity.js
@@ -59,6 +59,29 @@ describe('SequenceEntity', () => {
 			}, 50);
 		});
 
+		it('Check to get alternate viewer href', done => {
+			const sirenSequenceRoot =  window.D2L.Hypermedia.Siren.Parse(sequenceRootMultipleTopLevel);
+			const orgHref = {};
+			entityFactory(SequenceEntity, '/sequenceRoot2', 'whatever', (entity) => {
+				entity.onSubSequencesChange((subSequence) => {
+					orgHref[subSequence.index()] = subSequence.alternateViewerHref();
+				});
+			}, sirenSequenceRoot);
+
+			setTimeout(() => {
+				expect(orgHref[0]).to.equal(
+					'https://qa2019716994g.bspc.com/d2l/le/content/121694/Home?itemIdentifier=D2L.LE.Content.ContentObject.ModuleCO-121263'
+				);
+				expect(orgHref[1]).to.equal(
+					'https://qa2019716994g.bspc.com/d2l/le/content/121694/Home?itemIdentifier=D2L.LE.Content.ContentObject.ModuleCO-121264'
+				);
+				expect(orgHref[2]).to.equal(
+					'https://qa2019716994g.bspc.com/d2l/le/content/121694/Home?itemIdentifier=D2L.LE.Content.ContentObject.ModuleCO-121265'
+				);
+				done();
+			}, 50);
+		});
+
 		it('Check completion', done => {
 			const sirenSequenceRoot =  window.D2L.Hypermedia.Siren.Parse(sequenceRootMultipleTopLevel);
 			const completionData = {};


### PR DESCRIPTION
# Changes
- Add an `alternateViewerHref` function to the `SequenceEntity` to allow access to the alternate viewer rather than always using Enhanced Sequence Viewer