### PR TITLE
DE38379 Added assignmentHasSubmissions method to AssignmentEntity.js

### DIFF
--- a/src/activities/assignments/AssignmentEntity.js
+++ b/src/activities/assignments/AssignmentEntity.js
@@ -202,6 +202,22 @@ export class AssignmentEntity extends Entity {
 	}
 
 	/**
+	 * @returns {bool} If the assignment has submissions
+	 */
+	assignmentHasSubmissions() {
+		if (!this._entity) {
+			return false;
+		}
+
+		const subEntity = this._entity.getSubEntityByRel(Rels.Assignments.folderType);
+		if (!subEntity) {
+			return false;
+		}
+
+		return subEntity.hasClass(Classes.assignments.assignmentType.hasSubmissions);
+	}
+
+	/**
 	 * @returns {bool} If the assignment type "group assignment" can be set
 	 */
 	isGroupAssignmentTypeDisabled() {

--- a/src/hypermedia-constants.js
+++ b/src/hypermedia-constants.js
@@ -219,7 +219,8 @@ export const Classes = {
 		assignmentType: {
 			individual: 'individual',
 			noGroupType: 'no-group-type',
-			readOnly: 'read-only'
+			readOnly: 'read-only',
+			hasSubmissions: 'has-submissions'
 		},
 		attachment: 'attachment',
 		attachmentList: 'attachment-list',


### PR DESCRIPTION
For [DE38379](https://rally1.rallydev.com/#/110294864140d/detail/defect/377932041916), added a method to retrieve if an assignment has submissions. 

## Why?
At the moment the Hypermedia API will never return a `folder-type` entity with the `has-submissions` class because it does not exist in the API. The plan is to rename the `read-only` class when the user HAS permission to edit the entity to `has-submissions` since that is what it was really being used for. Then when the user does NOT have permissions the API will actually respond with `read-only`.

## What is next?
The plan is as follows:
1. add `assignmentHasSubmissions` method to siren-sdk
2. add property in assignment MobX store to retrieve this value along with `read-only`
3. replace the `read-only` class in the hypermedia API with `has-submissions` when the user HAS permission to edit
4. update the `isAssignmentTypeReadOnly` method in siren-sdk to rely on the presence of actions
5. update `save` method in siren-sdk to also check if the assignment has submissions
6. remove `read-only` class in the hypermedia API since we don't need it
7. verify UI to make sure permissions reflected as expected