### PR TITLE
Fix undefined check on name and instructions so that you can save an …

### DIFF
--- a/src/activities/assignments/AssignmentEntity.js
+++ b/src/activities/assignments/AssignmentEntity.js
@@ -386,11 +386,11 @@ export class AssignmentEntity extends Entity {
 
 		const fields = [];
 
-		if (assignment.name && assignment.name !== this.name() && this.canEditName()) {
+		if (typeof assignment.name !== 'undefined' && assignment.name !== this.name() && this.canEditName()) {
 			fields.push({ name: 'name', value: assignment.name });
 		}
 
-		if (assignment.instructions &&
+		if (typeof assignment.instructions !== 'undefined' &&
 				assignment.instructions !== this.instructionsEditorHtml() &&
 				this.canEditInstructions()) {
 			fields.push({ name: 'instructions', value: assignment.instructions });

--- a/test/activities/assignments/AssignmentEntity.js
+++ b/test/activities/assignments/AssignmentEntity.js
@@ -57,6 +57,24 @@ describe('AssignmentEntity', () => {
 			expect(fetchMock.called()).to.be.true;
 		});
 
+		it('saves empty instructions', async() => {
+			fetchMock.patchOnce('https://f5aa43d7-c082-485c-84f5-4808147fe98a.assignments.api.dev.brightspace.com/123065/folders/7', editableEntity);
+
+			var assignmentEntity = new AssignmentEntity(editableEntity);
+
+			await assignmentEntity.save({
+				name: 'New name',
+				instructions: ''
+			});
+
+			const form = await getFormData(fetchMock.lastCall().request);
+			if (!form.notSupported) {
+				expect(form.get('name')).to.equal('New name');
+				expect(form.get('instructions')).to.equal('');
+			}
+			expect(fetchMock.called()).to.be.true;
+		});
+
 		it('skips save if not dirty', async() => {
 			var assignmentEntity = new AssignmentEntity(editableEntity);
 


### PR DESCRIPTION
…empty name and instructions. Previously was just checking for a non false value which failed with an empty string