### PR TITLE
upgrade wct so that we can run individual tests in the browser

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,8 +26,10 @@
     "@polymer/iron-demo-helpers": "^3.0.0-pre.18",
     "@polymer/iron-test-helpers": "^3.0.0",
     "@polymer/polymer": "^3.0.0",
+    "@polymer/test-fixture": "^4.0.2",
     "@webcomponents/webcomponentsjs": "^2.2.1",
     "babel-eslint": "^10.0.1",
+    "chai": "^4.2.0",
     "eslint": "^4.15.0",
     "eslint-config-brightspace": "^0.4.0",
     "eslint-plugin-html": "^4.0.1",
@@ -35,8 +37,10 @@
     "jsdoc": "^3.5.5",
     "lie": "^3.3.0",
     "lit-element": "^2",
+    "mocha": "^7.0.1",
     "polymer-cli": "^1.9.1",
-    "wct-browser-legacy": "^1.0.1",
+    "sinon": "^7.5.0",
+    "wct-mocha": "^1.0.1",
     "whatwg-fetch": "^2.0.0"
   }
 }

--- a/test/AlertsEntity/AlertsEntity.html
+++ b/test/AlertsEntity/AlertsEntity.html
@@ -2,8 +2,12 @@
 	<head>
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
-		<script src="../../../@webcomponents/webcomponentsjs/webcomponents-bundle.js"></script>
-		<script src="../../../wct-browser-legacy/browser.js"></script>
+		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
+		<script src="/node_modules/mocha/mocha.js"></script>
+		<script src="/node_modules/chai/chai.js"></script>
+		<script src="/node_modules/@polymer/test-fixture/test-fixture.js"></script>
+		<script src="/node_modules/wct-mocha/wct-mocha.js"></script>
+		<script src="/node_modules/sinon/pkg/sinon.js"></script>
 
 		<script type="module" src="../../../siren-parser/global.js"></script>
 		<script type="module" src="../../src/organizations/AlertsEntity.js"></script>

--- a/test/EnrollmentEntity/EnrollmentEntity.html
+++ b/test/EnrollmentEntity/EnrollmentEntity.html
@@ -2,8 +2,12 @@
 	<head>
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
-		<script src="../../../@webcomponents/webcomponentsjs/webcomponents-bundle.js"></script>
-		<script src="../../../wct-browser-legacy/browser.js"></script>
+		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
+		<script src="/node_modules/mocha/mocha.js"></script>
+		<script src="/node_modules/chai/chai.js"></script>
+		<script src="/node_modules/@polymer/test-fixture/test-fixture.js"></script>
+		<script src="/node_modules/wct-mocha/wct-mocha.js"></script>
+		<script src="/node_modules/sinon/pkg/sinon.js"></script>
 
 		<script type="module" src="../../../siren-parser/global.js"></script>
 		<script type="module" src="../../src/enrollments/EnrollmentEntity.js"></script>

--- a/test/PromotedSearchEntity/PromotedSearchEntity.html
+++ b/test/PromotedSearchEntity/PromotedSearchEntity.html
@@ -2,8 +2,12 @@
 	<head>
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
-		<script src="../../../@webcomponents/webcomponentsjs/webcomponents-bundle.js"></script>
-		<script src="../../../wct-browser-legacy/browser.js"></script>
+		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
+		<script src="/node_modules/mocha/mocha.js"></script>
+		<script src="/node_modules/chai/chai.js"></script>
+		<script src="/node_modules/@polymer/test-fixture/test-fixture.js"></script>
+		<script src="/node_modules/wct-mocha/wct-mocha.js"></script>
+		<script src="/node_modules/sinon/pkg/sinon.js"></script>
 
 		<script type="module" src="../../../siren-parser/global.js"></script>
 		<script type="module" src="../../src/promotedSearch/PromotedSearchEntity.js"></script>

--- a/test/SequenceEntity/SequenceEntity.html
+++ b/test/SequenceEntity/SequenceEntity.html
@@ -2,8 +2,12 @@
 	<head>
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
-		<script src="../../../@webcomponents/webcomponentsjs/webcomponents-bundle.js"></script>
-		<script src="../../../wct-browser-legacy/browser.js"></script>
+		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
+		<script src="/node_modules/mocha/mocha.js"></script>
+		<script src="/node_modules/chai/chai.js"></script>
+		<script src="/node_modules/@polymer/test-fixture/test-fixture.js"></script>
+		<script src="/node_modules/wct-mocha/wct-mocha.js"></script>
+		<script src="/node_modules/sinon/pkg/sinon.js"></script>
 
 		<script type="module" src="../../../siren-parser/global.js"></script>
 		<script type="module" src="../../src/sequences/SequenceEntity.js"></script>

