### PR TITLE
US110195 Modify getRichTextEditorConfig

### DIFF
--- a/src/activities/assignments/AssignmentEntity.js
+++ b/src/activities/assignments/AssignmentEntity.js
@@ -59,8 +59,9 @@ export class AssignmentEntity extends Entity {
 	}
 
 	getRichTextEditorConfig() {
-		return this._entity
-			&& this._entity.getSubEntityByRel(Rels.richTextEditorConfig);
+		const instructionsEntity = this._getInstructionsEntity();
+		return instructionsEntity
+			&& instructionsEntity.getSubEntityByRel(Rels.richTextEditorConfig);
 	}
 }
 


### PR DESCRIPTION
Merged the previous version of this a little too quickly - the richtext editor config should be a sub-entity of the richtext instructions entity, not on the assignment itself.