### PR TITLE
Add new Save method to AssignmentEntity for use by Save/Cancel

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "eslint": "^4.15.0",
     "eslint-config-brightspace": "^0.4.0",
     "eslint-plugin-html": "^4.0.1",
+    "fetch-mock": "^8.3.2",
     "frau-ci": "^1.40.0",
     "jsdoc": "^3.5.5",
     "lie": "^3.3.0",

--- a/src/activities/assignments/AssignmentEntity.js
+++ b/src/activities/assignments/AssignmentEntity.js
@@ -380,6 +380,10 @@ export class AssignmentEntity extends Entity {
 			return;
 		}
 
+		// TODO - Need to force PATCH on this API now. The backend just delegates the PATCH call to the PUT
+		// implementation with the correct semantics for unprovided fields
+		action.method = 'PATCH';
+
 		const fields = [];
 
 		if (assignment.name && assignment.name !== this.name() && this.canEditName()) {

--- a/src/activities/assignments/AssignmentEntity.js
+++ b/src/activities/assignments/AssignmentEntity.js
@@ -369,4 +369,31 @@ export class AssignmentEntity extends Entity {
 
 		return this._entity.getLinkByRel(Rels.Assignments.attachments).href;
 	}
+
+	canSave() {
+		return this._entity && this._entity.hasActionByName(Actions.assignments.update);
+	}
+
+	async save(assignment) {
+		const action = this.canSave() && this._entity.getActionByName(Actions.assignments.update);
+		if (!action) {
+			return;
+		}
+
+		const fields = [];
+
+		if (assignment.name && assignment.name !== this.name() && this.canEditName()) {
+			fields.push({ name: 'name', value: assignment.name });
+		}
+
+		if (assignment.instructions &&
+				assignment.instructions !== this.instructionsEditorHtml() &&
+				this.canEditInstructions()) {
+			fields.push({ name: 'instructions', value: assignment.instructions });
+		}
+
+		if (fields.length > 0) {
+			await performSirenAction(this._token, action, fields);
+		}
+	}
 }

