### PR TITLE
Stop d2l-pending-state event propagation

### DIFF
--- a/src/mixin/pending-container-mixin.js
+++ b/src/mixin/pending-container-mixin.js
@@ -32,6 +32,9 @@ export const PendingContainerMixin = superclass => class extends superclass {
 		}
 		this._hasPendingChildren = true;
 		this.__pendingCount++;
+
+		e.stopPropagation();
+
 		try {
 			await promise;
 		} catch (e) {


### PR DESCRIPTION
By allowing the `d2l-pending-state` event to continue bubbling up the DOM, through every `PendingContainerMixin` element, we end up in a situation where the topmost Container can make overarching decisions that it shouldn't necessarily make.

In FACE, this shows when adding a new attachment - the list of attachments emits the `d2l-pending-state` event, and we want to dynamically reload/re-render just the attachment list. However, the event continues to bubble up to the top level, which interprets as "the page is still loading", and switches to show the "Loading..." text, effectively re-rendering the entire page. By stopping the event's propagation, we can have better control over how much of the page re-renders - effectively saying "if any of my children emit `d2l-pending-state`, I can handle the loading state for them".