### PR TITLE
US110198 Add methods for submission type

### DIFF
--- a/src/hypermedia-constants.js
+++ b/src/hypermedia-constants.js
@@ -354,7 +354,8 @@ export const Actions = {
 		assign: 'assign',
 		delete: 'delete',
 		updateInstructions: 'update-instructions',
-		updateName: 'update-name'
+		updateName: 'update-name',
+		updateSubmissionType: 'update-submission-type'
 	},
 	notifications: {
 		getCarrierClass: 'get-carrier',


### PR DESCRIPTION
This simply surfaces the current submission type for assignment, the list of submission type options, and a method to update the current submission type. Note that this doesn't include full support for completion type (coming soon), which means that some options (On Paper and Observed in Person) will always use the default completion type of "Automatically on due date".