### PR TITLE
Vwong/us114169 associate new grade

### DIFF
--- a/src/activities/ActivityUsageEntity.js
+++ b/src/activities/ActivityUsageEntity.js
@@ -530,16 +530,33 @@ export class ActivityUsageEntity extends Entity {
 		}
 
 		const associatedGrade = scoreAndGrade.associatedGrade;
-		const associateGrade = associatedGrade && associatedGrade.href() !== this.gradeHref() && associatedGrade.canAssociateGrade();
-		if (associateGrade) {
+		const replaceGradeItem = scoreAndGrade.inGrades && !associatedGrade && this.gradeHref() && scoreAndGrade.associateNewGradeAction;
+		const associateToExistingGrade = scoreAndGrade.inGrades && associatedGrade && associatedGrade.canAssociateGrade() && this.gradeHref() !== associatedGrade.href();
+		if (replaceGradeItem) {
+			await this._replaceGradeItem(scoreAndGrade);
+		} else if (associateToExistingGrade) {
 			await associatedGrade.associateGrade();
 		}
 
-		if (associateGrade ||
+		if (associateToExistingGrade ||
 			scoreAndGrade.scoreOutOf !== this.scoreOutOf().toString() ||
 			scoreAndGrade.inGrades !== this.inGrades()) {
 			await this.setScoreOutOf(scoreAndGrade.scoreOutOf, scoreAndGrade.inGrades);
 		}
+	}
+
+	async _replaceGradeItem(scoreAndGrade) {
+		const action = scoreAndGrade.associateNewGradeAction;
+		if (!action || !this.canEditGrades()) {
+			return;
+		}
+
+		const fields = [
+			{ name: 'gradeName', value: scoreAndGrade.newGradeName },
+			{ name: 'scoreOutOf', value: scoreAndGrade.scoreOutOf }
+		];
+
+		await performSirenAction(this._token, action, fields);
 	}
 
 	async save(activity) {

--- a/src/activities/GradeCandidateCollectionEntity.js
+++ b/src/activities/GradeCandidateCollectionEntity.js
@@ -1,3 +1,4 @@
+import { Actions } from '../hypermedia-constants';
 import { Entity } from '../es6/Entity';
 
 /**
@@ -9,5 +10,9 @@ export class GradeCandidateCollectionEntity extends Entity {
 	 */
 	getGradeCandidates() {
 		return (this._entity && this._entity.getSubEntitiesByRel('item')) || [];
+	}
+
+	getAssociateNewGradeAction() {
+		return this._entity && this._entity.getActionByName(Actions.activities.associateNewGrade);
 	}
 }

--- a/src/activities/GradeCandidateEntity.js
+++ b/src/activities/GradeCandidateEntity.js
@@ -1,4 +1,4 @@
-import { Classes, Rels } from '../hypermedia-constants';
+import { Actions, Classes, Rels } from '../hypermedia-constants';
 import { Entity } from '../es6/Entity';
 import { performSirenAction } from '../es6/SirenAction';
 
@@ -50,7 +50,7 @@ export class GradeCandidateEntity extends Entity {
 	 * @returns {bool} True if the associate-grade action is present on the grade candidate
 	 */
 	canAssociateGrade() {
-		return this._entity && this._entity.hasActionByName('associate-grade');
+		return this._entity && this._entity.hasActionByName(Actions.activities.associateGrade);
 	}
 
 	/**
@@ -61,7 +61,7 @@ export class GradeCandidateEntity extends Entity {
 			return;
 		}
 
-		const action = this._entity.getActionByName('associate-grade');
+		const action = this._entity.getActionByName(Actions.activities.associateGrade);
 		await performSirenAction(this._token, action);
 	}
 }

--- a/src/es6/SirenAction.js
+++ b/src/es6/SirenAction.js
@@ -30,14 +30,14 @@ const _getEntityUrl = function(action, fields) {
 	}
 
 	let url = new URL(action.href, window.location.origin);
-
-	if (fields) {
-		fields = _appendHiddenFields(action, fields);
+	let tempFields = fields ? [...fields] : [];
+	if (tempFields.length) {
+		_appendHiddenFields(action, tempFields);
 	} else {
-		fields = _getSirenFields(action);
+		tempFields = _getSirenFields(action);
 	}
 	if (action.method === 'GET' || action.method === 'HEAD') {
-		const params = _createURLSearchParams(fields);
+		const params = _createURLSearchParams(tempFields);
 		url = new URL(url.pathname + '?' + params.toString(), url.origin);
 	}
 
@@ -116,7 +116,7 @@ const _performSirenAction = function(action, fields, tokenValue) {
 	let body;
 
 	if (fields) {
-		fields = _appendHiddenFields(action, fields);
+		_appendHiddenFields(action, fields);
 	} else {
 		fields = _getSirenFields(action);
 	}

--- a/src/hypermedia-constants.js
+++ b/src/hypermedia-constants.js
@@ -411,7 +411,9 @@ export const Actions = {
 		updateDraft: 'update-draft',
 		scoreOutOf: {
 			update: 'update'
-		}
+		},
+		associateGrade: 'associate-grade',
+		associateNewGrade: 'associate-new-grade',
 	},
 	assignments: {
 		assign: 'assign',


### PR DESCRIPTION
**Call `associate-new-grade` action**
This will send a PATCH request to the `activity-usage` endpoint. The start/due/end dates also use this endpoint.
In a future PR, the two PATCH requests will be combined into one.

**Fix hidden fields appended twice when the original fields argument is not `undefined`**
When `fields` is passed in as a parameter, because it is an array, appending hidden fields in the `_getEntityUrl` function and then again in the `_performSirenAction` function modifies the original `fields` variable. This results in  the hidden field to be added twice.