### PR TITLE
Add SirenAction ES6 module

### DIFF
--- a/src/activities/ActivityUsageEntity.js
+++ b/src/activities/ActivityUsageEntity.js
@@ -3,6 +3,7 @@ import { Actions, Classes, Rels } from '../hypermedia-constants';
 import { OrganizationEntity } from '../organizations/OrganizationEntity.js';
 import { UserActivityUsageEntity } from '../enrollments/UserActivityUsageEntity.js';
 import { ActivityUsageCollectionEntity } from './ActivityUsageCollectionEntity.js';
+import { performSirenAction } from '../es6/SirenAction.js';
 
 /**
  * ActivityUsageEntity class representation of a d2l activity usage.
@@ -73,5 +74,20 @@ export class ActivityUsageEntity extends Entity {
 	saveDueDateAction() {
 		const dueDate = this._getDueDateSubEntity();
 		return dueDate && dueDate.getActionByName(Actions.activities.update);
+	}
+
+	async setDueDate(dateString) {
+		const dueDate = this.canEditDueDate && this._getDueDateSubEntity();
+		if (!dueDate) {
+			return;
+		}
+
+		const action = dueDate.getActionByName(Actions.activities.update);
+		if (!action) {
+			return;
+		}
+
+		const fields = [{ name: 'dueDate', value: dateString }];
+		await performSirenAction(this._token, action, fields);
 	}
 }

--- a/src/activities/assignments/AssignmentEntity.js
+++ b/src/activities/assignments/AssignmentEntity.js
@@ -1,7 +1,8 @@
 'use strict';
 
-import { Entity } from '../../es6/Entity.js';
+import { Entity } from '../../es6/Entity';
 import { Actions, Rels } from '../../hypermedia-constants';
+import { performSirenAction } from '../../es6/SirenAction';
 
 /**
  * AssignmentEntity class representation of a d2l Assignment.
@@ -13,6 +14,16 @@ export class AssignmentEntity extends Entity {
 
 	canEditName() {
 		return this._entity && this._entity.hasActionByName(Actions.assignments.updateName);
+	}
+
+	async setName(name) {
+		const action = this.canEditName() && this._entity.getActionByName(Actions.assignments.updateName);
+		if (!action) {
+			return;
+		}
+
+		const fields = [{ name: 'name', value: name }];
+		await performSirenAction(this._token, action, fields);
 	}
 
 	getSaveNameAction() {
@@ -56,6 +67,21 @@ export class AssignmentEntity extends Entity {
 		const instructionsEntity = this._getInstructionsEntity();
 		return instructionsEntity
 			&& instructionsEntity.getActionByName(Actions.assignments.updateInstructions);
+	}
+
+	async setInstructions(instructions) {
+		const instructionsEntity = this.canEditInstructions() && this._getInstructionsEntity();
+		if (!instructionsEntity) {
+			return;
+		}
+
+		const action = instructionsEntity.getActionByName(Actions.assignments.updateInstructions);
+		if (!action) {
+			return;
+		}
+
+		const fields = [{ name: 'instructions', value: instructions }];
+		await performSirenAction(this._token, action, fields);
 	}
 
 	getRichTextEditorConfig() {

--- a/src/es6/SirenAction.js
+++ b/src/es6/SirenAction.js
@@ -1,0 +1,161 @@
+import 'd2l-fetch/d2l-fetch.js';
+import 'd2l-polymer-siren-behaviors/store/entity-store.js';
+import 'd2l-polymer-siren-behaviors/store/action-queue.js';
+import SirenParse from 'siren-parser';
+
+const _getSirenFields = function(action) {
+	const url = new URL(action.href, window.location.origin);
+	const fields = [];
+	if (action.method === 'GET' || action.method === 'HEAD') {
+		for (const param in url.searchParams.entries()) {
+			fields.push({ name: param[0], value: param[1] });
+		}
+	}
+
+	if (action.fields && action.fields.forEach) {
+		action.fields.forEach(function(field) {
+			if (field.value === undefined) {
+				return;
+			}
+			// if the field is specified multiple times, assume it is intentional
+			fields.push({ name: field.name, value: field.value });
+		});
+	}
+	return fields;
+};
+
+const _getEntityUrl = function(action, fields) {
+	if (!action) {
+		return null;
+	}
+
+	let url = new URL(action.href, window.location.origin);
+
+	fields = fields || _getSirenFields(action);
+	if (action.method === 'GET' || action.method === 'HEAD') {
+		const params = _createURLSearchParams(fields);
+		url = new URL(url.pathname + '?' + params.toString(), url.origin);
+	}
+
+	return url;
+};
+
+const _createURLSearchParams = function(fields) {
+	const sequence = [];
+	for (let i = 0; i < fields.length; i++) {
+		const field = fields[i];
+		sequence.push([field.name, field.value]);
+	}
+	return new URLSearchParams(sequence);
+};
+
+const _createFormData = function(fields) {
+	const formData = new FormData();
+	for (let i = 0; i < fields.length; i++) {
+		formData.append(fields[i].name, fields[i].value);
+	}
+	return formData;
+};
+
+const _appendHiddenFields = function(action, fields) {
+	if (action.fields && action.fields.forEach) {
+		action.fields.forEach(function(field) {
+			if (field.type === 'hidden' && field.value !== undefined) {
+				fields.push({ name: field.name, value: field.value });
+			}
+		});
+	}
+	return fields;
+};
+
+const _fetch = function(href, opts) {
+	return window.d2lfetch.fetch(href, opts)
+		.then(function(resp) {
+			if (!resp.ok) {
+				const errMsg = resp.statusText + ' response executing ' + opts.method + ' on ' + href + '.';
+				return resp.json().then(function(data) {
+					throw { json: data, message: errMsg };
+				}, function(data) {
+					throw { string: data, message: errMsg };
+				});
+			}
+			const linkHeader = resp.headers ? resp.headers.get('Link') : null;
+			let links;
+			if (linkHeader) {
+				links = window.D2L.Siren.EntityStore.parseLinkHeader(linkHeader);
+			}
+			if (resp.status === 204) {
+				return {
+					body: null,
+					links: links
+				};
+			}
+			return resp.json().then(function(body) {
+				return {
+					body: body,
+					links: links
+				};
+			});
+		});
+};
+
+const _performSirenAction = function(action, fields, tokenValue) {
+	if (!action) {
+		return Promise.reject(new Error('No action given'));
+	}
+
+	const headers = new Headers();
+	tokenValue && headers.append('Authorization', 'Bearer ' + tokenValue);
+
+	const url = _getEntityUrl(action, fields);
+
+	let body;
+
+	if (fields) {
+		fields = _appendHiddenFields(action, fields);
+	} else {
+		fields = _getSirenFields(action);
+	}
+
+	if (action.type.indexOf('json') !== -1) {
+		const json = {};
+		for (let i = 0; i < fields.length; i++) {
+			const field = fields[i];
+			json[field.name] = field.value;
+		}
+		headers.set('Content-Type', action.type);
+		body = JSON.stringify(json);
+	} else if (action.method !== 'GET' && action.method !== 'HEAD') {
+		body = _createFormData(fields);
+	}
+
+	const token = tokenValue;
+
+	return _fetch(url.href, {
+		method: action.method,
+		body: body,
+		headers: headers
+	})
+		.then(function(result) {
+			const linkRequests = [];
+			if (result.links) {
+				result.links.forEach(function(link) {
+					linkRequests.push(window.D2L.Siren.EntityStore.fetch(link.href, token, true));
+				});
+			}
+			const entity = SirenParse(result.body);
+			return Promise.all(linkRequests).then(function() {
+				return window.D2L.Siren.EntityStore.update(url.href, token, entity);
+			});
+		});
+};
+
+export const performSirenAction = function(token, action, fields, immediate) {
+	return window.D2L.Siren.EntityStore.getToken(token)
+		.then(function(resolved) {
+			const tokenValue = resolved.tokenValue;
+			return !immediate ? window.D2L.Siren.ActionQueue.enqueue(function() {
+				return _performSirenAction(action, fields, tokenValue);
+			}) : _performSirenAction(action, fields, tokenValue);
+		});
+};

--- a/test/es6/SirenUtilTest.html
+++ b/test/es6/SirenUtilTest.html
@@ -1,0 +1,27 @@
+<html>
+
+<head>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1, user-scalable=yes">
+	<script src="../../../@webcomponents/webcomponentsjs/webcomponents-bundle.js"></script>
+	<script src="../../../wct-browser-legacy/browser.js"></script>
+
+	<script type="module" src="../../../siren-parser/global.js"></script>
+
+	<!-- For IE11 -->
+	<script src="../../../lie/dist/lie.polyfill.min.js"></script>
+	<script src="../../../whatwg-fetch/fetch.js"></script>
+
+	<script type="module" src="./SirenUtilTestComponent.js"></script>
+</head>
+
+<body>
+	<test-fixture id="basic">
+		<template>
+			<siren-util-test-component></siren-util-test-component>
+		</template>
+	</test-fixture>
+	<script type="module" src="./SirenUtilTest.js"></script>
+</body>
+
+</html>

--- a/test/es6/SirenUtilTest.js
+++ b/test/es6/SirenUtilTest.js
@@ -1,0 +1,187 @@
+/* global suite, test, fixture, expect, setup, teardown, sinon */
+
+'use strict';
+
+suite('SirenUtil', function() {
+	var element, sandbox;
+
+	var testAction = { // example from https://github.com/kevinswiber/siren
+		'name': 'add-item',
+		'title': 'Add Item',
+		'method': 'POST',
+		'href': 'http://api.x.io/orders/42/items',
+		'type': 'application/x-www-form-urlencoded',
+		'fields': [
+			{ 'name': 'orderNumber', 'type': 'hidden', 'value': '42' },
+			{ 'name': 'productCode', 'type': 'text' },
+			{ 'name': 'quantity', 'type': 'number' }
+		]
+	};
+
+	var testAction2 = {
+		'name': 'delete-item',
+		'title': 'Delete Item',
+		'method': 'DELETE',
+		'href': 'http://api.x.io/orders/42/items/5',
+		'type': 'application/x-www-form-urlencoded'
+	};
+
+	var testEntity = { // example from https://github.com/kevinswiber/siren
+		'class': ['order'],
+		'properties': {
+			'orderNumber': 42,
+			'itemCount': 3,
+			'status': 'pending'
+		},
+		'entities': [
+			{
+				'class': ['items', 'collection'],
+				'rel': ['http://x.io/rels/order-items'],
+				'href': 'http://api.x.io/orders/42/items'
+			},
+			{
+				'class': ['info', 'customer'],
+				'rel': ['http://x.io/rels/customer'],
+				'properties': {
+					'customerId': 'pj123',
+					'name': 'Peter Joseph'
+				},
+				'links': [
+					{ 'rel': ['self'], 'href': 'http://api.x.io/customers/pj123' }
+				]
+			}
+		],
+		'actions': [
+			{
+				'name': 'add-item',
+				'title': 'Add Item',
+				'method': 'POST',
+				'href': 'http://api.x.io/orders/42/items',
+				'type': 'application/x-www-form-urlencoded',
+				'fields': [
+					{ 'name': 'orderNumber', 'type': 'hidden', 'value': '42' },
+					{ 'name': 'productCode', 'type': 'text' },
+					{ 'name': 'quantity', 'type': 'number' }
+				]
+			}
+		],
+		'links': [
+			{ 'rel': ['self'], 'href': 'http://api.x.io/orders/42' },
+			{ 'rel': ['previous'], 'href': 'http://api.x.io/orders/41' },
+			{ 'rel': ['next'], 'href': 'http://api.x.io/orders/43' }
+		]
+	};
+
+	setup(function() {
+		sandbox = sinon.sandbox.create();
+		element = fixture('basic');
+		element.token = 'foozleberries';
+	});
+
+	teardown(function() {
+		sandbox.restore();
+		window.D2L.Siren.ActionQueue.queueEnd = Promise.resolve();
+		window.D2L.Siren.EntityStore.clear();
+	});
+
+	suite('smoke test', function() {
+		test('can be instantiated', function() {
+			expect(element.tagName.toLowerCase()).to.equal('siren-util-test-component');
+		});
+	});
+
+	suite('send action unit tests', function() {
+		var fetchStub;
+		setup(function() {
+			fetchStub = sinon.stub(window.d2lfetch, 'fetch');
+			var res = new window.Response(JSON.stringify(testEntity), {
+				status: 200,
+				headers: {
+					'Content-type': 'application/json'
+				},
+			});
+
+			fetchStub.returns(Promise.resolve(res));
+		});
+
+		teardown(function() {
+			fetchStub.restore();
+		});
+
+		test('send form-urlencoded', function() {
+			var result = element.performSirenAction(testAction);
+			result.then(function() {
+				expect(fetchStub.callCount).to.equal(1);
+				var requestUrl = fetchStub.getCall(0).args[0];
+				var requestMethod = fetchStub.getCall(0).args[1].method;
+				expect(requestUrl).to.equal('http://api.x.io/orders/42/items');
+				expect(requestMethod).to.equal('POST');
+			});
+			return result;
+		});
+	});
+
+	suite('enqueue action unit tests', function() {
+		var res1, res2;
+		var fetchStub;
+		var actionQueueSpy;
+		setup(function() {
+			actionQueueSpy = sinon.spy(window.D2L.Siren.ActionQueue, 'enqueue');
+			fetchStub = sinon.stub(window.d2lfetch, 'fetch');
+			res1 = new window.Response(JSON.stringify(testEntity), {
+				status: 200,
+				headers: {
+					'Content-type': 'application/json'
+				},
+			});
+			res2 = new window.Response(null, {
+				status: 204
+			});
+		});
+
+		teardown(function() {
+			fetchStub.restore();
+			actionQueueSpy.restore();
+		});
+
+		test('enqueues actions', function() {
+			fetchStub.withArgs('http://api.x.io/orders/42/items').returns(
+				new Promise(function(resolve) {
+					setTimeout(function() {
+						expect(fetchStub.callCount).to.equal(1);
+						expect(actionQueueSpy.callCount).to.equal(2);
+						resolve(res1);
+					});
+				})
+			);
+			fetchStub.withArgs('http://api.x.io/orders/42/items/5').returns(
+				new Promise(function(resolve) {
+					resolve(res2);
+				})
+			);
+			var firstCall = element.performSirenAction(testAction);
+			element.performSirenAction(testAction2);
+			return firstCall;
+		});
+
+		test('immediate actions skip queue', function() {
+			fetchStub.withArgs('http://api.x.io/orders/42/items').returns(
+				new Promise(function(resolve) {
+					setTimeout(function() {
+						expect(fetchStub.callCount).to.equal(2);
+						expect(actionQueueSpy.callCount).to.equal(1);
+						resolve(res1);
+					});
+				})
+			);
+			fetchStub.withArgs('http://api.x.io/orders/42/items/5').returns(
+				new Promise(function(resolve) {
+					resolve(res2);
+				})
+			);
+			var firstCall = element.performSirenAction(testAction);
+			element.performSirenAction(testAction2, null, true);
+			return firstCall;
+		});
+	});
+});

