### PR TITLE
US110195 Add assignment instructions methods

### DIFF
--- a/src/activities/assignments/AssignmentEntity.js
+++ b/src/activities/assignments/AssignmentEntity.js
@@ -1,6 +1,7 @@
 'use strict';
 
 import { Entity } from '../../es6/Entity.js';
+import { Actions, Rels } from '../../hypermedia-constants';
 
 /**
  * AssignmentEntity class representation of a d2l Assignment.
@@ -9,12 +10,52 @@ export class AssignmentEntity extends Entity {
 	name() {
 		return this._entity && this._entity.properties && this._entity.properties.name;
 	}
+
 	canEditName() {
-		return this._entity && this._entity.hasActionByName('update-name');
-	}
-	getSaveNameAction() {
-		return this._entity && this._entity.getActionByName('update-name');
+		return this._entity && this._entity.hasActionByName(Actions.assignments.updateName);
 	}
 
+	getSaveNameAction() {
+		return this._entity && this._entity.getActionByName(Actions.assignments.updateName);
+	}
+
+	_getInstructionsEntity() {
+		return this._entity
+			&& this._entity.hasSubEntityByRel(Rels.Assignments.instructions)
+			&& this._entity.getSubEntityByRel(Rels.Assignments.instructions);
+	}
+
+	instructionsPlaintext() {
+		const instructionsEntity = this._getInstructionsEntity();
+		return instructionsEntity
+			&& instructionsEntity.properties
+			&& instructionsEntity.properties.text;
+	}
+
+	instructionsHtml() {
+		const instructionsEntity = this._getInstructionsEntity();
+		return instructionsEntity
+			&& instructionsEntity.properties
+			&& instructionsEntity.properties.html;
+	}
+
+	instructionsEditorHtml() {
+		const updateInstructionsAction = this.getSaveInstructionsAction();
+		return updateInstructionsAction
+			&& updateInstructionsAction.hasFieldByName('instructions')
+			&& updateInstructionsAction.getFieldByName('instructions').value;
+	}
+
+	canEditInstructions() {
+		const instructionsEntity = this._getInstructionsEntity();
+		return instructionsEntity
+			&& instructionsEntity.hasActionByName(Actions.assignments.updateInstructions);
+	}
+
+	getSaveInstructionsAction() {
+		const instructionsEntity = this._getInstructionsEntity();
+		return instructionsEntity
+			&& instructionsEntity.getActionByName(Actions.assignments.updateInstructions);
+	}
 }
 

--- a/src/hypermedia-constants.js
+++ b/src/hypermedia-constants.js
@@ -347,7 +347,9 @@ export const Actions = {
 	},
 	assignments: {
 		assign: 'assign',
-		delete: 'delete'
+		delete: 'delete',
+		updateInstructions: 'update-instructions',
+		updateName: 'update-name'
 	},
 	notifications: {
 		getCarrierClass: 'get-carrier',


### PR DESCRIPTION
These allow fetching and editing of the `instructions` on an assignment entity. There are three different representations of the instructions, all of which are made available:

- `instructionsPlaintext`: self-explanatory, this is the HTML-stripped version of the instructions (not really that useful)
- `instructionsHtml`: HTML version of the instructions for displaying the assignment instructions
- `instructionsEditorHtml`: HTML version of the instructions for usage in editors

An example of the difference between the latter two is that an `{orgUnitId}` string template in the former will show as e.g. "6606", whereas in the latter it will just be "{orgUnitId}".