### PR TITLE
DE38379 Update siren-sdk to allow displaying info even when in read only mode

### DIFF
--- a/src/activities/assignments/AssignmentEntity.js
+++ b/src/activities/assignments/AssignmentEntity.js
@@ -194,7 +194,7 @@ export class AssignmentEntity extends Entity {
 		if (!this._entity) {
 			return false;
 		}
-		return !this._entity.hasActionByName(Actions.assignments.setToGroup) && 
+		return !this._entity.hasActionByName(Actions.assignments.setToGroup) &&
 			!this._entity.hasActionByName(Actions.assignments.setToIndividual) ;
 	}
 
@@ -363,7 +363,7 @@ export class AssignmentEntity extends Entity {
 
 	_getReadOnlySubmissionTypeOptions() {
 		if (!this._entity) {
-			return []
+			return [];
 		}
 
 		const currentSubmissionType = this._entity.properties.submissionType;

--- a/src/activities/assignments/AssignmentEntity.js
+++ b/src/activities/assignments/AssignmentEntity.js
@@ -194,11 +194,8 @@ export class AssignmentEntity extends Entity {
 		if (!this._entity) {
 			return false;
 		}
-		const subEntity = this._entity.getSubEntityByRel(Rels.Assignments.folderType);
-		if (!subEntity) {
-			return false;
-		}
-		return subEntity.hasClass(Classes.assignments.assignmentType.readOnly);
+		
+		return this._entity.getActionByName(Actions.assignments.setToGroup) && this._entity.getActionByName(Actions.assignments.setToIndividual) ;
 	}
 
 	/**

--- a/src/activities/assignments/AssignmentEntity.js
+++ b/src/activities/assignments/AssignmentEntity.js
@@ -194,8 +194,13 @@ export class AssignmentEntity extends Entity {
 		if (!this._entity) {
 			return false;
 		}
-		return !this._entity.hasActionByName(Actions.assignments.setToGroup) &&
-			!this._entity.hasActionByName(Actions.assignments.setToIndividual) ;
+
+		const subEntity = this._entity.getSubEntityByRel(Rels.Assignments.folderType);
+		if (!subEntity) {
+			return false;
+		}
+		return !subEntity.hasActionByName(Actions.assignments.setToGroup) &&
+			!subEntity.hasActionByName(Actions.assignments.setToIndividual) ;
 	}
 
 	/**

--- a/src/activities/assignments/AssignmentEntity.js
+++ b/src/activities/assignments/AssignmentEntity.js
@@ -194,7 +194,8 @@ export class AssignmentEntity extends Entity {
 		if (!this._entity) {
 			return false;
 		}
-		return this._entity.getActionByName(Actions.assignments.setToGroup) && this._entity.getActionByName(Actions.assignments.setToIndividual) ;
+		return !this._entity.hasActionByName(Actions.assignments.setToGroup) && 
+			!this._entity.hasActionByName(Actions.assignments.setToIndividual) ;
 	}
 
 	/**
@@ -360,6 +361,15 @@ export class AssignmentEntity extends Entity {
 		await performSirenAction(this._token, action, fields);
 	}
 
+	_getReadOnlySubmissionTypeOptions() {
+		if (!this._entity) {
+			return []
+		}
+
+		const currentSubmissionType = this._entity.properties.submissionType;
+		return currentSubmissionType ? [currentSubmissionType] : [];
+	}
+
 	/**
 	 * @returns {object} Submission type of the assignment (including type value and type title)
 	 */
@@ -375,13 +385,17 @@ export class AssignmentEntity extends Entity {
 	 * @returns {Array} Set of submission type options for this assignment
 	 */
 	submissionTypeOptions() {
-		if (!this.canEditSubmissionType()) {
+		if (!this._entity) {
 			return [];
 		}
 
 		const action = this._entity.getActionByName(Actions.assignments.updateSubmissionType);
+		if (!action) {
+			return this._getReadOnlySubmissionTypeOptions();
+		}
+
 		if (!action.hasFieldByName('submissionType')) {
-			return [];
+			return this._getReadOnlySubmissionTypeOptions();
 		}
 
 		return action.getFieldByName('submissionType').value;

--- a/src/activities/assignments/AssignmentEntity.js
+++ b/src/activities/assignments/AssignmentEntity.js
@@ -194,7 +194,6 @@ export class AssignmentEntity extends Entity {
 		if (!this._entity) {
 			return false;
 		}
-		
 		return this._entity.getActionByName(Actions.assignments.setToGroup) && this._entity.getActionByName(Actions.assignments.setToIndividual) ;
 	}
 

--- a/src/hypermedia-constants.js
+++ b/src/hypermedia-constants.js
@@ -219,7 +219,6 @@ export const Classes = {
 		assignmentType: {
 			individual: 'individual',
 			noGroupType: 'no-group-type',
-			readOnly: 'read-only',
 			hasSubmissions: 'has-submissions'
 		},
 		attachment: 'attachment',


### PR DESCRIPTION
Continuing work from https://github.com/BrightspaceHypermediaComponents/siren-sdk/pull/171

This PR makes the `isAssignmentTypeReadOnly` method check the entity for the assignment type actions rather than relying on the `read-only` class.
Also return the submission type even if the assignment is read only.