### PR TITLE
Added method for retrieving all completion type options

### DIFF
--- a/src/activities/assignments/AssignmentEntity.js
+++ b/src/activities/assignments/AssignmentEntity.js
@@ -433,6 +433,22 @@ export class AssignmentEntity extends Entity {
 	}
 
 	/**
+	 * @returns {Array} Set of all possible completion type options
+	 */
+	allCompletionTypeOptions() {
+		if (!this.canEditCompletionType()) {
+			return [];
+		}
+
+		const action = this._entity.getActionByName(Actions.assignments.updateCompletionType);
+		if (!action.hasFieldByName('completionType')) {
+			return [];
+		}
+
+		return action.getFieldByName('completionType').value;
+	}
+
+	/**
 	 * @returns {bool} Whether or not the edit completion type action is present on the assignment entity
 	 */
 	canEditCompletionType() {


### PR DESCRIPTION
For [US112499](https://rally1.rallydev.com/#/110294864140d/detail/userstory/356264445024)

We need this method for MobX to allow validation of completion types when a user switches submission types. This method is very similar to `completionTypeOptions` but does not do the filtering for the currently selected submission type.