### PR TITLE
Add check to see if GradeCandidate isCurrentAssociation

### DIFF
--- a/src/activities/GradeCandidateEntity.js
+++ b/src/activities/GradeCandidateEntity.js
@@ -40,6 +40,13 @@ export class GradeCandidateEntity extends Entity {
 	}
 
 	/**
+	 * @returns {bool} True if candidate is the currently associated item
+	 */
+	isCurrentAssociation() {
+		return this._entity && this._entity.hasClass(Classes.grades.currentAssociation);
+	}
+
+	/**
 	 * @returns {bool} True if the associate-grade action is present on the grade candidate
 	 */
 	canAssociateGrade() {

--- a/src/hypermedia-constants.js
+++ b/src/hypermedia-constants.js
@@ -286,6 +286,7 @@ export const Classes = {
 	grades: {
 		category: 'grade-category',
 		comments: 'comments',
+		currentAssociation: 'current-association',
 		description: 'description',
 		final: 'final',
 		grade: 'grade',

--- a/test/activities/GradeCandidateEntity.js
+++ b/test/activities/GradeCandidateEntity.js
@@ -29,6 +29,10 @@ describe('GradeCandidateEntity', () => {
 			expect(entity.isCategory()).to.be.false;
 		});
 
+		it('is the current association', () => {
+			expect(entity.isCurrentAssociation()).to.be.true;
+		});
+
 		it('can associate grade', () => {
 			expect(entity.canAssociateGrade()).to.be.true;
 		});
@@ -66,6 +70,10 @@ describe('GradeCandidateEntity', () => {
 			expect(entity.isCategory()).to.be.false;
 		});
 
+		it('is not the current association', () => {
+			expect(entity.isCurrentAssociation()).to.be.false;
+		});
+
 		it('can not associate to grade', () => {
 			expect(entity.canAssociateGrade()).to.be.false;
 		});
@@ -96,6 +104,10 @@ describe('GradeCandidateEntity', () => {
 
 		it('is a category', () => {
 			expect(entity.isCategory()).to.be.true;
+		});
+
+		it('is not the current association', () => {
+			expect(entity.isCurrentAssociation()).to.be.false;
 		});
 
 		it('can associate grade', () => {

--- a/test/activities/data/GradeCandidateEntity.js
+++ b/test/activities/data/GradeCandidateEntity.js
@@ -2,6 +2,7 @@ export const testData = {
 	gradeCandidateEntity: {
 		grade: {
 			'class': [
+				'current-association',
 				'grade-candidate'
 			],
 			'rel': [


### PR DESCRIPTION
The API serializer add a `current-association` class to the grade item that is currently associated to the assignment. This class will be present on at most one grade item in the whole collection.
It will be used in FACE to determine which `<option>` to set as the default in the `<select>` dropdown.