### PR TITLE
Vwong/us111000 render grade candidates

### DIFF
--- a/src/activities/GradeCandidateCollectionEntity.js
+++ b/src/activities/GradeCandidateCollectionEntity.js
@@ -1,40 +1,13 @@
 import { Entity } from '../es6/Entity';
-import { Rels } from '../hypermedia-constants';
 
 /**
  * Entity representation of a collection of grade candidates
  */
 export class GradeCandidateCollectionEntity extends Entity {
 	/**
-	 * @returns {Array} Returns all grade-candidate and category sub-entity URLs from the grade-candidates collection
+	 * @returns {Array} Returns all grade-candidate and category sub-entities
 	 */
-	getGradeCandidateHrefs() {
-		return this._entity && this._entity.getSubEntitiesByRel('item').map(entity => {
-			if (entity.hasLinkByRel(Rels.Grades.grade)) {
-				return entity.getLinkByRel(Rels.Grades.grade).href;
-			}
-			if (entity.hasLinkByRel(Rels.Grades.category)) {
-				return entity.getLinkByRel(Rels.Grades.category).href;
-			}
-		});
-	}
-
-	/**
-	 * @param {*} href Href of an entity in the collection
-	 * @returns {Array} Returns grade-candidate entity hrefs
-	 */
-	getGradeCandidatesForCategory(href) {
-		const categories = this._entity && this._entity.getSubEntitiesByRel(Rels.Grades.category);
-		for (const category of categories) {
-			if (category.getLinkByRel(Rels.Grades.category).href === href) {
-				return category.getSubEntitiesByRel(Rels.Grades.grade).map(grade => {
-					if (grade.hasLinkByRel(Rels.Grades.grade)) {
-						return grade.getLinkByRel(Rels.Grades.grade).href;
-					}
-				});
-			}
-		}
-
-		return [];
+	getGradeCandidates() {
+		return (this._entity && this._entity.getSubEntitiesByRel('item')) || [];
 	}
 }

--- a/src/activities/GradeCandidateCollectionEntity.js
+++ b/src/activities/GradeCandidateCollectionEntity.js
@@ -1,14 +1,41 @@
 import { Entity } from '../es6/Entity';
-import { GradeCandidateEntity } from './GradeCandidateEntity';
+import { Rels } from '../hypermedia-constants';
 
 /**
  * Entity representation of a collection of grade candidates
  */
 export class GradeCandidateCollectionEntity extends Entity {
 	/**
-	 * @returns {Array} Returns all grade-candidate sub-entities from the grade-candidates collection
+	 * @returns {Array} Returns all grade-candidate and category sub-entity URLs from the grade-candidates collection
 	 */
-	getGradeCandidateEntities() {
-		return this._entity.getSubEntitiesByRel('item').map(entity => new GradeCandidateEntity(entity));
+	getGradeCandidateHrefs() {
+		return this._entity && this._entity.getSubEntitiesByRel('item').map(entity => {
+			if (entity.hasLinkByRel(Rels.Grades.grade)) {
+				return entity.getLinkByRel(Rels.Grades.grade).href;
+			}
+			if (entity.hasLinkByRel(Rels.Grades.category)) {
+				return entity.getLinkByRel(Rels.Grades.category).href;
+			}
+		});
+	}
+
+	
+	/**
+	 * @param {*} href Href of an entity in the collection
+	 * @returns {Array} Returns grade-candidate entity hrefs
+	 */
+	getGradeCandidatesForCategory(href) {
+		const categories = this._entity && this._entity.getSubEntitiesByRel(Rels.Grades.category);
+		for (const category of categories) {
+			if (category.getLinkByRel(Rels.Grades.category).href === href) {
+				return category.getSubEntitiesByRel(Rels.Grades.grade).map(grade => {
+					if (grade.hasLinkByRel(Rels.Grades.grade)) {
+						return grade.getLinkByRel(Rels.Grades.grade).href;
+					}
+				});
+			}
+		};
+
+		return [];
 	}
 }

--- a/src/activities/GradeCandidateCollectionEntity.js
+++ b/src/activities/GradeCandidateCollectionEntity.js
@@ -19,7 +19,6 @@ export class GradeCandidateCollectionEntity extends Entity {
 		});
 	}
 
-	
 	/**
 	 * @param {*} href Href of an entity in the collection
 	 * @returns {Array} Returns grade-candidate entity hrefs
@@ -34,7 +33,7 @@ export class GradeCandidateCollectionEntity extends Entity {
 					}
 				});
 			}
-		};
+		}
 
 		return [];
 	}

--- a/src/activities/GradeCandidateEntity.js
+++ b/src/activities/GradeCandidateEntity.js
@@ -14,14 +14,17 @@ export class GradeCandidateEntity extends Entity {
 	}
 
 	/**
-	 * @returns {string} Grade candidate's weight value
+	 * @returns {string} Grade candidate's base weight value
 	 */