--- a/test/UserActivityUsageEntity/UserActivityUsageEntity.html
+++ b/test/UserActivityUsageEntity/UserActivityUsageEntity.html
@@ -2,8 +2,12 @@
 	<head>
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
-		<script src="../../../@webcomponents/webcomponentsjs/webcomponents-bundle.js"></script>
-		<script src="../../../wct-browser-legacy/browser.js"></script>
+		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
+		<script src="/node_modules/mocha/mocha.js"></script>
+		<script src="/node_modules/chai/chai.js"></script>
+		<script src="/node_modules/@polymer/test-fixture/test-fixture.js"></script>
+		<script src="/node_modules/wct-mocha/wct-mocha.js"></script>
+		<script src="/node_modules/sinon/pkg/sinon.js"></script>
 
 		<script type="module" src="../../../siren-parser/global.js"></script>
 		<script type="module" src="../../src/enrollments/UserActivityUsageEntity.js"></script>

--- a/test/UserSettingsEntity/UserSettingsEntity.html
+++ b/test/UserSettingsEntity/UserSettingsEntity.html
@@ -2,8 +2,12 @@
 	<head>
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
-		<script src="../../../@webcomponents/webcomponentsjs/webcomponents-bundle.js"></script>
-		<script src="../../../wct-browser-legacy/browser.js"></script>
+		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
+		<script src="/node_modules/mocha/mocha.js"></script>
+		<script src="/node_modules/chai/chai.js"></script>
+		<script src="/node_modules/@polymer/test-fixture/test-fixture.js"></script>
+		<script src="/node_modules/wct-mocha/wct-mocha.js"></script>
+		<script src="/node_modules/sinon/pkg/sinon.js"></script>
 
 		<script type="module" src="../../../siren-parser/global.js"></script>
 		<script type="module" src="../../src/userSettings/UserSettingsEntity.js"></script>

--- a/test/activities/ActivityUsageCollectionEntity.html
+++ b/test/activities/ActivityUsageCollectionEntity.html
@@ -2,8 +2,12 @@
 	<head>
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes" />
-		<script src="../../../@webcomponents/webcomponentsjs/webcomponents-bundle.js"></script>
-		<script src="../../../wct-browser-legacy/browser.js"></script>
+		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
+		<script src="/node_modules/mocha/mocha.js"></script>
+		<script src="/node_modules/chai/chai.js"></script>
+		<script src="/node_modules/@polymer/test-fixture/test-fixture.js"></script>
+		<script src="/node_modules/wct-mocha/wct-mocha.js"></script>
+		<script src="/node_modules/sinon/pkg/sinon.js"></script>
 
 		<script type="module" src="../../../siren-parser/global.js"></script>
 		<script type="module" src="../../src/activities/ActivityUsageCollectionEntity.js"></script>

--- a/test/activities/ActivityUsageEntity.html
+++ b/test/activities/ActivityUsageEntity.html
@@ -2,8 +2,12 @@
 	<head>
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
-		<script src="../../../@webcomponents/webcomponentsjs/webcomponents-bundle.js"></script>
-		<script src="../../../wct-browser-legacy/browser.js"></script>
+		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
+		<script src="/node_modules/mocha/mocha.js"></script>
+		<script src="/node_modules/chai/chai.js"></script>
+		<script src="/node_modules/@polymer/test-fixture/test-fixture.js"></script>
+		<script src="/node_modules/wct-mocha/wct-mocha.js"></script>
+		<script src="/node_modules/sinon/pkg/sinon.js"></script>
 
 		<script type="module" src="../../../siren-parser/global.js"></script>
 		<script type="module" src="../../src/activities/ActivityUsageEntity.js"></script>

--- a/test/activities/GradeCandidateEntity.html
+++ b/test/activities/GradeCandidateEntity.html
@@ -2,8 +2,12 @@
 	<head>
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
-		<script src="../../../@webcomponents/webcomponentsjs/webcomponents-bundle.js"></script>
-		<script src="../../../wct-browser-legacy/browser.js"></script>
+		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
+		<script src="/node_modules/mocha/mocha.js"></script>
+		<script src="/node_modules/chai/chai.js"></script>
+		<script src="/node_modules/@polymer/test-fixture/test-fixture.js"></script>
+		<script src="/node_modules/wct-mocha/wct-mocha.js"></script>
+		<script src="/node_modules/sinon/pkg/sinon.js"></script>
 
 		<script type="module" src="../../../siren-parser/global.js"></script>
 		<script type="module" src="../../src/activities/GradeCandidateCollectionEntity.js"></script>

