### PR TITLE
US110198 Fixup setSubmissionType

### DIFF
--- a/src/activities/assignments/AssignmentEntity.js
+++ b/src/activities/assignments/AssignmentEntity.js
@@ -135,7 +135,9 @@ export class AssignmentEntity extends Entity {
 		}
 
 		const validCompletionTypes = fieldValue.completionTypes;
-		if (validCompletionTypes !== null && validCompletionTypes.indexOf(completionType) === -1) {
+		if (validCompletionTypes === null) {
+			completionType = 0;
+		} else if (validCompletionTypes.indexOf(completionType) === -1) {
 			throw new Error(`Invalid completionType ${completionType} for submissionType ${submissionType}`);
 		}
 


### PR DESCRIPTION
When setting the submissionType to one that doesn't have a completion type, we must set the `completionType` to 0 in the request, otherwise we get a 400 from the LMS (i.e. we always have to set both the submissionType and completionType in the request, "clearing" the latter when it doesn't apply).