-	weight() {
-		const weightEntity = !this.isCategory() && this._entity && this._entity.getSubEntitiesByRel(Rels.Grades.weight);
-		if (weightEntity) {
-			return weightEntity[0].properties && weightEntity[0].properties.weight;
-		}
-		return '';
+	baseWeight() {
+		return this._entity && this._entity.properties && this._entity.properties.baseWeight;
+	}
+
+	/**
+	 * @returns {string} Grade candidate's max points value
+	 */
+	maxPoints() {
+		return this._entity && this._entity.properties && this._entity.properties.maxPoints;
 	}
 
 	/**

--- a/src/activities/GradeCandidateEntity.js
+++ b/src/activities/GradeCandidateEntity.js
@@ -1,4 +1,4 @@
-import { Classes, Rels } from '../hypermedia-constants';
+import { Classes } from '../hypermedia-constants';
 import { Entity } from '../es6/Entity';
 import { performSirenAction } from '../es6/SirenAction';
 

--- a/src/activities/GradeCandidateEntity.js
+++ b/src/activities/GradeCandidateEntity.js
@@ -1,4 +1,4 @@
-import { Classes } from '../hypermedia-constants';
+import { Classes, Rels } from '../hypermedia-constants';
 import { Entity } from '../es6/Entity';
 import { performSirenAction } from '../es6/SirenAction';
 
@@ -7,24 +7,29 @@ import { performSirenAction } from '../es6/SirenAction';
  */
 export class GradeCandidateEntity extends Entity {
 	/**
-	 * @returns {string} Grade candidate's name
+	 * @returns {string} Grade's URL
 	 */
-	name() {
-		return this._entity && this._entity.properties && this._entity.properties.name;
+	href() {
+		const entity = this._entity;
+
+		if (!this._entity) {
+			return;
+		}
+
+		if (this.isCategory() && entity.hasLinkByRel(Rels.Grades.category)) {
+			return entity.getLinkByRel(Rels.Grades.category).href;
+		}
+
+		if (!this.isCategory() && entity.hasLinkByRel(Rels.Grades.grade)) {
+			return entity.getLinkByRel(Rels.Grades.grade).href;
+		}
 	}
 
 	/**
-	 * @returns {string} Grade candidate's base weight value
+	 * @returns {Array} Returns all grade-candidate sub-entities
 	 */
-	baseWeight() {
-		return this._entity && this._entity.properties && this._entity.properties.baseWeight;
-	}
-
-	/**
-	 * @returns {string} Grade candidate's max points value
-	 */
-	maxPoints() {
-		return this._entity && this._entity.properties && this._entity.properties.maxPoints;
+	getGradeCandidates() {
+		return (this._entity && this._entity.getSubEntitiesByRel(Rels.Grades.grade)) || [];
 	}
 
 	/**

--- a/src/activities/GradeCandidateEntity.js
+++ b/src/activities/GradeCandidateEntity.js
@@ -1,3 +1,4 @@
+import { Classes, Rels } from '../hypermedia-constants';
 import { Entity } from '../es6/Entity';
 import { performSirenAction } from '../es6/SirenAction';
 
@@ -13,10 +14,21 @@ export class GradeCandidateEntity extends Entity {
 	}
 
 	/**
-	 * @returns {string} Grade candidate's maxPoints value
+	 * @returns {string} Grade candidate's weight value
 	 */
-	maxPoints() {
-		return this._entity && this._entity.properties && this._entity.properties.maxPoints;
+	weight() {
+		const weightEntity = !this.isCategory() && this._entity && this._entity.getSubEntitiesByRel(Rels.Grades.weight);
+		if (weightEntity) {
+			return weightEntity[0].properties && weightEntity[0].properties.weight;
+		}
+		return '';
+	}
+
+	/**
+	 * @returns {bool} True if candidate is a category
+	 */
+	isCategory() {
+		return this._entity && this._entity.hasClass(Classes.grades.category);
 	}
 
 	/**

--- a/src/activities/GradeCategoryEntity.js
+++ b/src/activities/GradeCategoryEntity.js
@@ -1,0 +1,13 @@
+import { Entity } from '../es6/Entity';
+
+/**
+ * GradeCategoryEntity class representation of a grade category
+ */
+export class GradeCategoryEntity extends Entity {
+	/**
+	 * @returns {string} Grade cateogry's name
+	 */
+	name() {
+		return this._entity && this._entity.properties && this._entity.properties.name;
+	}
+}

--- a/src/activities/GradeEntity.js
+++ b/src/activities/GradeEntity.js
@@ -1,0 +1,27 @@
+import { Entity } from '../es6/Entity';
+
+/**
+ * GradeEntity class representation of a grade
+ */
+export class GradeEntity extends Entity {
+	/**
+	 * @returns {string} Grade's name
+	 */
+	name() {
+		return this._entity && this._entity.properties && this._entity.properties.name;
+	}
+
+	/**
+	 * @returns {string} Grade's base weight value
+	 */
+	baseWeight() {
+		return this._entity && this._entity.properties && this._entity.properties.baseWeight;
+	}
+
+	/**
+	 * @returns {string} Grade's max points value
+	 */
+	maxPoints() {
+		return this._entity && this._entity.properties && this._entity.properties.maxPoints;
+	}
+}

--- a/src/hypermedia-constants.js
+++ b/src/hypermedia-constants.js
@@ -114,6 +114,7 @@ export const Rels = {
 	},
 	// Grades API sub-domain rels
 	Grades: {
+		category: 'https://grades.api.brightspace.com/rels/grade-category',
 		comment: 'https://grades.api.brightspace.com/rels/comment',
 		comments: 'https://grades.api.brightspace.com/rels/comments',
 		description: 'https://grades.api.brightspace.com/rels/description',
@@ -275,6 +276,7 @@ export const Classes = {
 		unpinned: 'unpinned'
 	},
 	grades: {
+		category: 'grade-category',
 		comments: 'comments',
 		description: 'description',
 		final: 'final',

--- a/test/activities/GradeCandidateCollectionEntity.html
+++ b/test/activities/GradeCandidateCollectionEntity.html
@@ -10,10 +10,10 @@
 		<script src="/node_modules/sinon/pkg/sinon.js"></script>
 
 		<script type="module" src="../../../siren-parser/global.js"></script>
-		<script type="module" src="../../src/activities/GradeCandidateEntity.js"></script>
+		<script type="module" src="../../src/activities/GradeCandidateCollectionEntity.js"></script>
 	</head>
 
 	<body>
-		<script type="module" src="./GradeCandidateEntity.js"></script>
+		<script type="module" src="./GradeCandidateCollectionEntity.js"></script>
 	</body>
 </html>

--- a/test/activities/GradeCandidateCollectionEntity.js
+++ b/test/activities/GradeCandidateCollectionEntity.js
@@ -1,0 +1,24 @@
+import { GradeCandidateCollectionEntity } from '../../src/activities/GradeCandidateCollectionEntity.js';
+import { testData } from './data/GradeCandidateCollectionEntity.js';
+
+describe('GradeCandidateCollectionEntity', () => {
+	let sandbox;
+	afterEach(() => {
+		sandbox.restore();
+	});
+
+	describe('getGradeCandidates', () => {
+		let entity;
+
+		beforeEach(() => {
+			const entityJson = window.D2L.Hypermedia.Siren.Parse(testData.gradeCandidateCollectionEntity);
+			entity = new GradeCandidateCollectionEntity(entityJson);
+			sandbox = sinon.sandbox.create();
+		});
+
+		it('returns entities', () => {
+			const result = entity.getGradeCandidates();
+			expect(result).to.have.lengthOf(3);
+		});
+	});
+});

--- a/test/activities/GradeCandidateEntity.html
+++ b/test/activities/GradeCandidateEntity.html
@@ -8,6 +8,7 @@
 		<script src="/node_modules/@polymer/test-fixture/test-fixture.js"></script>
 		<script src="/node_modules/wct-mocha/wct-mocha.js"></script>
 		<script src="/node_modules/sinon/pkg/sinon.js"></script>
+		<script type="module" src="/node_modules/fetch-mock/es5/client-bundle.js"></script>
 
 		<script type="module" src="../../../siren-parser/global.js"></script>
 		<script type="module" src="../../src/activities/GradeCandidateEntity.js"></script>

--- a/test/activities/GradeCandidateEntity.js
+++ b/test/activities/GradeCandidateEntity.js
@@ -1,13 +1,10 @@
-import { GradeCandidateCollectionEntity } from '../../src/activities/GradeCandidateCollectionEntity.js';
-import { testData } from './data/GradeCandidateCollectionEntity.js';
+import { GradeCandidateEntity } from '../../src/activities/GradeCandidateEntity.js';
+import { testData } from './data/GradeCandidateEntity.js';
 
-describe('GradeCandidateCollectionEntity', () => {
-	let collectionEntity;
+describe('GradeCandidateEntity', () => {
 	let sandbox;
 
 	beforeEach(() => {
-		const entityJson = window.D2L.Hypermedia.Siren.Parse(testData.gradeCandidateCollectionEntity);
-		collectionEntity = new GradeCandidateCollectionEntity(entityJson);
 		sandbox = sinon.sandbox.create();
 	});
 
@@ -15,21 +12,26 @@ describe('GradeCandidateCollectionEntity', () => {
 		sandbox.restore();
 	});
 
-	describe('GradeCandidateEntity', () => {
-		let associateGradeSpy;
+	describe('Grade', () => {
 		let entity;
+		let associateGradeSpy;
 
 		beforeEach(() => {
-			entity = collectionEntity.getGradeCandidateEntities()[0];
+			const entityJson = window.D2L.Hypermedia.Siren.Parse(testData.gradeCandidateEntity.grade);
+			entity = new GradeCandidateEntity(entityJson);
 			associateGradeSpy = sandbox.spy(entity, 'associateGrade');
 		});
 
-		it('gets name', () => {
-			expect(entity.name()).to.equal('Assignment 1 Grade');
+		it('gets href', () => {
+			expect(entity.href()).to.equal('https://9caa9c10-0175-4c56-84e5-fc2bca4d8a52.grades.api.proddev.d2l/organizations/6609/grades/20');
 		});
 
-		it('gets maxPoints', () => {
-			expect(entity.maxPoints()).to.equal('30');
+		it('gets getGradeCandidates', () => {
+			expect(entity.getGradeCandidates()).to.be.an('array').that.is.empty;
+		});
+
+		it('is not a category', () => {
+			expect(entity.isCategory()).to.be.false;
 		});
 
 		it('can associate grade', () => {
@@ -39,6 +41,72 @@ describe('GradeCandidateCollectionEntity', () => {
 		it('returns a promise when associating grade', () => {
 			entity.associateGrade();
 			expect(associateGradeSpy.returnValues[0]).to.be.a('promise');
+		});
+	});
+
+	describe('Grade without Associate Action', () => {
+		let entity;
+		let associateGradeSpy;
+
+		beforeEach(() => {
+			const entityJson = window.D2L.Hypermedia.Siren.Parse(testData.gradeCandidateEntity.gradeWithoutAssociateAction);
+			entity = new GradeCandidateEntity(entityJson);
+			associateGradeSpy = sandbox.spy(entity, 'associateGrade');
+		});
+
+		it('gets href', () => {
+			expect(entity.href()).to.equal('https://9caa9c10-0175-4c56-84e5-fc2bca4d8a52.grades.api.proddev.d2l/organizations/6609/grades/20');
+		});
+
+		it('gets getGradeCandidates', () => {
+			expect(entity.getGradeCandidates()).to.be.an('array').that.is.empty;
+		});
+
+		it('is not a category', () => {
+			expect(entity.isCategory()).to.be.false;
+		});
+
+		it('can associate grade', () => {
+			expect(entity.canAssociateGrade()).to.be.false;
+		});
+
+		it('cannot associate to a grade', () => {
+			entity.associateGrade();
+			expect(associateGradeSpy.returnValues).to.not.be.a('promise');
+		});
+	});
+
+	describe('Category with Grade', () => {
+		let entity;
+		let associateGradeSpy;
+
+		beforeEach(() => {
+			const entityJson = window.D2L.Hypermedia.Siren.Parse(testData.gradeCandidateEntity.categoryWithGrade);
+			entity = new GradeCandidateEntity(entityJson);
+			associateGradeSpy = sandbox.spy(entity, 'associateGrade');
+		});
+
+		it('gets href', () => {
+			expect(entity.href()).to.equal('https://9caa9c10-0175-4c56-84e5-fc2bca4d8a52.grades.api.proddev.d2l/organizations/6609/grade-categories/5010');
+		});
+
+		it('gets getGradeCandidates', () => {
+			const expected = entity.getGradeCandidates();
+			expect(expected).to.be.an('array');
+			expect(expected).to.have.lengthOf(1);
+		});
+
+		it('is a category', () => {
+			expect(entity.isCategory()).to.be.true;
+		});
+
+		it('can associate grade', () => {
+			expect(entity.canAssociateGrade()).to.be.false;
+		});
+
+		it('cannot associate to a grade', () => {
+			entity.associateGrade();
+			expect(associateGradeSpy.returnValues).to.not.be.a('promise');
 		});
 	});
 });

--- a/test/activities/GradeCategoryEntity.html
+++ b/test/activities/GradeCategoryEntity.html
@@ -1,0 +1,19 @@
+<html>
+	<head>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
+		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
+		<script src="/node_modules/mocha/mocha.js"></script>
+		<script src="/node_modules/chai/chai.js"></script>
+		<script src="/node_modules/@polymer/test-fixture/test-fixture.js"></script>
+		<script src="/node_modules/wct-mocha/wct-mocha.js"></script>
+		<script src="/node_modules/sinon/pkg/sinon.js"></script>
+
+		<script type="module" src="../../../siren-parser/global.js"></script>
+		<script type="module" src="../../src/activities/GradeCategoryEntity.js"></script>
+	</head>
+
+	<body>
+		<script type="module" src="./GradeCategoryEntity.js"></script>
+	</body>
+</html>

--- a/test/activities/GradeCategoryEntity.js
+++ b/test/activities/GradeCategoryEntity.js
@@ -1,0 +1,17 @@
+import { GradeCategoryEntity } from '../../src/activities/GradeCategoryEntity.js';
+import { testData } from './data/GradeCategoryEntity.js';
+
+describe('GradeCategoryEntity', () => {
+	describe('Normal grade category', () => {
+		let entity;
+
+		beforeEach(() => {
+			const entityJson = window.D2L.Hypermedia.Siren.Parse(testData.gradeCategoryEntity.normal);
+			entity = new GradeCategoryEntity(entityJson);
+		});
+
+		it('gets name', () => {
+			expect(entity.name()).to.equal('Category 1');
+		});
+	});
+});

--- a/test/activities/GradeEntity.html
+++ b/test/activities/GradeEntity.html
@@ -10,10 +10,10 @@
 		<script src="/node_modules/sinon/pkg/sinon.js"></script>
 
 		<script type="module" src="../../../siren-parser/global.js"></script>
-		<script type="module" src="../../src/activities/GradeCandidateEntity.js"></script>
+		<script type="module" src="../../src/activities/GradeEntity.js"></script>
 	</head>
 
 	<body>
-		<script type="module" src="./GradeCandidateEntity.js"></script>
+		<script type="module" src="./GradeEntity.js"></script>
 	</body>
 </html>

--- a/test/activities/GradeEntity.js
+++ b/test/activities/GradeEntity.js
@@ -43,25 +43,4 @@ describe('GradeEntity', () => {
 			expect(entity.maxPoints()).to.equal(100);
 		});
 	});
-
-	describe('Grade Category', () => {
-		let entity;
-
-		beforeEach(() => {
-			const entityJson = window.D2L.Hypermedia.Siren.Parse(testData.gradeEntity.category);
-			entity = new GradeEntity(entityJson);
-		});
-
-		it('gets name', () => {
-			expect(entity.name()).to.equal('Category 1');
-		});
-
-		it('gets baseWeight', () => {
-			expect(entity.baseWeight()).to.be.undefined;
-		});
-
-		it('gets maxPoints', () => {
-			expect(entity.maxPoints()).to.be.undefined;
-		});
-	});
 });

--- a/test/activities/GradeEntity.js
+++ b/test/activities/GradeEntity.js
@@ -1,0 +1,67 @@
+import { GradeEntity } from '../../src/activities/GradeEntity.js';
+import { testData } from './data/GradeEntity.js';
+
+describe('GradeEntity', () => {
+	describe('Grade from Points Gradebook', () => {
+		let entity;
+
+		beforeEach(() => {
+			const entityJson = window.D2L.Hypermedia.Siren.Parse(testData.gradeEntity.points);
+			entity = new GradeEntity(entityJson);
+		});
+
+		it('gets name', () => {
+			expect(entity.name()).to.equal('Numeric type');
+		});
+
+		it('gets baseWeight', () => {
+			expect(entity.baseWeight()).to.be.undefined;
+		});
+
+		it('gets maxPoints', () => {
+			expect(entity.maxPoints()).to.equal(15);
+		});
+	});
+
+	describe('Grade from Weighted Gradebook', () => {
+		let entity;
+
+		beforeEach(() => {
+			const entityJson = window.D2L.Hypermedia.Siren.Parse(testData.gradeEntity.weighted);
+			entity = new GradeEntity(entityJson);
+		});
+
+		it('gets name', () => {
+			expect(entity.name()).to.equal('Numeric type inside category');
+		});
+
+		it('gets baseWeight', () => {
+			expect(entity.baseWeight()).to.equal(10);
+		});
+
+		it('gets maxPoints', () => {
+			expect(entity.maxPoints()).to.equal(100);
+		});
+	});
+
+	describe('Grade Category', () => {
+		let entity;
+
+		beforeEach(() => {
+			const entityJson = window.D2L.Hypermedia.Siren.Parse(testData.gradeEntity.category);
+			entity = new GradeEntity(entityJson);
+		});
+
+		it('gets name', () => {
+			expect(entity.name()).to.equal('Category 1');
+		});
+
+		it('gets baseWeight', () => {
+			expect(entity.baseWeight()).to.be.undefined;
+		});
+
+		it('gets maxPoints', () => {
+			expect(entity.maxPoints()).to.be.undefined;
+		});
+	});
+});

--- a/test/activities/data/GradeCandidateCollectionEntity.js
+++ b/test/activities/data/GradeCandidateCollectionEntity.js
@@ -10,22 +10,19 @@ export const testData = {
 					'grade-candidate'
 				],
 				'rel': [
-					'item'
+					'item',
+					'https://grades.api.brightspace.com/rels/grade'
 				],
-				'properties': {
-					'name': 'Assignment 1 Grade',
-					'maxPoints': '30'
-				},
 				'actions': [
 					{
-						'href': 'http://vlx1-mdulat.desire2learn.d2l:44444/d2l/api/hm/activities/activities/6606_2000_1/usages/6609/associate-grade',
+						'href': 'https://9caa9c10-0175-4c56-84e5-fc2bca4d8a52.activities.api.proddev.d2l/activities/6606_2000_11/usages/6609/associate-grade',
 						'name': 'associate-grade',
 						'method': 'POST',
 						'fields': [
 							{
 								'type': 'hidden',
 								'name': 'gradeItemId',
-								'value': '5006'
+								'value': 20
 							}
 						]
 					}
@@ -35,9 +32,59 @@ export const testData = {
 						'rel': [
 							'https://grades.api.brightspace.com/rels/grade'
 						],
-						'href': 'http://vlx1-mdulat.desire2learn.d2l:44444/d2l/api/hm/grades/organizations/6609/grades/5006'
+						'href': 'https://9caa9c10-0175-4c56-84e5-fc2bca4d8a52.grades.api.proddev.d2l/organizations/6609/grades/20'
 					}
-
+				]
+			},
+			{
+				'class': [
+					'grade-category'
+				],
+				'rel': [
+					'item',
+					'https://grades.api.brightspace.com/rels/grade-category'
+				],
+				'entities': [
+					{
+						'class': [
+							'current-association',
+							'grade-candidate'
+						],
+						'rel': [
+							'item',
+							'https://grades.api.brightspace.com/rels/grade'
+						],
+						'actions': [
+							{
+								'href': 'https://9caa9c10-0175-4c56-84e5-fc2bca4d8a52.activities.api.proddev.d2l/activities/6606_2000_11/usages/6609/associate-grade',
+								'name': 'associate-grade',
+								'method': 'POST',
+								'fields': [
+									{
+										'type': 'hidden',
+										'name': 'gradeItemId',
+										'value': 5024
+									}
+								]
+							}
+						],
+						'links': [
+							{
+								'rel': [
+									'https://grades.api.brightspace.com/rels/grade'
+								],
+								'href': 'https://9caa9c10-0175-4c56-84e5-fc2bca4d8a52.grades.api.proddev.d2l/organizations/6609/grades/5024'
+							}
+						]
+					}
+				],
+				'links': [
+					{
+						'rel': [
+							'https://grades.api.brightspace.com/rels/grade-category'
+						],
+						'href': 'https://9caa9c10-0175-4c56-84e5-fc2bca4d8a52.grades.api.proddev.d2l/organizations/6609/grade-categories/5010'
+					}
 				]
 			},
 			{
@@ -45,22 +92,19 @@ export const testData = {
 					'grade-candidate'
 				],
 				'rel': [
-					'item'
+					'item',
+					'https://grades.api.brightspace.com/rels/grade'
 				],
-				'properties': {
-					'name': 'Assignment 2 Grade',
-					'maxPoints': '30'
-				},
 				'actions': [
 					{
-						'href': 'http://vlx1-mdulat.desire2learn.d2l:44444/d2l/api/hm/activities/activities/6606_2000_1/usages/6609/associate-grade',
+						'href': 'https://9caa9c10-0175-4c56-84e5-fc2bca4d8a52.activities.api.proddev.d2l/activities/6606_2000_11/usages/6609/associate-grade',
 						'name': 'associate-grade',
 						'method': 'POST',
 						'fields': [
 							{
 								'type': 'hidden',
 								'name': 'gradeItemId',
-								'value': '5007'
+								'value': 6024
 							}
 						]
 					}
@@ -70,7 +114,7 @@ export const testData = {
 						'rel': [
 							'https://grades.api.brightspace.com/rels/grade'
 						],
-						'href': 'http://vlx1-mdulat.desire2learn.d2l:44444/d2l/api/hm/grades/organizations/6609/grades/5007'
+						'href': 'https://9caa9c10-0175-4c56-84e5-fc2bca4d8a52.grades.api.proddev.d2l/organizations/6609/grades/6024'
 					}
 				]
 			}
@@ -80,7 +124,7 @@ export const testData = {
 				'rel': [
 					'self'
 				],
-				'href': 'http://vlx1-mdulat.desire2learn.d2l:44444/d2l/api/hm/activities/activities/6606_2000_1/usages/6609/grade-candidates'
+				'href': 'https://9caa9c10-0175-4c56-84e5-fc2bca4d8a52.activities.api.proddev.d2l/activities/6606_2000_11/usages/6609/grade-candidates?gradeTypes=5&includeGradesWithDirectRubrics=0'
 			}
 		]
 	}

--- a/test/activities/data/GradeCandidateEntity.js
+++ b/test/activities/data/GradeCandidateEntity.js
@@ -1,0 +1,102 @@
+export const testData = {
+	gradeCandidateEntity: {
+		grade: {
+			'class': [
+				'grade-candidate'
+			],
+			'rel': [
+				'item',
+				'https://grades.api.brightspace.com/rels/grade'
+			],
+			'actions': [
+				{
+					'href': 'https://9caa9c10-0175-4c56-84e5-fc2bca4d8a52.activities.api.proddev.d2l/activities/6606_2000_11/usages/6609/associate-grade',
+					'name': 'associate-grade',
+					'method': 'POST',
+					'fields': [
+						{
+							'type': 'hidden',
+							'name': 'gradeItemId',
+							'value': 20
+						}
+					]
+				}
+			],
+			'links': [
+				{
+					'rel': [
+						'https://grades.api.brightspace.com/rels/grade'
+					],
+					'href': 'https://9caa9c10-0175-4c56-84e5-fc2bca4d8a52.grades.api.proddev.d2l/organizations/6609/grades/20'
+				}
+			]
+		},
+		gradeWithoutAssociateAction: {
+			'class': [
+				'grade-candidate'
+			],
+			'rel': [
+				'item',
+				'https://grades.api.brightspace.com/rels/grade'
+			],
+			'links': [
+				{
+					'rel': [
+						'https://grades.api.brightspace.com/rels/grade'
+					],
+					'href': 'https://9caa9c10-0175-4c56-84e5-fc2bca4d8a52.grades.api.proddev.d2l/organizations/6609/grades/20'
+				}
+			]
+		},
+		categoryWithGrade: {
+			'class': [
+				'grade-category'
+			],
+			'rel': [
+				'item',
+				'https://grades.api.brightspace.com/rels/grade-category'
+			],
+			'entities': [
+				{
+					'class': [
+						'grade-candidate'
+					],
+					'rel': [
+						'item',
+						'https://grades.api.brightspace.com/rels/grade'
+					],
+					'actions': [
+						{
+							'href': 'https://9caa9c10-0175-4c56-84e5-fc2bca4d8a52.activities.api.proddev.d2l/activities/6606_2000_11/usages/6609/associate-grade',
+							'name': 'associate-grade',
+							'method': 'POST',
+							'fields': [
+								{
+									'type': 'hidden',
+									'name': 'gradeItemId',
+									'value': 5024
+								}
+							]
+						}
+					],
+					'links': [
+						{
+							'rel': [
+								'https://grades.api.brightspace.com/rels/grade'
+							],
+							'href': 'https://9caa9c10-0175-4c56-84e5-fc2bca4d8a52.grades.api.proddev.d2l/organizations/6609/grades/5024'
+						}
+					]
+				}
+			],
+			'links': [
+				{
+					'rel': [
+						'https://grades.api.brightspace.com/rels/grade-category'
+					],
+					'href': 'https://9caa9c10-0175-4c56-84e5-fc2bca4d8a52.grades.api.proddev.d2l/organizations/6609/grade-categories/5010'
+				}
+			]
+		}
+	}
+};

--- a/test/activities/data/GradeCategoryEntity.js
+++ b/test/activities/data/GradeCategoryEntity.js
@@ -1,0 +1,30 @@
+export const testData = {
+	gradeCategoryEntity: {
+		normal: {
+			'class': [
+				'grade-category'
+			],
+			'rel': [
+				'item',
+				'https://grades.api.brightspace.com/rels/grade-category'
+			],
+			'properties': {
+				'name': 'Category 1'
+			},
+			'links': [
+				{
+					'rel': [
+						'self'
+					],
+					'href': 'https://9caa9c10-0175-4c56-84e5-fc2bca4d8a52.grades.api.proddev.d2l/organizations/6609/grade-categories/5008'
+				},
+				{
+					'rel': [
+						'https://api.brightspace.com/rels/organization'
+					],
+					'href': 'https://9caa9c10-0175-4c56-84e5-fc2bca4d8a52.organizations.api.proddev.d2l/6609'
+				}
+			]
+		}
+	}
+};

--- a/test/activities/data/GradeEntity.js
+++ b/test/activities/data/GradeEntity.js
@@ -68,28 +68,6 @@ export const testData = {
 				'item',
 				'https://grades.api.brightspace.com/rels/grade'
 			]
-		},
-		category: {
-			'class': [
-				'grade-category'
-			],
-			'properties': {
-				'name': 'Category 1'
-			},
-			'links': [
-				{
-					'rel': [
-						'self'
-					],
-					'href': 'https://9caa9c10-0175-4c56-84e5-fc2bca4d8a52.grades.api.proddev.d2l/organizations/6609/grade-categories/5008'
-				},
-				{
-					'rel': [
-						'https://api.brightspace.com/rels/organization'
-					],
-					'href': 'https://9caa9c10-0175-4c56-84e5-fc2bca4d8a52.organizations.api.proddev.d2l/6609'
-				}
-			]
 		}
 	}
 };

--- a/test/activities/data/GradeEntity.js
+++ b/test/activities/data/GradeEntity.js
@@ -1,0 +1,95 @@
+export const testData = {
+	gradeEntity: {
+		weighted: {
+			'class': [
+				'grade'
+			],
+			'properties': {
+				'name': 'Numeric type inside category',
+				'baseWeight': 10,
+				'maxPoints': 100
+			},
+			'entities': [
+				{
+					'class': [
+						'weight',
+						'weighted'
+					],
+					'rel': [
+						'https://grades.api.brightspace.com/rels/weight'
+					],
+					'properties': {
+						'weight': 5
+					}
+				}
+			],
+			'links': [
+				{
+					'rel': [
+						'self'
+					],
+					'href': 'https://9caa9c10-0175-4c56-84e5-fc2bca4d8a52.grades.api.proddev.d2l/organizations/6609/grades/5024'
+				},
+				{
+					'rel': [
+						'https://api.brightspace.com/rels/organization'
+					],
+					'href': 'https://9caa9c10-0175-4c56-84e5-fc2bca4d8a52.organizations.api.proddev.d2l/6609'
+				}
+			],
+			'rel': [
+				'item',
+				'https://grades.api.brightspace.com/rels/grade'
+			]
+		},
+		points: {
+			'class': [
+				'grade'
+			],
+			'properties': {
+				'name': 'Numeric type',
+				'maxPoints': 15
+			},
+			'links': [
+				{
+					'rel': [
+						'self'
+					],
+					'href': 'https://9caa9c10-0175-4c56-84e5-fc2bca4d8a52.grades.api.proddev.d2l/organizations/6614/grades/5026'
+				},
+				{
+					'rel': [
+						'https://api.brightspace.com/rels/organization'
+					],
+					'href': 'https://9caa9c10-0175-4c56-84e5-fc2bca4d8a52.organizations.api.proddev.d2l/6614'
+				}
+			],
+			'rel': [
+				'item',
+				'https://grades.api.brightspace.com/rels/grade'
+			]
+		},
+		category: {
+			'class': [
+				'grade-category'
+			],
+			'properties': {
+				'name': 'Category 1'
+			},
+			'links': [
+				{
+					'rel': [
+						'self'
+					],
+					'href': 'https://9caa9c10-0175-4c56-84e5-fc2bca4d8a52.grades.api.proddev.d2l/organizations/6609/grade-categories/5008'
+				},
+				{
+					'rel': [
+						'https://api.brightspace.com/rels/organization'
+					],
+					'href': 'https://9caa9c10-0175-4c56-84e5-fc2bca4d8a52.organizations.api.proddev.d2l/6609'
+				}
+			]
+		}
+	}
+};

--- a/test/index.html
+++ b/test/index.html
@@ -34,6 +34,9 @@
 			'./activities/assignments/AssignmentEntity.html',
 			'./activities/ActivityUsageCollectionEntity.html',
 			'./activities/ActivityUsageEntity.html',
+			'./activities/GradeCandidateCollectionEntity.html',
+			'./activities/GradeCandidateEntity.html',
+			'./activities/GradeEntity.html',
 			'./activities/GradeCandidateEntity.html',
 			'./organizations/OrganizationAvailabilitySetEntity.html',
 			'./organizations/OrganizationAvailabilityEntity.html'

--- a/test/index.html
+++ b/test/index.html
@@ -36,6 +36,7 @@
 			'./activities/ActivityUsageEntity.html',
 			'./activities/GradeCandidateCollectionEntity.html',
 			'./activities/GradeCandidateEntity.html',
+			'./activities/GradeCategoryEntity.html',
 			'./activities/GradeEntity.html',
 			'./activities/GradeCandidateEntity.html',
 			'./organizations/OrganizationAvailabilitySetEntity.html',


### PR DESCRIPTION
So we now have
`GradeCandidateCollectionEntity` which contains a list of `GradeCandidateEntity`s.
`GradeEntity` is what is returned by the `/grades/cache-primer`.
`GradeCategoryEntity` is what is returned by the `/grade-categories/cache-primer`.

A `GradeEntity` and `GradeCategoryEntity` will contain the properties of the item such as its name.
The `GradeCandidateEntity` will contain the associate action. (Activity specific)