### PR TITLE
Add siren sdk wrappers for File Preview Location

### DIFF
--- a/src/activities/AttachmentCollectionEntity.js
+++ b/src/activities/AttachmentCollectionEntity.js
@@ -1,5 +1,6 @@
 import { Entity } from '../es6/Entity';
 import { performSirenAction } from '../es6/SirenAction';
+import { Rels } from '../hypermedia-constants';
 
 /**
  * Entity representation of a collection of attachments
@@ -180,5 +181,16 @@ export class AttachmentCollectionEntity extends Entity {
 
 		const action = this._entity.getActionByName('add-file');
 		await this._addFileAttachment(action, fileSystemType, fileId);
+	}
+
+	/**
+* @returns {string} Returns URL of the files home API
+*/
+	getFilesHref() {
+		if (!this._entity || !this._entity.hasLinkByRel(Rels.Files.files)) {
+			return;
+		}
+
+		return this._entity.getLinkByRel(Rels.Files.files).href;
 	}
 }

--- a/src/files/FilePreviewLocationEntity.js
+++ b/src/files/FilePreviewLocationEntity.js
@@ -1,0 +1,14 @@
+import { Entity } from '../es6/Entity';
+
+/**
+ * FilePreviewLocationEntity class representation of file preview location
+ */
+export class FilePreviewLocationEntity extends Entity {
+
+	/**
+	 * @returns {bool} True if the file preview location action is present
+	 */
+	previewLocation() {
+		return this._entity && this._entity.properties && this._entity.properties.previewLocation;
+	}
+}