--- a/src/hypermedia-constants.js
+++ b/src/hypermedia-constants.js
@@ -391,7 +391,8 @@ export const Actions = {
 		updateName: 'update-name',
 		updateCompletionType: 'update-completion-type',
 		updateSubmissionType: 'update-submission-type',
-		updateAnnotationToolsAvailability: 'update-annotation-tools-availability'
+		updateAnnotationToolsAvailability: 'update-annotation-tools-availability',
+		update: 'quick-create-folder'
 	},
 	notifications: {
 		getCarrierClass: 'get-carrier',

--- a/test/activities/assignments/AssignmentEntity.html
+++ b/test/activities/assignments/AssignmentEntity.html
@@ -8,6 +8,7 @@
 		<script src="/node_modules/@polymer/test-fixture/test-fixture.js"></script>
 		<script src="/node_modules/wct-mocha/wct-mocha.js"></script>
 		<script src="/node_modules/sinon/pkg/sinon.js"></script>
+		<script type="module" src="/node_modules/fetch-mock/es5/client-bundle.js"></script>
 
 		<script type="module" src="../../../../siren-parser/global.js"></script>
 	</head>

--- a/test/activities/assignments/AssignmentEntity.js
+++ b/test/activities/assignments/AssignmentEntity.js
@@ -39,7 +39,7 @@ describe('AssignmentEntity', () => {
 
 	describe('Saves', () => {
 		it('saves name and instructions', async() => {
-			fetchMock.putOnce('https://f5aa43d7-c082-485c-84f5-4808147fe98a.assignments.api.dev.brightspace.com/123065/folders/7', editableEntity);
+			fetchMock.patchOnce('https://f5aa43d7-c082-485c-84f5-4808147fe98a.assignments.api.dev.brightspace.com/123065/folders/7', editableEntity);
 
 			var assignmentEntity = new AssignmentEntity(editableEntity);
 

--- a/test/activities/assignments/AssignmentEntity.js
+++ b/test/activities/assignments/AssignmentEntity.js
@@ -1,101 +1,19 @@
+/* global fetchMock */
+
 import { AssignmentEntity } from '../../../src/activities/assignments/AssignmentEntity.js';
+import { nonEditableAssignment } from './data/NonEditableAssignment.js';
+import { editableAssignment } from './data/EditableAssignment.js';
 
 describe('AssignmentEntity', () => {
 	var editableEntity, nonEditableEntity;
 
 	beforeEach(() => {
-		nonEditableEntity = window.D2L.Hypermedia.Siren.Parse({
-			'class': [
-				'assignment'
-			],
-			'properties': {
-				'name': 'Extra Special Assignment',
-			},
-			'links': [
-				{
-					'rel': [
-						'self'
-					],
-					'href': 'https://f5aa43d7-c082-485c-84f5-4808147fe98a.assignments.api.dev.brightspace.com/123065/folders/7'
-				},
-				{
-					'rel': [
-						'https://activities.api.brightspace.com/rels/activity-usage'
-					],
-					'href': 'https://f5aa43d7-c082-485c-84f5-4808147fe98a.activities.api.dev.brightspace.com/activities/6606_2000_7/usages/123065'
-				},
-			],
-			'rel': [
-				'https://assignments.api.brightspace.com/rels/assignment'
-			]
-		});
+		nonEditableEntity = window.D2L.Hypermedia.Siren.Parse(nonEditableAssignment);
+		editableEntity = window.D2L.Hypermedia.Siren.Parse(editableAssignment);
+	});
 
-		editableEntity = window.D2L.Hypermedia.Siren.Parse({
-			'class': [
-				'assignment'
-			],
-			'properties': {
-				'name': 'Extra Special Assignment',
-			},
-			'actions': [
-				{
-					'class': [
-						'required'
-					],
-					'href': 'https://f5aa43d7-c082-485c-84f5-4808147fe98a.assignments.api.dev.brightspace.com/123065/folders/7',
-					'name': 'update-name',
-					'method': 'PATCH',
-					'fields': [
-						{
-							'type': 'text',
-							'name': 'name',
-							'value': 'Folder 1'
-						}
-					]
-				},
-				{
-					'href': 'https://f5aa43d7-c082-485c-84f5-4808147fe98a.assignments.api.dev.brightspace.com/123065/folders/7',
-					'name': 'update-instructions',
-					'method': 'PATCH',
-					'fields': [
-						{
-							'type': 'text',
-							'name': 'instructions',
-							'value': ''
-						}
-					]
-				},
-				{
-					'href': 'https://f5aa43d7-c082-485c-84f5-4808147fe98a.assignments.api.dev.brightspace.com/123065/folders/7',
-					'name': 'update-max-grade-point',
-					'method': 'PATCH',
-					'fields': [
-						{
-							'type': 'number',
-							'name': 'outOf',
-							'value': 10.000000000
-						}
-					]
-				},
-			],
-			'links': [
-				{
-					'rel': [
-						'self'
-					],
-					'href': 'https://f5aa43d7-c082-485c-84f5-4808147fe98a.assignments.api.dev.brightspace.com/123065/folders/7'
-				},
-				{
-					'rel': [
-						'https://activities.api.brightspace.com/rels/activity-usage'
-					],
-					'href': 'https://f5aa43d7-c082-485c-84f5-4808147fe98a.activities.api.dev.brightspace.com/activities/6606_2000_7/usages/123065'
-				},
-			],
-			'rel': [
-				'https://assignments.api.brightspace.com/rels/assignment'
-			]
-		});
+	afterEach(() => {
+		fetchMock.reset();
 	});
 
 	describe('Basic loading', () => {
@@ -104,16 +22,58 @@ describe('AssignmentEntity', () => {
 			expect(assignmentEntity.name()).to.equal('Extra Special Assignment');
 		});
 	});
+
 	describe('Editable', () => {
 		it('sets canEditName to true', () => {
 			var assignmentEntity = new AssignmentEntity(editableEntity);
 			expect(assignmentEntity.canEditName()).to.be.true;
 		});
 	});
+
 	describe('Non Editable', () => {
 		it('sets canEditName to false', () => {
 			var assignmentEntity = new AssignmentEntity(nonEditableEntity);
 			expect(assignmentEntity.canEditName()).to.be.false;
+		});
+	});
+
+	describe('Saves', () => {
+		it('saves name and instructions', async() => {
+			fetchMock.putOnce('https://f5aa43d7-c082-485c-84f5-4808147fe98a.assignments.api.dev.brightspace.com/123065/folders/7', editableEntity);
+
+			var assignmentEntity = new AssignmentEntity(editableEntity);
+
+			await assignmentEntity.save({
+				name: 'New name',
+				instructions: 'New instructions'
+			});
+
+			const form = await fetchMock.lastCall().request.formData();
+			expect(form.get('name')).to.equal('New name');
+			expect(form.get('instructions')).to.equal('New instructions');
+			expect(fetchMock.called()).to.be.true;
+		});
+
+		it('skips save if not dirty', async() => {
+			var assignmentEntity = new AssignmentEntity(editableEntity);
+
+			await assignmentEntity.save({
+				name: 'Extra Special Assignment',
+				instructions: '<p>These are your instructions</p>'
+			});
+
+			expect(fetchMock.done());
+		});
+
+		it('skips save if not editable', async() => {
+			var assignmentEntity = new AssignmentEntity(nonEditableEntity);
+
+			await assignmentEntity.save({
+				name: 'New name',
+				instructions: 'New instructions'
+			});
+
+			expect(fetchMock.done());
 		});
 	});
 });

--- a/test/activities/assignments/AssignmentEntity.js
+++ b/test/activities/assignments/AssignmentEntity.js
@@ -3,6 +3,7 @@
 import { AssignmentEntity } from '../../../src/activities/assignments/AssignmentEntity.js';
 import { nonEditableAssignment } from './data/NonEditableAssignment.js';
 import { editableAssignment } from './data/EditableAssignment.js';
+import { getFormData } from '../../utility/test-helpers.js';
 
 describe('AssignmentEntity', () => {
 	var editableEntity, nonEditableEntity;
@@ -48,9 +49,11 @@ describe('AssignmentEntity', () => {
 				instructions: 'New instructions'
 			});
 
-			const form = await fetchMock.lastCall().request.formData();
-			expect(form.get('name')).to.equal('New name');
-			expect(form.get('instructions')).to.equal('New instructions');
+			const form = await getFormData(fetchMock.lastCall().request);
+			if (!form.notSupported) {
+				expect(form.get('name')).to.equal('New name');
+				expect(form.get('instructions')).to.equal('New instructions');
+			}
 			expect(fetchMock.called()).to.be.true;
 		});
 

--- a/test/activities/assignments/data/EditableAssignment.js
+++ b/test/activities/assignments/data/EditableAssignment.js
@@ -1,0 +1,170 @@
+export const editableAssignment = {
+	'class': [
+		'assignment'
+	],
+	'properties': {
+		'name': 'Extra Special Assignment'
+	},
+	'entities': [
+		{
+			'class': [
+				'date',
+				'due-date'
+			],
+			'rel': [
+				'https://api.brightspace.com/rels/date'
+			],
+			'properties': {
+				'date': '2020-01-22T04:59:00.000Z'
+			}
+		},
+		{
+			'class': [
+				'annotations',
+				'enabled'
+			],
+			'rel': [
+				'https://assignments.api.brightspace.com/rels/annotations'
+			],
+			'actions': [
+				{
+					'href': 'https://f5aa43d7-c082-485c-84f5-4808147fe98a.assignments.api.dev.brightspace.com/123065/folders/7',
+					'name': 'update-annotation-tools-availability',
+					'method': 'PATCH',
+					'fields': [
+						{
+							'type': 'checkbox',
+							'name': 'annotationToolsAvailability',
+							'value': true
+						}
+					]
+				}
+			]
+		},
+		{
+			'class': [
+				'richtext',
+				'instructions',
+				'annotated'
+			],
+			'rel': [
+				'item',
+				'https://assignments.api.brightspace.com/rels/instructions'
+			],
+			'properties': {
+				'text': 'These are your instructions',
+				'html': '<p>These are your instructions</p>'
+			},
+			'entities': [
+				{
+					'class': [
+						'richtext-editor-config'
+					],
+					'rel': [
+						'https://api.brightspace.com/rels/richtext-editor-config'
+					],
+					'properties': {
+						'orgUnit': {
+							'OrgId': '6606',
+							'OrgUnitId': '121213'
+						},
+						'd2l_filter': {
+							'endpoint': '/d2l/lp/htmleditor/converttoabsolute?ou=121213'
+						},
+						'd2l_isf': {
+							'endpoint': '/d2l/common/dialogs/isf/selectItem.d2l?ou=121213&filterMode=Strict'
+						}
+					}
+				}
+			],
+			'actions': [
+				{
+					'type': 'application/x-www-form-urlencoded',
+					'href': 'https://f5aa43d7-c082-485c-84f5-4808147fe98a.assignments.api.dev.brightspace.com/123065/folders/7',
+					'name': 'update-instructions',
+					'method': 'PATCH',
+					'fields': [
+						{
+							'type': 'text',
+							'name': 'instructions',
+							'value': '<p>These are your instructions</p>'
+						}
+					]
+				}
+			]
+		}
+	],
+	'actions': [
+		{
+			'class': [
+				'required'
+			],
+			'href': 'https://f5aa43d7-c082-485c-84f5-4808147fe98a.assignments.api.dev.brightspace.com/123065/folders/7',
+			'name': 'update-name',
+			'method': 'PATCH',
+			'fields': [
+				{
+					'type': 'text',
+					'name': 'name',
+					'value': 'Folder 1'
+				}
+			]
+		},
+		{
+			'href': 'https://f5aa43d7-c082-485c-84f5-4808147fe98a.assignments.api.dev.brightspace.com/123065/folders/7',
+			'name': 'update-max-grade-point',
+			'method': 'PATCH',
+			'fields': [
+				{
+					'type': 'number',
+					'name': 'outOf',
+					'value': 10.000000000
+				}
+			]
+		},
+		{
+			'class': [
+				'link-attachment'
+			],
+			'type': 'application/x-www-form-urlencoded',
+			'title': 'Edit an assignment folder with defaults',
+			'href': 'https://f5aa43d7-c082-485c-84f5-4808147fe98a.assignments.api.dev.brightspace.com/123065/folders/7',
+			'name': 'quick-create-folder',
+			'method': 'PUT',
+			'fields': [
+				{
+					'class': [
+						'required'
+					],
+					'type': 'text',
+					'title': 'Folder name',
+					'name': 'name',
+					'value': 'Folder 1'
+				},
+				{
+					'type': 'text',
+					'title': 'Instructions',
+					'name': 'instructions',
+					'value': '<p>These are your instructions updated again</p>'
+				}
+			]
+		}
+	],
+	'links': [
+		{
+			'rel': [
+				'self'
+			],
+			'href': 'https://f5aa43d7-c082-485c-84f5-4808147fe98a.assignments.api.dev.brightspace.com/123065/folders/7'
+		},
+		{
+			'rel': [
+				'https://activities.api.brightspace.com/rels/activity-usage'
+			],
+			'href': 'https://f5aa43d7-c082-485c-84f5-4808147fe98a.activities.api.dev.brightspace.com/activities/6606_2000_7/usages/123065'
+		},
+	],
+	'rel': [
+		'https://assignments.api.brightspace.com/rels/assignment'
+	]
+};

--- a/test/activities/assignments/data/NonEditableAssignment.js
+++ b/test/activities/assignments/data/NonEditableAssignment.js
@@ -1,0 +1,25 @@
+export const nonEditableAssignment = {
+	'class': [
+		'assignment'
+	],
+	'properties': {
+		'name': 'Extra Special Assignment',
+	},
+	'links': [
+		{
+			'rel': [
+				'self'
+			],
+			'href': 'https://f5aa43d7-c082-485c-84f5-4808147fe98a.assignments.api.dev.brightspace.com/123065/folders/7'
+		},
+		{
+			'rel': [
+				'https://activities.api.brightspace.com/rels/activity-usage'
+			],
+			'href': 'https://f5aa43d7-c082-485c-84f5-4808147fe98a.activities.api.dev.brightspace.com/activities/6606_2000_7/usages/123065'
+		},
+	],
+	'rel': [
+		'https://assignments.api.brightspace.com/rels/assignment'
+	]
+};

--- a/test/utility/test-helpers.js
+++ b/test/utility/test-helpers.js
@@ -1,0 +1,15 @@
+// Safari doesn't support formData()
+export async function getFormData(request) {
+	try {
+		const form = await request.formData();
+		return form;
+	}
+	catch (e) {
+		if (e.name === 'NotSupportedError') {
+			return {
+				notSupported: true
+			};
+		}
+		throw e;
+	}
+}


### PR DESCRIPTION
Previously we were saving all properties individually which was very chatty. This uses the existing 'PUT' action that was developed for activity feed to save multiple properties in a single API call.
However, i override the action.method to be 'PATCH' which is what the API also supports on the backend, because the PUT implementation also requires a name to always be present, but other than that it basically behaves like a PATCH. I'm going to update the method on the action in the API on a subsequent PR.

In this PR only being used for name & instructions. Will add other fields later.

Also introduced `fetch-mock` library to make mocking siren action calls easier.

Refactored the existing AssignmentEntity test by moving the siren entities into data files to clean up the tests.