### PR TITLE
US111526 Add completion type support

### DIFF
--- a/src/hypermedia-constants.js
+++ b/src/hypermedia-constants.js
@@ -357,6 +357,7 @@ export const Actions = {
 		delete: 'delete',
 		updateInstructions: 'update-instructions',
 		updateName: 'update-name',
+		updateCompletionType: 'update-completion-type',
 		updateSubmissionType: 'update-submission-type'
 	},
 	notifications: {


### PR DESCRIPTION
This adds support for completion type values, and slightly modifies how the submission type works - in particular, you should be able to set a submission type without having to also set the completion type - we can silently just set it to the first completion type value as necessary, as a sort of fallback/default.

On the other hand, when setting the completion type, the assumption is that we are _only_ modifying the completion type, i.e. the function is only called when setting a completion type is a valid thing to do.