--- a/src/files/FilePreviewLocationEntity.js
+++ b/src/files/FilePreviewLocationEntity.js
@@ -6,7 +6,7 @@ import { Entity } from '../es6/Entity';
 export class FilePreviewLocationEntity extends Entity {
 
 	/**
-	 * @returns {bool} True if the file preview location action is present
+	 * @returns {string} Returns the file preview location for the file
 	 */
 	previewLocation() {
 		return this._entity && this._entity.properties && this._entity.properties.previewLocation;

--- a/src/files/FilesHomeEntity.js
+++ b/src/files/FilesHomeEntity.js
@@ -15,7 +15,7 @@ export class FilesHomeEntity extends Entity {
 	}
 
 	/**
-	 * @retirms {string } Calls the Siren action to get a preview location for the specified file
+	 * @returns {string } Calls the Siren action to get a preview location for the specified file
 	 */
 	async getFilePreviewLocationEntity(fileSystemType, fileId) {
 		if (!this.canPreviewFiles()) {

--- a/src/files/FilesHomeEntity.js
+++ b/src/files/FilesHomeEntity.js
@@ -1,0 +1,33 @@
+import { Actions } from '../hypermedia-constants';
+import { Entity } from '../es6/Entity';
+import { performSirenAction } from '../es6/SirenAction';
+
+/**
+ * FilesHomeEntity class representation of organization files
+ */
+export class FilesHomeEntity extends Entity {
+
+	/**
+	 * @returns {bool} True if the file preview location action is present
+	 */
+	canPreviewFiles() {
+		return this._entity && this._entity.hasActionByName(Actions.files.filePreviewLocation);
+	}
+
+	/**
+	 * @retirms {string } Calls the Siren action to get a preview location for the specified file
+	 */
+	async getFilePreviewLocationEntity(fileSystemType, fileId) {
+		if (!this.canPreviewFiles()) {
+			return;
+		}
+
+		const action = this._entity.getActionByName(Actions.files.filePreviewLocation);
+		const fields = [
+			{ name: 'fileSystemType', value: fileSystemType },
+			{ name: 'fileId', value: fileId }
+		];
+		const sirenEntity = await performSirenAction(this._token, action, fields);
+		return sirenEntity;
+	}
+}

--- a/src/hypermedia-constants.js
+++ b/src/hypermedia-constants.js
@@ -108,6 +108,10 @@ export const Rels = {
 		mySubscriptions: 'https://discussions.api.brightspace.com/rels/my-subscriptions',
 		topic: 'https://discussions.api.brightspace.com/rels/topic'
 	},
+	// Files API sub-domain rels
+	Files: {
+		files: 'https://files.api.brightspace.com/rels/files',
+	},
 	// Folio API sub-domain rels
 	Folio: {
 		contentItem: 'https://folio.api.brightspace.com/rels/Content',
@@ -471,4 +475,7 @@ export const Actions = {
 	associations: {
 		deleteAssociation: 'delete-association'
 	},
+	files: {
+		filePreviewLocation: 'file-preview-location'
+	}
 };

--- a/test/files/FilesHomeEntity.html
+++ b/test/files/FilesHomeEntity.html
@@ -1,21 +1,18 @@
 <html>
+	<head>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
+		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
+		<script src="/node_modules/mocha/mocha.js"></script>
+		<script src="/node_modules/chai/chai.js"></script>
+		<script src="/node_modules/@polymer/test-fixture/test-fixture.js"></script>
+		<script src="/node_modules/wct-mocha/wct-mocha.js"></script>
+		<script src="/node_modules/sinon/pkg/sinon.js"></script>
+		<script type="module" src="/node_modules/fetch-mock/es5/client-bundle.js"></script>
 
-<head>
-	<meta charset="utf-8">
-	<meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
-	<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
-	<script src="/node_modules/mocha/mocha.js"></script>
-	<script src="/node_modules/chai/chai.js"></script>
-	<script src="/node_modules/@polymer/test-fixture/test-fixture.js"></script>
-	<script src="/node_modules/wct-mocha/wct-mocha.js"></script>
-	<script src="/node_modules/sinon/pkg/sinon.js"></script>
-	<script type="module" src="/node_modules/fetch-mock/es5/client-bundle.js"></script>
-
-	<script type="module" src="../../../siren-parser/global.js"></script>
-</head>
-
-<body>
-	<script type="module" src="./FilesHomeEntity.js"></script>
-</body>
-
+		<script type="module" src="../../../siren-parser/global.js"></script>
+	</head>
+	<body>
+		<script type="module" src="./FilesHomeEntity.js"></script>
+	</body>
 </html>

--- a/test/files/FilesHomeEntity.html
+++ b/test/files/FilesHomeEntity.html
@@ -1,0 +1,21 @@
+<html>
+
+<head>
+	<meta charset="utf-8">
+	<meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
+	<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
+	<script src="/node_modules/mocha/mocha.js"></script>
+	<script src="/node_modules/chai/chai.js"></script>
+	<script src="/node_modules/@polymer/test-fixture/test-fixture.js"></script>
+	<script src="/node_modules/wct-mocha/wct-mocha.js"></script>
+	<script src="/node_modules/sinon/pkg/sinon.js"></script>
+	<script type="module" src="/node_modules/fetch-mock/es5/client-bundle.js"></script>
+
+	<script type="module" src="../../../siren-parser/global.js"></script>
+</head>
+
+<body>
+	<script type="module" src="./FilesHomeEntity.js"></script>
+</body>
+
+</html>

--- a/test/files/FilesHomeEntity.js
+++ b/test/files/FilesHomeEntity.js
@@ -1,0 +1,33 @@
+/* global fetchMock */
+
+import { FilesHomeEntity } from '../../src/files/FilesHomeEntity.js';
+import { FilePreviewLocationEntity } from '../../src/files/FilePreviewLocationEntity.js';
+import { testData } from './data/FilesHomeEntity.js';
+import { filePreviewLocationEntity } from './data/FilePreviewLocationEntity.js';
+
+describe('AssignmentEntity', () => {
+	var editableEntity;
+
+	beforeEach(() => {
+		editableEntity = window.D2L.Hypermedia.Siren.Parse(testData.filesHomeEntityEditable);
+	});
+
+	afterEach(() => {
+		fetchMock.reset();
+	});
+
+	describe('preview location', () => {
+		it('gets preview location', async() => {
+			fetchMock.getOnce('https://b4b1eaba-26aa-4017-b37c-33e22649e477.files.api.proddev.d2l/121213/preview-location?fileSystemType=Temp&fileId=12345',
+				filePreviewLocationEntity);
+
+			var filesHomeEntity = new FilesHomeEntity(editableEntity);
+
+			const sirenFilePreviewLocation = await filesHomeEntity.getFilePreviewLocationEntity('Temp', '12345');
+
+			const previewLocationEntity = new FilePreviewLocationEntity(sirenFilePreviewLocation);
+			expect(previewLocationEntity.previewLocation()).to.equal('/d2l/lp/files/temp/12345/View');
+			expect(fetchMock.called()).to.be.true;
+		});
+	});
+});

--- a/test/files/data/FilePreviewLocationEntity.js
+++ b/test/files/data/FilePreviewLocationEntity.js
@@ -1,0 +1,13 @@
+export const filePreviewLocationEntity = {
+	'properties': {
+		'previewLocation': '/d2l/lp/files/temp/12345/View'
+	},
+	'links': [
+		{
+			'rel': [
+				'self'
+			],
+			'href': 'https://b4b1eaba-26aa-4017-b37c-33e22649e477.files.api.proddev.d2l/121213/preview-location?fileSystemType=Temp&fileId=12345'
+		}
+	]
+};

--- a/test/files/data/FilesHomeEntity.js
+++ b/test/files/data/FilesHomeEntity.js
@@ -1,0 +1,37 @@
+export const testData = {
+	filesHomeEntityEditable: {
+		'links': [
+			{
+				'rel': [
+					'self'
+				],
+				'href': 'https://b4b1eaba-26aa-4017-b37c-33e22649e477.files.api.proddev.d2l/121213'
+			}
+		],
+		'actions': [
+			{
+				'type': 'multipart/form-data',
+				'title': 'Upload file',
+				'href': 'https://b4b1eaba-26aa-4017-b37c-33e22649e477.files.api.proddev.d2l/121213/upload',
+				'name': 'upload-file',
+				'method': 'POST'
+			},
+			{
+				'title': 'File Preview Location',
+				'href': 'https://b4b1eaba-26aa-4017-b37c-33e22649e477.files.api.proddev.d2l/121213/preview-location',
+				'name': 'file-preview-location',
+				'method': 'GET',
+				'fields': [
+					{
+						'type': 'text',
+						'name': 'fileId'
+					},
+					{
+						'type': 'text',
+						'name': 'fileSystemType'
+					}
+				]
+			}
+		]
+	}
+}

--- a/test/files/data/FilesHomeEntity.js
+++ b/test/files/data/FilesHomeEntity.js
@@ -34,4 +34,4 @@ export const testData = {
 			}
 		]
 	}
-}
+};


### PR DESCRIPTION
The wrappers include a `FileHomeEntity` which contains a method to execute the action to get the FilePreviewLocation siren entity representing the preview location for a file.

The `FilePreviewLocationEntity` is a simple entity that just exposes the file preview location property.