--- a/test/activities/assignments/AssignmentActivityUsageEntity.html
+++ b/test/activities/assignments/AssignmentActivityUsageEntity.html
@@ -2,8 +2,12 @@
 	<head>
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
-		<script src="../../../../@webcomponents/webcomponentsjs/webcomponents-bundle.js"></script>
-		<script src="../../../../wct-browser-legacy/browser.js"></script>
+		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
+		<script src="/node_modules/mocha/mocha.js"></script>
+		<script src="/node_modules/chai/chai.js"></script>
+		<script src="/node_modules/@polymer/test-fixture/test-fixture.js"></script>
+		<script src="/node_modules/wct-mocha/wct-mocha.js"></script>
+		<script src="/node_modules/sinon/pkg/sinon.js"></script>
 
 		<script type="module" src="../../../../siren-parser/global.js"></script>
 	</head>

--- a/test/activities/assignments/AssignmentEntity.html
+++ b/test/activities/assignments/AssignmentEntity.html
@@ -2,8 +2,12 @@
 	<head>
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
-		<script src="../../../../@webcomponents/webcomponentsjs/webcomponents-bundle.js"></script>
-		<script src="../../../../wct-browser-legacy/browser.js"></script>
+		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
+		<script src="/node_modules/mocha/mocha.js"></script>
+		<script src="/node_modules/chai/chai.js"></script>
+		<script src="/node_modules/@polymer/test-fixture/test-fixture.js"></script>
+		<script src="/node_modules/wct-mocha/wct-mocha.js"></script>
+		<script src="/node_modules/sinon/pkg/sinon.js"></script>
 
 		<script type="module" src="../../../../siren-parser/global.js"></script>
 	</head>

--- a/test/consortium/ConsortiumRootEntity.html
+++ b/test/consortium/ConsortiumRootEntity.html
@@ -2,9 +2,12 @@
 	<head>
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1, user-scalable=yes">
-		<script src="../../../@webcomponents/webcomponentsjs/webcomponents-bundle.js"></script>
-		<script src="../../../wct-browser-legacy/browser.js"></script>
-
+		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
+		<script src="/node_modules/mocha/mocha.js"></script>
+		<script src="/node_modules/chai/chai.js"></script>
+		<script src="/node_modules/@polymer/test-fixture/test-fixture.js"></script>
+		<script src="/node_modules/wct-mocha/wct-mocha.js"></script>
+		<script src="/node_modules/sinon/pkg/sinon.js"></script>
 		<script type="module" src="../../../siren-parser/global.js"></script>
 
 		<!-- For IE11 -->

--- a/test/consortium/ConsortiumTokenCollection.html
+++ b/test/consortium/ConsortiumTokenCollection.html
@@ -2,8 +2,12 @@
 	<head>
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1, user-scalable=yes">
-		<script src="../../../@webcomponents/webcomponentsjs/webcomponents-bundle.js"></script>
-		<script src="../../../wct-browser-legacy/browser.js"></script>
+		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
+		<script src="/node_modules/mocha/mocha.js"></script>
+		<script src="/node_modules/chai/chai.js"></script>
+		<script src="/node_modules/@polymer/test-fixture/test-fixture.js"></script>
+		<script src="/node_modules/wct-mocha/wct-mocha.js"></script>
+		<script src="/node_modules/sinon/pkg/sinon.js"></script>
 
 		<script type="module" src="../../../siren-parser/global.js"></script>
 

--- a/test/consortium/ConsortiumTokenCollectionEntity.js
+++ b/test/consortium/ConsortiumTokenCollectionEntity.js
@@ -26,7 +26,7 @@ describe('Consortium entity', () => {
 				}
 			]
 		};
