### PR TITLE
US112016 Add AttachmentEntity

### DIFF
--- a/src/activities/AttachmentEntity.js
+++ b/src/activities/AttachmentEntity.js
@@ -1,0 +1,20 @@
+import { Entity } from '../es6/Entity';
+
+/**
+ * AttachmentEntity class representation of an attachment (link or file)
+ */
+export class AttachmentEntity extends Entity {
+	/**
+	 * @returns {string} Attachment's name
+	 */
+	name() {
+		return this._entity && this._entity.properties && this._entity.properties.name;
+	}
+
+	/**
+	 * @returns {string} Attachment's location (for link attachments)
+	 */
+	href() {
+		return this._entity && this._entity.properties && this._entity.properties.href;
+	}
+}

--- a/src/activities/AttachmentEntity.js
+++ b/src/activities/AttachmentEntity.js
@@ -1,4 +1,5 @@
 import { Entity } from '../es6/Entity';
+import { performSirenAction } from '../es6/SirenAction';
 
 /**
  * AttachmentEntity class representation of an attachment (link or file)
@@ -16,5 +17,24 @@ export class AttachmentEntity extends Entity {
 	 */
 	href() {
 		return this._entity && this._entity.properties && this._entity.properties.href;
+	}
+
+	/**
+	 * @returns {bool} True if the delete action is present on the attachment
+	 */
+	canDeleteAttachment() {
+		return this._entity && this._entity.hasActionByName('delete');
+	}
+
+	/**
+	 * Calls the Siren action to delete this attachment
+	 */
+	async deleteAttachment() {
+		if (!this.canDeleteAttachment()) {
+			return;
+		}
+
+		const action = this._entity.getActionByName('delete');
+		await performSirenAction(this._token, action);
 	}
 }


### PR DESCRIPTION
This is a (very) generic entity that can represent an attachment on an activity - this only works for link attachments right now, but it will likely be changed/moved/updated/renamed when we tackle file attachments in the near future. (Rather than spending hours trying to predict what things will look like for file attachments, it's easier to just make something that works for links now, and come back to it later for files.)