### PR TITLE
add support for score and grade to activity usage aggregate save

### DIFF
--- a/src/activities/ActivityUsageEntity.js
+++ b/src/activities/ActivityUsageEntity.js
@@ -423,8 +423,9 @@ export class ActivityUsageEntity extends Entity {
 		}
 
 		const fields = [{ name: 'scoreOutOf', value: score }];
-		fields.push({ name: 'inGrades', value: inGrades });
-		if (inGrades) {
+
+		if (this.canEditGrades()) {
+			fields.push({ name: 'inGrades', value: inGrades });
 			fields.push({ name: 'gradeType', value: 'Numeric' });
 		}
 		await performSirenAction(this._token, this._getScoreOutOfAction(), fields);

--- a/test/activities/ActivityUsageEntity.js
+++ b/test/activities/ActivityUsageEntity.js
@@ -245,7 +245,7 @@ describe('ActivityUsageEntity', () => {
 					expect(form.get('startDate')).to.equal('');
 					expect(form.get('dueDate')).to.equal('2020-02-23T04:59:00.000Z');
 					expect(form.get('endDate')).to.equal('');
-					expect(form.get('validateOnly')).to.be.undefined;
+					expect(form.get('validateOnly')).to.be.null;
 				}
 				expect(fetchMock.called()).to.be.true;
 			});
@@ -298,6 +298,84 @@ describe('ActivityUsageEntity', () => {
 				expect(fetchMock.done());
 			});
 		});
