### PR TITLE
US110582 Add dueDate to ActivityUsageEntity

### DIFF
--- a/src/activities/ActivityUsageEntity.js
+++ b/src/activities/ActivityUsageEntity.js
@@ -1,7 +1,7 @@
 'use strict';
 
 import { Entity } from '../es6/Entity.js';
-import { Rels } from '../hypermedia-constants';
+import { Actions, Classes, Rels } from '../hypermedia-constants';
 import { OrganizationEntity } from '../organizations/OrganizationEntity.js';
 import { UserActivityUsageEntity } from '../enrollments/UserActivityUsageEntity.js';
 import { ActivityUsageCollectionEntity } from './ActivityUsageCollectionEntity.js';
@@ -47,5 +47,21 @@ export class ActivityUsageEntity extends Entity {
 	onActivityCollectionChange(onChange) {
 		const activityCollectionHref = this.activityCollectionHref();
 		activityCollectionHref && this._subEntity(ActivityUsageCollectionEntity, activityCollectionHref, onChange);
+	}
+
+	get dueDate() {
+		if (!this._entity || !this._entity.hasSubEntityByClass(Classes.dates.dueDate)) {
+			return;
+		}
+
+		return this._entity.getSubEntityByClass(Classes.dates.dueDate).properties.date;
+	}
+
+	get canEditDueDate() {
+		return this._entity && this._entity.hasActionByName(Actions.activities.update);
+	}
+
+	get saveDueDateAction() {
+		return this._entity && this._entity.getActionByName(Actions.activities.update);
 	}
 }

--- a/src/activities/ActivityUsageEntity.js
+++ b/src/activities/ActivityUsageEntity.js
@@ -1,5 +1,3 @@
-'use strict';
-
 import { Entity } from '../es6/Entity.js';
 import { Actions, Classes, Rels } from '../hypermedia-constants';
 import { OrganizationEntity } from '../organizations/OrganizationEntity.js';
@@ -49,7 +47,7 @@ export class ActivityUsageEntity extends Entity {
 		activityCollectionHref && this._subEntity(ActivityUsageCollectionEntity, activityCollectionHref, onChange);
 	}
 
-	get dueDate() {
+	dueDate() {
 		if (!this._entity || !this._entity.hasSubEntityByClass(Classes.dates.dueDate)) {
 			return;
 		}
@@ -57,11 +55,11 @@ export class ActivityUsageEntity extends Entity {
 		return this._entity.getSubEntityByClass(Classes.dates.dueDate).properties.date;
 	}
 
-	get canEditDueDate() {
+	canEditDueDate() {
 		return this._entity && this._entity.hasActionByName(Actions.activities.update);
 	}
 
-	get saveDueDateAction() {
+	saveDueDateAction() {
 		return this._entity && this._entity.getActionByName(Actions.activities.update);
 	}
 }

--- a/src/activities/ActivityUsageEntity.js
+++ b/src/activities/ActivityUsageEntity.js
@@ -47,19 +47,23 @@ export class ActivityUsageEntity extends Entity {
 		activityCollectionHref && this._subEntity(ActivityUsageCollectionEntity, activityCollectionHref, onChange);
 	}
 
-	dueDate() {
-		if (!this._entity || !this._entity.hasSubEntityByClass(Classes.dates.dueDate)) {
-			return;
-		}
+	_getDueDateSubEntity() {
+		return this._entity
+			&& this._entity.getSubEntityByClass(Classes.dates.dueDate);
+	}
 
-		return this._entity.getSubEntityByClass(Classes.dates.dueDate).properties.date;
+	dueDate() {
+		const dueDate = this._getDueDateSubEntity();
+		return dueDate && dueDate.properties.date;
 	}
 
 	canEditDueDate() {
-		return this._entity && this._entity.hasActionByName(Actions.activities.update);
+		const dueDate = this._getDueDateSubEntity();
+		return dueDate.hasActionByName(Actions.activities.update);
 	}
 
 	saveDueDateAction() {
-		return this._entity && this._entity.getActionByName(Actions.activities.update);
+		const dueDate = this._getDueDateSubEntity();
+		return dueDate.getActionByName(Actions.activities.update);
 	}
 }

--- a/src/activities/assignments/AssignmentEntity.js
+++ b/src/activities/assignments/AssignmentEntity.js
@@ -63,5 +63,12 @@ export class AssignmentEntity extends Entity {
 		return instructionsEntity
 			&& instructionsEntity.getSubEntityByRel(Rels.richTextEditorConfig);
 	}
-}
 
+	activityUsageHref() {
+		if (!this._entity || !this._entity.hasLinkByRel(Rels.Activities.activityUsage)) {
+			return;
+		}
+
+		return this._entity.getLinkByRel(Rels.Activities.activityUsage).href;
+	}
+}

--- a/src/hypermedia-constants.js
+++ b/src/hypermedia-constants.js
@@ -344,7 +344,8 @@ export const Actions = {
 		setCatalogImage: 'set-catalog-image'
 	},
 	activities: {
-		selectCustomDateRange: 'select-custom-date-range'
+		selectCustomDateRange: 'select-custom-date-range',
+		update: 'update'
 	},
 	assignments: {
 		assign: 'assign',


### PR DESCRIPTION
This adds accessors for `dueDate/canEditDueDate/saveDueDateAction` to the generic ActivityUsageEntity, which are required for the activity editor. When working with due dates, we're working with a generic activity (rather than a domain-specific entity e.g. `AssignmentActivityActivityUsage`).