### PR TITLE
US111410 Add support for adding due date

### DIFF
--- a/src/activities/ActivityUsageEntity.js
+++ b/src/activities/ActivityUsageEntity.js
@@ -69,8 +69,7 @@ export class ActivityUsageEntity extends Entity {
 	canEditDueDate() {
 		const dueDate = this._getDueDateSubEntity();
 		return (dueDate && dueDate.hasActionByName(Actions.activities.update))
-			|| this._entity.hasActionByName(Actions.activities.startAddNew)
-			|| false;
+			|| this._entity.hasActionByName(Actions.activities.startAddNew);
 	}
 
 	async setDueDate(dateString) {

--- a/src/hypermedia-constants.js
+++ b/src/hypermedia-constants.js
@@ -347,7 +347,9 @@ export const Actions = {
 		setCatalogImage: 'set-catalog-image'
 	},
 	activities: {
+		create: 'create',
 		selectCustomDateRange: 'select-custom-date-range',
+		startAddNew: 'start-add-new',
 		update: 'update'
 	},
 	assignments: {


### PR DESCRIPTION
This uses the new `start-add-new` workflow to set an initial due date if one isn't already set. This is exposed via the same `setDueDate` method, meaning the consumer is blind to this change, and the `siren-sdk` will either set or update the due date as required.

This also removes a method that returns a Siren action, as this was added in error - `siren-sdk` should not expose Siren objects.