### PR TITLE
US111610 Fix method name

### DIFF
--- a/src/activities/assignments/AssignmentEntity.js
+++ b/src/activities/assignments/AssignmentEntity.js
@@ -79,7 +79,7 @@ export class AssignmentEntity extends Entity {
 		await performSirenAction(this._token, action, fields);
 	}
 
-	getRichTextEditorConfig() {
+	instructionsRichTextEditorConfig() {
 		const instructionsEntity = this._getInstructionsEntity();
 		return instructionsEntity
 			&& instructionsEntity.getSubEntityByRel(Rels.richTextEditorConfig);


### PR DESCRIPTION
This configuration is specifically attached to the richtext instructions entity, which means the previous name was overly generic. Strictly speaking, they all come from the same place anyway, but that's not for the consumer to know.