### PR TITLE
US110195 Add getRichTextEditorConfig to AssignmentEntity

### DIFF
--- a/src/activities/assignments/AssignmentEntity.js
+++ b/src/activities/assignments/AssignmentEntity.js
@@ -57,5 +57,10 @@ export class AssignmentEntity extends Entity {
 		return instructionsEntity
 			&& instructionsEntity.getActionByName(Actions.assignments.updateInstructions);
 	}
+
+	getRichTextEditorConfig() {
+		return this._entity
+			&& this._entity.getSubEntityByRel(Rels.richTextEditorConfig);
+	}
 }
 


### PR DESCRIPTION
Missed this in the last change, but we also need to be able to fetch the `richtext-editor-config` subentity from an assignment, if present.