### PR TITLE
Add mixin that fires a custom event to signal siren entity save or fail

### DIFF
--- a/src/mixin/save-status-mixin.js
+++ b/src/mixin/save-status-mixin.js
@@ -1,0 +1,25 @@
+export const SaveStatusMixin = superclass => class extends superclass {
+	wrapSaveAction(promise) {
+		this.dispatchEvent(new CustomEvent('d2l-siren-entity-save-start', {
+			bubbles: true,
+			composed: true
+		}));
+
+		return promise
+			.then(result => {
+				this.dispatchEvent(new CustomEvent('d2l-siren-entity-save-end', {
+					bubbles: true,
+					composed: true
+				}));
+
+				return result;
+			})
+			.catch(error => {
+				this.dispatchEvent(new CustomEvent('d2l-siren-entity-save-error', {
+					error,
+					bubbles: true,
+					composed: true
+				}));
+			});
+	}
+};


### PR DESCRIPTION
To be used by BrightspaceHypermediaComponents/activities/components/d2l-activity-editor and BrightspaceHypermediaComponents/organizations/components/d2l-organization-availability-set