### PR TITLE
subEntity load promise

### DIFF
--- a/src/es6/Entity.js
+++ b/src/es6/Entity.js
@@ -95,9 +95,15 @@ export class Entity {
 				this._subEntities.set(source, entity);
 				onChange(entity, error);
 				if (error) {
-					reject();
+					reject && reject();
+					resolve = null;
+					reject = null;
 				} else {
-					Promise.all(entity._subEntitiesLoadStatus).then(resolve);
+					Promise.all(entity._subEntitiesLoadStatus).then(() => {
+						resolve && resolve();
+						resolve = null;
+						reject = null;
+					});
 				}
 			});
 		}));
@@ -126,7 +132,10 @@ export class Entity {
 			entityFactory(entityType, href, this._token, (entity) => {
 				this._subEntities.set(href, entity);
 				onChange(entity);
-				Promise.all(entity._subEntitiesLoadStatus).then(resolve);
+				Promise.all(entity._subEntitiesLoadStatus).then(() => {
+					resolve && resolve();
+					resolve = null;
+				});
 			}, entity);
 		}));
 	}

--- a/src/es6/Entity.js
+++ b/src/es6/Entity.js
@@ -38,8 +38,8 @@ export class Entity {
 
 		return this._entity.getLinkByRel('self').href;
 	}
-	async subEntitiesLoaded() {
-		await Promise.all(this._subEntitiesLoadStatus);
+	subEntitiesLoaded() {
+		return Promise.all(this._subEntitiesLoadStatus);
 	}
 	/**
 	 * Cleans up this entity by deleting the callbacks listeners stored in the entity store.

--- a/test/mixin/entity-mixin-test.js
+++ b/test/mixin/entity-mixin-test.js
@@ -72,7 +72,7 @@ describe('d2l-organization-name', () => {
 	afterEach(() => {
 		sandbox.restore();
 	});
-	[ 'lit' ].forEach(mixinType => {
+	[ 'lit', 'polymer' ].forEach(mixinType => {
 		describe(`Testing Swap ${mixinType}`, () => {
 			let spy, spy2;
 			beforeEach(done => {
@@ -101,6 +101,7 @@ describe('d2l-organization-name', () => {
 					expect(code.innerHTML.replace(/<!---->/g, '')).to.be.equal('SCI100');
 					expect(semesterNameDirect.innerHTML.replace(/<!---->/g, '')).to.be.equal('Semester Name');
 					expect(semesterName.innerHTML.replace(/<!---->/g, '')).to.be.contains('Semester Name');
+					expect(component._semesterNameDirectLoaded).to.be.equal('Semester Name');
 					done();
 				});
 

--- a/test/utility/siren-sdk-organization-info-lit.js
+++ b/test/utility/siren-sdk-organization-info-lit.js
@@ -24,6 +24,7 @@ class SdkSirenOrganizationInfoLit extends EntityMixinLit(LitElement) {
 	constructor() {
 		super();
 		this._setEntityType(OrganizationEntity);
+		this._semesterNameDirectLoaded = null;
 	}
 
 	render() {
@@ -41,6 +42,10 @@ class SdkSirenOrganizationInfoLit extends EntityMixinLit(LitElement) {
 		this._semesterHref = organization._semesterHref();
 		organization.onSemesterChange((semester) => {
 			this._semesterNameDirect = semester.name();
+		});
+
+		organization.subEntitiesLoaded().then(() => {
+			this._semesterNameDirectLoaded = this._semesterNameDirect;
 		});
 	}
 }

--- a/test/utility/siren-sdk-organization-info.js
+++ b/test/utility/siren-sdk-organization-info.js
@@ -53,6 +53,10 @@ class SdkSirenOrganizationInfo extends EntityMixin(PolymerElement) {
 		organization.onSemesterChange((semester) => {
 			this._semesterNameDirect = semester.name();
 		});
+
+		organization.subEntitiesLoaded().then(() => {
+			this._semesterNameDirectLoaded = this._semesterNameDirect;
+		});
 	}
 }
 


### PR DESCRIPTION
Did you ever have the problem where you wanted to use lit's awesome async states but just didn't have a promise when all the entities have loaded?

Well, now you can use `subEntitiesLoaded()` which is a promise that will load when all the sub entities have loaded. It even deals with multiple levels too!

For example, consider having a component root hypermedia entity be an ActivityUsage. That activity usage turns out to have a collection. This is how we would let litElement know when the list of items has changed after everything has loaded:
```
_onActivityUsageChange(usage) {
	usage.onSpecializationChange(NamedEntityMixin(DescribableEntityMixin(SimpleEntity)), (specialization) => {
		this._specialization = specialization;
		this._name = specialization.getName();
		this._description = specialization.getDescription();
	});

	usage.onActivityCollectionChange(async collection => {
		collection.onItemsChange((item, index) => {
			item.onActivityUsageChange((usage) => {
				usage.onOrganizationChange((organization) => {
					this._items[index] = organization;
					if (this._updateSingles) {
						this.requestUpdate('_items', []);
					}
				});
			});
		});

		await collection.subEntitiesLoaded();
		this.requestUpdate('_items', []);
		this._updateSingles = true;
	});
}
``` 