### PR TITLE
If the save promise fails, we should return the error instead of lett…

### DIFF
--- a/src/mixin/save-status-mixin.js
+++ b/src/mixin/save-status-mixin.js
@@ -20,6 +20,8 @@ export const SaveStatusMixin = superclass => class extends superclass {
 					bubbles: true,
 					composed: true
 				}));
+
+				return Promise.reject(error);
 			});
 	}
 };


### PR DESCRIPTION
…ing it die in our wrapper

This allows us to do `wrapSaveAction(promise).then(resolve, reject);`