+
+		describe('score and grade', () => {
+			it('saves updated score', async() => {
+				fetchMock.postOnce('http://vlx1-mdulat.desire2learn.d2l:44444/d2l/api/hm/assignments/6609/folders/31/score-out-of', entityJson);
+
+				await entity.save({
+					scoreAndGrade: {
+						scoreOutOf: '99',
+						inGrades: true
+					}
+				});
+
+				const form = await getFormData(fetchMock.lastCall().request);
+				if (!form.notSupported) {
+					expect(form.get('scoreOutOf')).to.equal('99');
+					expect(form.get('inGrades')).to.equal('true');
+				}
+				expect(fetchMock.called()).to.be.true;
+			});
+
+			it('saves empty score', async() => {
+				fetchMock.postOnce('http://vlx1-mdulat.desire2learn.d2l:44444/d2l/api/hm/assignments/6609/folders/31/score-out-of', entityJson);
+
+				await entity.save({
+					scoreAndGrade: {
+						scoreOutOf: '',
+						inGrades: false
+					}
+				});
+
+				const form = await getFormData(fetchMock.lastCall().request);
+				if (!form.notSupported) {
+					expect(form.get('scoreOutOf')).to.equal('');
+					expect(form.get('inGrades')).to.equal('false');
+				}
+				expect(fetchMock.called()).to.be.true;
+			});
+
+			it('removes from grades', async() => {
+				fetchMock.postOnce('http://vlx1-mdulat.desire2learn.d2l:44444/d2l/api/hm/assignments/6609/folders/31/score-out-of', entityJson);
+
+				await entity.save({
+					scoreAndGrade: {
+						scoreOutOf: '56',
+						inGrades: false
+					}
+				});
+
+				const form = await getFormData(fetchMock.lastCall().request);
+				if (!form.notSupported) {
+					expect(form.get('scoreOutOf')).to.equal('56');
+					expect(form.get('inGrades')).to.equal('false');
+				}
+				expect(fetchMock.called()).to.be.true;
+			});
+
+			it('skips save if not dirty', async() => {
+				await entity.save({
+					scoreAndGrade: {
+						scoreOutOf: '56',
+						inGrades: true
+					}
+				});
+
+				expect(fetchMock.done());
+			});
+
+			it('skips save if not editable', async() => {
+				await readonlyEntity.save({
+					scoreAndGrade: {
+						scoreOutOf: '99',
+						inGrades: false
+					}
+				});
+
+				expect(fetchMock.done());
+			});
+		});
 	});
 
 	describe('Validation', () => {
@@ -319,7 +397,7 @@ describe('ActivityUsageEntity', () => {
 				const form = await getFormData(fetchMock.lastCall().request);
 				if (!form.notSupported) {
 					expect(form.get('startDate')).to.equal('2020-02-23T04:59:00.000Z');
-					expect(form.get('dueDate')).to.equal('2020-02-23T04:59:00.000Z');
+					expect(form.get('dueDate')).to.equal('2020-02-24T04:59:00.000Z');
 					expect(form.get('endDate')).to.equal('2020-02-25T04:59:00.000Z');
 					expect(form.get('validateOnly')).to.equal('true');
 				}
@@ -328,9 +406,9 @@ describe('ActivityUsageEntity', () => {
 
 			it('skips validation if not dirty', async() => {
 				await entity.validate({
-					startDate: '2020-02-23T04:59:00.000Z',
-					dueDate: '2020-02-24T04:59:00.000Z',
-					endDate: '2020-02-25T04:59:00.000Z',
+					startDate: '',
+					dueDate: '2019-12-26T04:59:00.000Z',
+					endDate: '',
 				});
 
 				expect(fetchMock.done());

--- a/test/activities/data/ActivityUsageEntity.js
+++ b/test/activities/data/ActivityUsageEntity.js
@@ -212,6 +212,198 @@ export const testData = {
 			}
 		]
 	},
+	activityUsageEntityEditableCannotEditGrades: {
+		'class': [
+			'assignment-activity',
+			'draft-published-entity',
+			'draft'
+		],
+		'entities': [
+			{
+				'class': [
+					'score-out-of'
+				],
+				'rel': [
+					'https://activities.api.brightspace.com/rels/score-out-of'
+				],
+				'properties': {
+					'scoreOutOf': 56.000000000,
+					'inGrades': true,
+					'gradeType': 'Points',
+					'gradeItemId': 6064
+				},
+				'actions': [
+					{
+						'href': 'http://vlx1-mdulat.desire2learn.d2l:44444/d2l/api/hm/assignments/6609/folders/31/score-out-of',
+						'name': 'update',
+						'method': 'POST',
+						'fields': [
+							{
+								'type': 'number',
+								'name': 'scoreOutOf',
+								'value': 56.000000000
+							},
+							{
+								'type': 'number',
+								'name': 'gradeItemId',
+								'value': 6064
+							}
+						]
+					}
+				]
+			},
+			{
+				'rel': [
+					'https://activities.api.brightspace.com/rels/release-conditions-dialog-opener'
+				],
+				'properties': {
+					'url': '/d2l/le/conditionalRelease/6609/dialog/dropboxes/31/openDialog'
+				}
+			},
+			{
+				'class': [
+					'dates'
+				],
+				'rel': [
+					'https://api.brightspace.com/rels/date'
+				],
+				'actions': [
+					{
+						'href': 'http://vlx1-mdulat.desire2learn.d2l:44444/d2l/api/hm/activities/activities/6606_2000_31/usages/6609',
+						'name': 'update',
+						'method': 'PATCH',
+						'fields': [
+							{
+								'type': 'text',
+								'name': 'startDate',
+								'value': ''
+							},
+							{
+								'type': 'text',
+								'name': 'dueDate',
+								'value': '2019-12-26T04:59:00.000Z'
+							},
+							{
+								'type': 'text',
+								'name': 'endDate',
+								'value': ''
+							}
+						]
+					}
+				]
+			},
+			{
+				'class': [
+					'due-date',
+					'date'
+				],
+				'rel': [
+					'https://api.brightspace.com/rels/date'
+				],
+				'properties': {
+					'date': '2019-12-26T04:59:00.000Z',
+					'localizedDate': '2019-12-25T23:59:00.000'
+				},
+				'actions': [
+					{
+						'href': 'http://vlx1-mdulat.desire2learn.d2l:44444/d2l/api/hm/activities/activities/6606_2000_31/usages/6609',
+						'name': 'update',
+						'method': 'PATCH',
+						'fields': [
+							{
+								'type': 'text',
+								'name': 'dueDate',
+								'value': '2019-12-26T04:59:00.000Z'
+							}
+						]
+					}
+				]
+			}
+		],
+		'links': [
+			{
+				'rel': [
+					'https://activities.api.brightspace.com/rels/activity-usage',
+					'self'
+				],
+				'href': 'http://vlx1-mdulat.desire2learn.d2l:44444/d2l/api/hm/activities/activities/6606_2000_31/usages/6609'
+			},
+			{
+				'rel': [
+					'https://activities.api.brightspace.com/rels/user-activity-usage',
+					'https://activities.api.brightspace.com/rels/my-activity-usage'
+				],
+				'href': 'http://vlx1-mdulat.desire2learn.d2l:44444/d2l/api/hm/activities/activities/6606_2000_31/usages/6609/users/169'
+			},
+			{
+				'rel': [
+					'https://activities.api.brightspace.com/rels/evaluation-status'
+				],
+				'href': 'http://vlx1-mdulat.desire2learn.d2l:44444/d2l/api/hm/activities/activities/6606_2000_31/usages/6609/evaluation-status'
+			},
+			{
+				'rel': [
+					'https://api.brightspace.com/rels/dismiss'
+				],
+				'href': 'http://vlx1-mdulat.desire2learn.d2l:44444/d2l/api/hm/activities/activities/6606_2000_31/usages/6609/dismiss-info'
+			},
+			{
+				'rel': [
+					'https://api.brightspace.com/rels/organization'
+				],
+				'href': 'http://vlx1-mdulat.desire2learn.d2l:44444/d2l/api/hm/organizations/6609'
+			},
+			{
+				'rel': [
+					'https://api.brightspace.com/rels/assignment',
+					'https://api.brightspace.com/rels/specialization'
+				],
+				'href': 'http://vlx1-mdulat.desire2learn.d2l:44444/d2l/api/hm/assignments/6609/folders/31'
+			},
+			{
+				'rel': [
+					'https://grades.api.brightspace.com/rels/grade'
+				],
+				'href': 'http://vlx1-mdulat.desire2learn.d2l:44444/d2l/api/hm/grades/organizations/6609/grades/6064'
+			},
+			{
+				'rel': [
+					'https://conditions.api.brightspace.com/rels/conditions'
+				],
+				'href': 'http://vlx1-mdulat.desire2learn.d2l:44444/d2l/api/hm/conditions/activity-usage/TmpZd05sOHlNREF3WHpNeC42NjA5'
+			},
+			{
+				'rel': [
+					'https://activities.api.brightspace.com/rels/grade-candidates'
+				],
+				'href': 'http://vlx1-mdulat.desire2learn.d2l:44444/d2l/api/hm/activities/activities/6606_2000_31/usages/6609/grade-candidates'
+			}
+		],
+		'actions': [
+			{
+				'href': 'http://vlx1-mdulat.desire2learn.d2l:44444/d2l/api/hm/assignments/6609/folders/31/setDraft/0',
+				'name': 'set-published',
+				'method': 'POST'
+			},
+			{
+				'href': 'http://vlx1-mdulat.desire2learn.d2l:44444/d2l/api/hm/assignments/6609/folders/31/draft',
+				'name': 'update-draft',
+				'method': 'PUT',
+				'fields': [
+					{
+						'type': 'checkbox',
+						'name': 'draft',
+						'value': true
+					}
+				]
+			},
+			{
+				'href': 'http://vlx1-mdulat.desire2learn.d2l:44444/d2l/api/hm/activities/activities/6606_2000_31/usages/6609/start-add-new',
+				'name': 'start-add-new',
+				'method': 'POST'
+			}
+		]
+	},
 	activityUsageEntityReadOnly: {
 		'class': [
 			'assignment-activity',

--- a/test/activities/data/ActivityUsageEntity.js
+++ b/test/activities/data/ActivityUsageEntity.js
@@ -70,6 +70,38 @@ export const testData = {
 			},
 			{
 				'class': [
+					'dates'
+				],
+				'rel': [
+					'https://api.brightspace.com/rels/date'
+				],
+				'actions': [
+					{
+						'href': 'http://vlx1-mdulat.desire2learn.d2l:44444/d2l/api/hm/activities/activities/6606_2000_31/usages/6609',
+						'name': 'update',
+						'method': 'PATCH',
+						'fields': [
+							{
+								'type': 'text',
+								'name': 'startDate',
+								'value': ''
+							},
+							{
+								'type': 'text',
+								'name': 'dueDate',
+								'value': '2019-12-26T04:59:00.000Z'
+							},
+							{
+								'type': 'text',
+								'name': 'endDate',
+								'value': ''
+							}
+						]
+					}
+				]
+			},
+			{
+				'class': [
 					'due-date',
 					'date'
 				],

--- a/test/index.html
+++ b/test/index.html
@@ -33,6 +33,7 @@
 			'./activities/assignments/AssignmentActivityUsageEntity.html',
 			'./activities/assignments/AssignmentEntity.html',
 			'./activities/ActivityUsageCollectionEntity.html',
+			'./activities/ActivityUsageEntity.html',
 			'./activities/GradeCandidateEntity.html',
 			'./organizations/OrganizationAvailabilitySetEntity.html',
 			'./organizations/OrganizationAvailabilityEntity.html'


### PR DESCRIPTION
[US113166](https://rally1.rallydev.com/#/29180338367d/detail/userstory/362987616496)

I've simplified the saving of the score and grade to just use the existing method/action that was being used to just set the score and add a new grade. There were existing methods which were more aligned to autosave which were geared around being very granular around whether we were setting score, adding to grades, removing from grades etc. But this would have made things much more complicated than necessary to handle the general save case. Also for the general save case we want to pass the `inGrades` flag regardless of whether it has changed because we want the latest state to always reflect what the user was seeing.

Also added tests to prevent updating grades if cannot edit grades.

Also, had to fix up some of the existing dates tests.
The ActivityUsage tests were actually missing from the `index.html` file so a lot of them were not actually working as intended. A reminder again to verify that your tests fail correctly so that you can check that they are actually being run. Also, you can run the tests in the browser using `npm run serve` to verify that your tests are running and to debug them.
