### PR TITLE
US110582 Fixup logic

### DIFF
--- a/src/activities/ActivityUsageEntity.js
+++ b/src/activities/ActivityUsageEntity.js
@@ -59,11 +59,11 @@ export class ActivityUsageEntity extends Entity {
 
 	canEditDueDate() {
 		const dueDate = this._getDueDateSubEntity();
-		return dueDate.hasActionByName(Actions.activities.update);
+		return (dueDate && dueDate.hasActionByName(Actions.activities.update)) || false;
 	}
 
 	saveDueDateAction() {
 		const dueDate = this._getDueDateSubEntity();
-		return dueDate.getActionByName(Actions.activities.update);
+		return dueDate && dueDate.getActionByName(Actions.activities.update);
 	}
 }


### PR DESCRIPTION
Upon initial load, or for entities without a due date, we can end up trying to call `hasActionByName` on undefined. This fixes that, and also explicitly returns `false` for `canEditDueDate` rather than `undefined` if the user does not have the correct action.