--- a/test/es6/SirenUtilTestComponent.js
+++ b/test/es6/SirenUtilTestComponent.js
@@ -1,0 +1,16 @@
+import { html, LitElement } from 'lit-element/lit-element.js';
+import { EntityMixinLit } from '../../src/mixin/entity-mixin-lit.js';
+import { SirenUtil } from '../../src/es6/SirenUtil.js';
+
+class SirenUtilTestComponent extends EntityMixinLit(LitElement) {
+	performSirenAction(action, fields, immediate) {
+		SirenUtil.performSirenAction(action, fields, immediate);
+	}
+
+	render() {
+		return html`
+			<div id="test">Test Component</div>
+		`;
+	}
+}
+customElements.define('siren-util-test-component', SirenUtilTestComponent);


### PR DESCRIPTION
This is basically a copy of the existing `siren-fetch-mixin-lit`, with the intent of replacing it entirely. (It will be removed entirely in a subsequent PR.) The intent of this ES6 module is to be able to do "Siren things" anywhere - right now limited to just `performSirenAction`, but potentially with more functionality to come. This can then be dropped into any class that extends `Entity`.

One difference between this and `siren-fetch-mixin-lit` is that `SirenAction.performSirenAction` doesn't emit `d2l-siren-entity-save-*` events. An HTMLElement is required to fire these events, and passing it in was weird and blurred the line of what exactly `siren-sdk` does - so instead, consumers of `SirenAction.performSirenAction` will be responsible for their own start/end/error behaviour, which is easily implemented. This keeps a clearer line between "Siren things" (which `siren-sdk` does) and ancillary behaviour (which is the responsibility of the consumer).