### PR TITLE
US112361 Add file attachment methods

### DIFF
--- a/src/activities/AttachmentCollectionEntity.js
+++ b/src/activities/AttachmentCollectionEntity.js
@@ -20,7 +20,8 @@ export class AttachmentCollectionEntity extends Entity {
 	canAddAttachments() {
 		return this.canAddLinkAttachment()
 			|| this.canAddGoogleDriveLinkAttachment()
-			|| this.canAddOneDriveLinkAttachment();
+			|| this.canAddOneDriveLinkAttachment()
+			|| this.canAddFileAttachment();
 	}
 
 	/**
@@ -99,5 +100,12 @@ export class AttachmentCollectionEntity extends Entity {
 			name: 'href', value: href
 		}];
 		await performSirenAction(this._token, action, fields);
+	}
+
+	/**
+	 * @returns {bool} Returns true if the add-file action is present on the entity
+	 */
+	canAddFileAttachment() {
+		return this._entity.hasActionByName('add-file');
 	}
 }

--- a/src/activities/AttachmentEntity.js
+++ b/src/activities/AttachmentEntity.js
@@ -13,10 +13,18 @@ export class AttachmentEntity extends Entity {
 	}
 
 	/**
-	 * @returns {string} Attachment's location (for link attachments)
+	 * @returns {string} Attachment's URL location (for link attachments) or file location (for file attachments)
 	 */
 	href() {
-		return this._entity && this._entity.properties && this._entity.properties.href;
+		if (!this._entity) {
+			return;
+		}
+
+		if (this._entity.hasLinkByRel('alternate')) {
+			return this._entity.getLinkByRel('alternate').href;
+		}
+
+		return this._entity.properties && this._entity.properties.href;
 	}
 
 	/**


### PR DESCRIPTION
Nothing very exciting here, just adds `canAddFileAttachment` to the attachment collection, and modifies the `href` property of an attachment to work with both files and links.