### PR TITLE
DE37737 - Check for token and href

### DIFF
--- a/src/mixin/entity-mixin.js
+++ b/src/mixin/entity-mixin.js
@@ -21,7 +21,7 @@ export const interalEntityMixin = function(superClass) {
 					reflectToAttribute: true
 				},
 				/**
-				 * Token JWT Token for brightspace | a function that returns a JWT token for brightspace | null (defaults to cookie authentication in a browser)
+				 * Token JWT Token for brightspace | a function that returns a JWT token for brightspace
 				 */
 				token: String,
 				/**

--- a/src/mixin/entity-mixin.js
+++ b/src/mixin/entity-mixin.js
@@ -70,6 +70,9 @@ export const interalEntityMixin = function(superClass) {
 		}
 
 		__onHrefChange(href, token) {
+			if (!href || (typeof token !== 'string' && typeof token !== 'function')) {
+				return;
+			}
 			dispose(this._entity); // Make sure the entity is cleaned up before setting a new one.
 			if (typeof this._entityType === 'function') {
 				entityFactory(this._entityType, href, token, entity => {

--- a/test/mixin/entity-mixin-test.js
+++ b/test/mixin/entity-mixin-test.js
@@ -129,5 +129,24 @@ describe('d2l-organization-name', () => {
 				});
 			});
 		});
+		describe(`Testing No Token ${mixinType}`, () => {
+			let spy, spy2;
+			beforeEach(done => {
+				component = fixture(`no-params-${mixinType}`);
+				component2 = fixture(`no-params-2-${mixinType}`);
+				spy = sandbox.spy(component, '_onOrganizationChange');
+				spy2 = sandbox.spy(component2, '_onOrganizationChange');
+
+				component.token = 'whatever';
+				component.href = '/organization.json';
+				component2.href = '/organization2.json';
+				afterNextRender(component, done);
+			});
+
+			it('Not called if token is undefined', () => {
+				expect(spy).to.have.been.calledOnce;
+				expect(spy2).to.have.not.been.called;
+			});
+		});
 	});
 });


### PR DESCRIPTION
This checks for a valid href and token before fetching anything.  This means that it will no longer fall back to cookie auth, but brings it in line with what the old Polymer behavour does (https://github.com/Brightspace/polymer-siren-behaviors/blob/master/store/entity-behavior.js#L70) and what the Lit version of the mixin does (https://github.com/BrightspaceHypermediaComponents/siren-sdk/blob/master/src/mixin/entity-mixin-lit.js#L32).

This fixes an issue with the consortium tabs fetching things twice - once with cookie auth (token is `null`), and again one the token resolver has added the token getter function.  I've gone and proactively fixed a bunch of places that were not passing in a `token` to component that use the `EntityMixin` in `organizations`, `enrollments`, `activities` and `my-courses`.  `sequences` didn't look to have any issues.  I will also put out a message in #web-platform to let teams know.