### PR TITLE
US111949 Add AttachmentCollectionEntity

### DIFF
--- a/src/activities/ActivityUsageEntity.js
+++ b/src/activities/ActivityUsageEntity.js
@@ -113,7 +113,7 @@ export class ActivityUsageEntity extends Entity {
 	 * @param {string} dateString Date string to set as the due date, or empty string to clear the due date
 	 */
 	async setDueDate(dateString) {
-		if (!this.canEditDueDate) {
+		if (!this.canEditDueDate()) {
 			return;
 		}
 

--- a/src/activities/AttachmentCollectionEntity.js
+++ b/src/activities/AttachmentCollectionEntity.js
@@ -1,0 +1,91 @@
+'use strict';
+
+import { Entity } from '../es6/Entity';
+import { performSirenAction } from '../es6/SirenAction';
+
+/**
+ * Entity representation of a collection of attachments
+ */
+export class AttachmentCollectionEntity extends Entity {
+	/**
+	 * @returns {Array} Returns all Attachment sub-entities from the attachments collection
+	 */
+	getAttachmentEntities() {
+		return this._entity.getSubEntitiesByRel('item');
+	}
+
+	/**
+	 * @returns {bool} Returns true if any valid action to add attachments is present on the entity
+	 */
+	canAddAttachments() {
+		return this.canAddLinkAttachment()
+			|| this.canAddGoogleDriveLinkAttachment()
+			|| this.canAddOneDriveLinkAttachment();
+	}
+
+	/**
+	 * @returns {bool} Returns true if the add-link action is present on the entity
+	 */
+	canAddLinkAttachment() {
+		return this._entity.hasActionByName('add-link');
+	}
+
+	/**
+	 * Adds a link attachment to the attachments collection
+	 * @param {string} name Name for the link attachment
+	 * @param {string} href URL of the link attachment
+	 */
+	async addLinkAttachment(name, href) {
+		if (!this.canAddLinkAttachment()) {
+			return;
+		}
+
+		const action = this._entity.getActionByName('add-link');
+		const fields = [{ name: name, href: href }];
+		await performSirenAction(this._token, action, fields);
+	}
+
+	/**
+	 * @returns {bool} Returns true if the add-google-drive-link action is present on the entity
+	 */
+	canAddGoogleDriveLinkAttachment() {
+		return this._entity.hasActionByName('add-google-drive-link');
+	}
+
+	/**
+	 * Adds a Google Drive link attachment to the attachments collection
+	 * @param {string} name Name for the Google Drive link attachment
+	 * @param {string} href URL of the Google Drive link attachment
+	 */
+	async addGoogleDriveLinkAttachment(name, href) {
+		if (!this.canAddGoogleDriveLinkAttachment()) {
+			return;
+		}
+
+		const action = this._entity.getActionByName('add-google-drive-link');
+		const fields = [{ name: name, href: href }];
+		await performSirenAction(this._token, action, fields);
+	}
+
+	/**
+	 * @returns {bool} Returns true if the add-onedrive-link action is present on the entity
+	 */
+	canAddOneDriveLinkAttachment() {
+		return this._entity.hasActionByName('add-onedrive-link');
+	}
+
+	/**
+	 * Adds a OneDrive link attachment to the attachments collection
+	 * @param {string} name Name for the OneDrive link attachment
+	 * @param {string} href URL of the OneDrive link attachment
+	 */
+	async addOneDriveLinkAttachment(name, href) {
+		if (!this.canAddOneDriveLinkAttachment()) {
+			return;
+		}
+
+		const action = this._entity.getActionByName('add-onedrive-link');
+		const fields = [{ name: name, href: href }];
+		await performSirenAction(this._token, action, fields);
+	}
+}

--- a/src/activities/AttachmentCollectionEntity.js
+++ b/src/activities/AttachmentCollectionEntity.js
@@ -41,7 +41,11 @@ export class AttachmentCollectionEntity extends Entity {
 		}
 
 		const action = this._entity.getActionByName('add-link');
-		const fields = [{ name: name, href: href }];
+		const fields = [{
+			name: 'name', value: name
+		}, {
+			name: 'href', value: href
+		}];
 		await performSirenAction(this._token, action, fields);
 	}
 
@@ -63,7 +67,11 @@ export class AttachmentCollectionEntity extends Entity {
 		}
 
 		const action = this._entity.getActionByName('add-google-drive-link');
-		const fields = [{ name: name, href: href }];
+		const fields = [{
+			name: 'name', value: name
+		}, {
+			name: 'href', value: href
+		}];
 		await performSirenAction(this._token, action, fields);
 	}
 
@@ -85,7 +93,11 @@ export class AttachmentCollectionEntity extends Entity {
 		}
 
 		const action = this._entity.getActionByName('add-onedrive-link');
-		const fields = [{ name: name, href: href }];
+		const fields = [{
+			name: 'name', value: name
+		}, {
+			name: 'href', value: href
+		}];
 		await performSirenAction(this._token, action, fields);
 	}
 }

--- a/src/activities/assignments/AssignmentEntity.js
+++ b/src/activities/assignments/AssignmentEntity.js
@@ -258,4 +258,15 @@ export class AssignmentEntity extends Entity {
 		];
 		await performSirenAction(this._token, action, fields);
 	}
+
+	/**
+	 * @returns {string} URL of the assignment's attachments collection
+	 */
+	attachmentsCollectionHref() {
+		if (!this._entity || !this._entity.hasLinkByRel(Rels.Assignments.attachments)) {
+			return;
+		}
+
+		return this._entity.getLinkByRel(Rels.Assignments.attachments).href;
+	}
 }


### PR DESCRIPTION
This is an entity representation of an attachment collection. Currently, this is only being used in the assignments domain, but the design of this entity is generic enough that it could easily be applied to the activities domain (decisions underway on that). For now, this just gives us the basic abilities we need to show an attachment-picker component, in particular knowing whether or not certain actions are available to the user.