-		sandbox.stub(window.d2lfetch, 'fetch', (input) => {
+		sandbox.stub(window.d2lfetch, 'fetch').callsFake((input) => {
 			const whatToFetch = {
 				'/root.json': rootResponse
 			};

--- a/test/entity.html
+++ b/test/entity.html
@@ -4,12 +4,16 @@
 	<head>
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1, user-scalable=yes">
-		<script src="../../@webcomponents/webcomponentsjs/webcomponents-bundle.js"></script>
+		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
+		<script src="/node_modules/mocha/mocha.js"></script>
+		<script src="/node_modules/chai/chai.js"></script>
+		<script src="/node_modules/@polymer/test-fixture/test-fixture.js"></script>
+		<script src="/node_modules/wct-mocha/wct-mocha.js"></script>
+		<script src="/node_modules/sinon/pkg/sinon.js"></script>
 
 		<!-- For IE11 -->
 		<script src="../../lie/dist/lie.polyfill.min.js"></script>
 		<script src="../../whatwg-fetch/fetch.js"></script>
-		<script src="../../wct-browser-legacy/browser.js"></script>
 	</head>
 	<body>
 

--- a/test/es6/EntityFactory.html
+++ b/test/es6/EntityFactory.html
@@ -2,8 +2,12 @@
 	<head>
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1, user-scalable=yes">
-		<script src="../../../@webcomponents/webcomponentsjs/webcomponents-bundle.js"></script>
-		<script src="../../../wct-browser-legacy/browser.js"></script>
+		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
+		<script src="/node_modules/mocha/mocha.js"></script>
+		<script src="/node_modules/chai/chai.js"></script>
+		<script src="/node_modules/@polymer/test-fixture/test-fixture.js"></script>
+		<script src="/node_modules/wct-mocha/wct-mocha.js"></script>
+		<script src="/node_modules/sinon/pkg/sinon.js"></script>
 
 		<script type="module" src="../../../siren-parser/global.js"></script>
 

--- a/test/es6/EntityFactory.js
+++ b/test/es6/EntityFactory.js
@@ -11,7 +11,7 @@ describe('Entityfactory', () => {
 		beforeEach(() => {
 			sandbox = sinon.sandbox.create();
 
-			sandbox.stub(window.d2lfetch, 'fetch', () => {
+			sandbox.stub(window.d2lfetch, 'fetch').callsFake(() => {
 
 				return Promise.resolve({
 					ok: false,

--- a/test/es6/SirenActionTest.html
+++ b/test/es6/SirenActionTest.html
@@ -3,8 +3,12 @@
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1, user-scalable=yes">
-	<script src="../../../@webcomponents/webcomponentsjs/webcomponents-bundle.js"></script>
-	<script src="../../../wct-browser-legacy/browser.js"></script>
+		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
+		<script src="/node_modules/mocha/mocha.js"></script>
+		<script src="/node_modules/chai/chai.js"></script>
+		<script src="/node_modules/@polymer/test-fixture/test-fixture.js"></script>
+		<script src="/node_modules/wct-mocha/wct-mocha.js"></script>
+		<script src="/node_modules/sinon/pkg/sinon.js"></script>
 
 	<script type="module" src="../../../siren-parser/global.js"></script>
 

--- a/test/helpers/StateTree.html
+++ b/test/helpers/StateTree.html
@@ -3,8 +3,13 @@
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
-	<script src="../../../@webcomponents/webcomponentsjs/webcomponents-bundle.js"></script>
-	<script src="../../../wct-browser-legacy/browser.js"></script>
+		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
+		<script src="/node_modules/mocha/mocha.js"></script>
+		<script src="/node_modules/chai/chai.js"></script>
+		<script src="/node_modules/@polymer/test-fixture/test-fixture.js"></script>
+		<script src="/node_modules/wct-mocha/wct-mocha.js"></script>
+		<script src="/node_modules/sinon/pkg/sinon.js"></script>
+		<script src="/node_modules/sinon-chai/lib/sinon-chai.js"></script>
 
 	<script type="module" src="../../../siren-parser/global.js"></script>
 	<script type="module" src="../../src/helpers/StateTree.js"></script>

--- a/test/index.html
+++ b/test/index.html
@@ -4,13 +4,9 @@
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
-	<script src="../../@webcomponents/webcomponentsjs/webcomponents-bundle.js"></script>
-
-	<!-- For IE11 -->
-	<script src="../../lie/dist/lie.polyfill.min.js"></script>
-	<script src="../../whatwg-fetch/fetch.js"></script>
-
-	<script src="../../wct-browser-legacy/browser.js"></script>
+	<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
+	<script src="/node_modules/mocha/mocha.js"></script>
+	<script src="/node_modules/wct-mocha/wct-mocha.js"></script>
 </head>
 
 <body>
@@ -37,6 +33,7 @@
 			'./activities/assignments/AssignmentActivityUsageEntity.html',
 			'./activities/assignments/AssignmentEntity.html',
 			'./activities/ActivityUsageCollectionEntity.html',
+			'./activities/GradeCandidateEntity.html',
 			'./organizations/OrganizationAvailabilitySetEntity.html',
 			'./organizations/OrganizationAvailabilityEntity.html'
 		]);

--- a/test/mixin/entity-mixin-test.html
+++ b/test/mixin/entity-mixin-test.html
@@ -2,8 +2,13 @@
 	<head>
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1, user-scalable=yes">
-		<script src="../../../@webcomponents/webcomponentsjs/webcomponents-bundle.js"></script>
-		<script src="../../../wct-browser-legacy/browser.js"></script>
+		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
+		<script src="/node_modules/mocha/mocha.js"></script>
+		<script src="/node_modules/chai/chai.js"></script>
+		<script src="/node_modules/@polymer/test-fixture/test-fixture.js"></script>
+		<script src="/node_modules/wct-mocha/wct-mocha.js"></script>
+		<script src="/node_modules/sinon/pkg/sinon.js"></script>
+		<script src="/node_modules/sinon-chai/lib/sinon-chai.js"></script>
 
 		<script type="module" src="../../../siren-parser/global.js"></script>
 

--- a/test/mixin/entity-mixin-test.js
+++ b/test/mixin/entity-mixin-test.js
@@ -55,7 +55,7 @@ describe('d2l-organization-name', () => {
 				href: '/semester2.json'
 			}]
 		};
-		sandbox.stub(window.d2lfetch, 'fetch', (input) => {
+		sandbox.stub(window.d2lfetch, 'fetch').callsFake((input) => {
 			const whatToFetch = {
 				'/organization.json': organizationEntity,
 				'/organization2.json': organizationEntity2,

--- a/test/mixin/pending-container-mixin-test.html
+++ b/test/mixin/pending-container-mixin-test.html
@@ -2,8 +2,12 @@
 	<head>
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1, user-scalable=yes">
-		<script src="../../../@webcomponents/webcomponentsjs/webcomponents-bundle.js"></script>
-		<script src="../../../wct-browser-legacy/browser.js"></script>
+		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
+		<script src="/node_modules/mocha/mocha.js"></script>
+		<script src="/node_modules/chai/chai.js"></script>
+		<script src="/node_modules/@polymer/test-fixture/test-fixture.js"></script>
+		<script src="/node_modules/wct-mocha/wct-mocha.js"></script>
+		<script src="/node_modules/sinon/pkg/sinon.js"></script>
 
 		<script type="module" src="../../../siren-parser/global.js"></script>
 

--- a/test/mixin/pending-container-mixin-test.js
+++ b/test/mixin/pending-container-mixin-test.js
@@ -28,7 +28,7 @@ describe('PendingContainer', function() {
 			}]
 		};
 
-		sandbox.stub(window.d2lfetch, 'fetch', (input) => {
+		sandbox.stub(window.d2lfetch, 'fetch').callsFake((input) => {
 			const whatToFetch = {
 				'/organization.json': organizationEntity
 			};

--- a/test/mixin/simple-entity-mixin-test.html
+++ b/test/mixin/simple-entity-mixin-test.html
@@ -2,8 +2,12 @@
 	<head>
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1, user-scalable=yes">
-		<script src="../../../@webcomponents/webcomponentsjs/webcomponents-bundle.js"></script>
-		<script src="../../../wct-browser-legacy/browser.js"></script>
+		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
+		<script src="/node_modules/mocha/mocha.js"></script>
+		<script src="/node_modules/chai/chai.js"></script>
+		<script src="/node_modules/@polymer/test-fixture/test-fixture.js"></script>
+		<script src="/node_modules/wct-mocha/wct-mocha.js"></script>
+		<script src="/node_modules/sinon/pkg/sinon.js"></script>
 
 		<script type="module" src="../../../siren-parser/global.js"></script>
 

--- a/test/mixin/simple-entity-mixin-test.js
+++ b/test/mixin/simple-entity-mixin-test.js
@@ -62,7 +62,7 @@ describe('Simple Entity Mixin Test', function() {
 			}]
 		};
 
-		sandbox.stub(window.d2lfetch, 'fetch', (input) => {
+		sandbox.stub(window.d2lfetch, 'fetch').callsFake((input) => {
 			const whatToFetch = {
 				'/organization.json': organizationEntity
 			};

--- a/test/organizations/OrganizationAvailabilityEntity.html
+++ b/test/organizations/OrganizationAvailabilityEntity.html
@@ -2,8 +2,12 @@
 	<head>
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
-		<script src="../../../@webcomponents/webcomponentsjs/webcomponents-bundle.js"></script>
-		<script src="../../../wct-browser-legacy/browser.js"></script>
+		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
+		<script src="/node_modules/mocha/mocha.js"></script>
+		<script src="/node_modules/chai/chai.js"></script>
+		<script src="/node_modules/@polymer/test-fixture/test-fixture.js"></script>
+		<script src="/node_modules/wct-mocha/wct-mocha.js"></script>
+		<script src="/node_modules/sinon/pkg/sinon.js"></script>
 
 		<script type="module" src="../../../siren-parser/global.js"></script>
 		<script type="module" src="../../src/organizations/OrganizationAvailabilityEntity.js"></script>

--- a/test/organizations/OrganizationAvailabilitySetEntity.html
+++ b/test/organizations/OrganizationAvailabilitySetEntity.html
@@ -2,8 +2,12 @@
 	<head>
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
-		<script src="../../../@webcomponents/webcomponentsjs/webcomponents-bundle.js"></script>
-		<script src="../../../wct-browser-legacy/browser.js"></script>
+		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
+		<script src="/node_modules/mocha/mocha.js"></script>
+		<script src="/node_modules/chai/chai.js"></script>
+		<script src="/node_modules/@polymer/test-fixture/test-fixture.js"></script>
+		<script src="/node_modules/wct-mocha/wct-mocha.js"></script>
+		<script src="/node_modules/sinon/pkg/sinon.js"></script>
 
 		<script type="module" src="../../../siren-parser/global.js"></script>
 		<script type="module" src="../../src/organizations/OrganizationAvailabilitySetEntity.js"></script>

--- a/test/root/root.html
+++ b/test/root/root.html
@@ -2,8 +2,12 @@
 	<head>
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1, user-scalable=yes">
-		<script src="../../../@webcomponents/webcomponentsjs/webcomponents-bundle.js"></script>
-		<script src="../../../wct-browser-legacy/browser.js"></script>
+		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
+		<script src="/node_modules/mocha/mocha.js"></script>
+		<script src="/node_modules/chai/chai.js"></script>
+		<script src="/node_modules/@polymer/test-fixture/test-fixture.js"></script>
+		<script src="/node_modules/wct-mocha/wct-mocha.js"></script>
+		<script src="/node_modules/sinon/pkg/sinon.js"></script>
 
 		<script type="module" src="../../../siren-parser/global.js"></script>
 

--- a/test/root/root.js
+++ b/test/root/root.js
@@ -56,7 +56,7 @@ describe('root', () => {
 			}
 			]
 		};
-		sandbox.stub(window.d2lfetch, 'fetch', (input) => {
+		sandbox.stub(window.d2lfetch, 'fetch').callsFake((input) => {
 			const whatToFetch = {
 				'/root.json': rootResponse,
 				'/organization.json': organizationResponse

--- a/test/skeleton-test.html
+++ b/test/skeleton-test.html
@@ -4,12 +4,16 @@
 	<head>
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1, user-scalable=yes">
-		<script src="../../@webcomponents/webcomponentsjs/webcomponents-bundle.js"></script>
+		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
+		<script src="/node_modules/mocha/mocha.js"></script>
+		<script src="/node_modules/chai/chai.js"></script>
+		<script src="/node_modules/@polymer/test-fixture/test-fixture.js"></script>
+		<script src="/node_modules/wct-mocha/wct-mocha.js"></script>
+		<script src="/node_modules/sinon/pkg/sinon.js"></script>
 
 		<!-- For IE11 -->
 		<script src="../../lie/dist/lie.polyfill.min.js"></script>
 		<script src="../../whatwg-fetch/fetch.js"></script>
-		<script src="../../wct-browser-legacy/browser.js"></script>
 
 	</head>
 	<body>


### PR DESCRIPTION
This looks like a lot of changes, but it is just upgrading the version of web component tester so that we can run individual tests in the browser using `polymer serve`.

It updates the version of `sinon` as well so they were a few changes to `sinon.stub` calls to fix removed APIs.