### PR TITLE
US111258 - Add ability to know how many elements are in the ConsortiumTokenCollectionEntity

### DIFF
--- a/src/consortium/ConsortiumTokenCollectionEntity.js
+++ b/src/consortium/ConsortiumTokenCollectionEntity.js
@@ -21,6 +21,14 @@ export class ConsortiumTokenCollectionEntity extends Entity {
 		}
 	}
 	/**
+	 *
+	 * @returns length of array of siren consortium entities
+	 */
+	getConsortiumTokenEntitiesLength() {
+		const tokenEntities = this._consortiumTokenEntities() || [];
+		return tokenEntities.length;
+	}
+	/**
 	 * @returns array of siren consortium entities, can be used to create {@link ConsortiumTokenEntity}
 	 */
 	_consortiumTokenEntities() {

--- a/test/consortium/ConsortiumTokenCollectionEntity.js
+++ b/test/consortium/ConsortiumTokenCollectionEntity.js
@@ -93,6 +93,7 @@ describe('Consortium entity', () => {
 			});
 			const consortium = new ConsortiumTokenCollectionEntity(entity);
 			expect(consortium._consortiumTokenEntities().length).to.equal(2);
+			expect(consortium.getConsortiumTokenEntitiesLength()).to.equal(2);
 			const tokenEntities = [];
 			const rootEntities = [];
 			const errors = [];
@@ -127,4 +128,3 @@ describe('Consortium entity', () => {
 		});
 	});
 });
-


### PR DESCRIPTION
This is the second of the three PRs, related to https://github.com/BrightspaceUI/navigation/pull/89.  Since the org tabs are all loaded and added asynchronously, I need a way to know how many tabs we can be expecting, or at least how many tokens we are going to try.  Once we have that, I can check if each of those are done loading, and _then_ tell the scrollbar to start moving.

@ctwomey1 Is this the best way to do this?  Is there an edge scenario I'm missing?