### PR TITLE
US112361 Add function to attach temp file

### DIFF
--- a/src/activities/AttachmentCollectionEntity.js
+++ b/src/activities/AttachmentCollectionEntity.js
@@ -108,4 +108,20 @@ export class AttachmentCollectionEntity extends Entity {
 	canAddFileAttachment() {
 		return this._entity.hasActionByName('add-file');
 	}
+
+	/**
+	 * Attaches an existing temp file to the attachment collection
+	 * @param {string} tempFileId ID of an existing temp file e.g. "abcd1234.png;filename.png"
+	 */
+	async addTempFileAttachment(tempFileId) {
+		if (!this.canAddFileAttachment()) {
+			return;
+		}
+
+		const action = this._entity.getActionByName('add-file');
+		const fields = [{
+			name: 'tempFileId', value: tempFileId
+		}];
+		await performSirenAction(this._token, action, fields);
+	}
 }


### PR DESCRIPTION
Since we're using the file selector dialog in FACE, it takes care of the actual uploading of files. Once they're uploaded by the dialog, we need to attach the existing temp file to the attachment collection, which can be accomplished via the `add-file` action with a `tempFileId` in the POST body.

This is a followup to #111 - probably should have been included there, but didn't yet know what this would look like.