### PR TITLE
US113746 Add helper to get save action from GradeCandidateEntity

### DIFF
--- a/src/activities/GradeCandidateEntity.js
+++ b/src/activities/GradeCandidateEntity.js
@@ -61,6 +61,13 @@ export class GradeCandidateEntity extends Entity {
 	}
 
 	/**
+	 * @returns {object} Returns the save action if it is present on the grade candidate
+	 */
+	getSaveAction() {
+		return this._entity && this._entity.getActionByName(Actions.activities.save);
+	}
+
+	/**
 	 * Calls the Siren action to associate this grade with the activity
 	 */
 	async associateGrade() {

--- a/src/hypermedia-constants.js
+++ b/src/hypermedia-constants.js
@@ -417,6 +417,7 @@ export const Actions = {
 		},
 		associateGrade: 'associate-grade',
 		associateNewGrade: 'associate-new-grade',
+		save: 'save'
 	},
 	assignments: {
 		assign: 'assign',

--- a/test/activities/GradeCandidateEntity.js
+++ b/test/activities/GradeCandidateEntity.js
@@ -41,6 +41,10 @@ describe('GradeCandidateEntity', () => {
 			expect(entity.canAssociateGrade()).to.be.true;
 		});
 
+		it('does not have a save action', () => {
+			expect(entity.getSaveAction()).to.be.undefined;
+		});
+
 		it('returns a promise when associating grade', async() => {
 			fetchMock.postOnce('https://9caa9c10-0175-4c56-84e5-fc2bca4d8a52.activities.api.proddev.d2l/activities/6606_2000_11/usages/6609/associate-grade', entityJson);
 
@@ -86,6 +90,10 @@ describe('GradeCandidateEntity', () => {
 			expect(entity.canAssociateGrade()).to.be.false;
 		});
 
+		it('does not have a save action', () => {
+			expect(entity.getSaveAction()).to.be.undefined;
+		});
+
 		it('skips associating as it does not have the associate action', async() => {
 			await entity.associateGrade();
 			expect(fetchMock.done());
@@ -120,6 +128,10 @@ describe('GradeCandidateEntity', () => {
 
 		it('can associate grade', () => {
 			expect(entity.canAssociateGrade()).to.be.false;
+		});
+
+		it('does not have a save action', () => {
+			expect(entity.getSaveAction()).to.be.undefined;
 		});
 
 		it('skips associating as it does not hve the associate action', async() => {
@@ -160,6 +172,10 @@ describe('GradeCandidateEntity', () => {
 			expect(entity.canAssociateGrade()).to.be.false;
 		});
 
+		it('has a save action', () => {
+			expect(entity.getSaveAction()).to.be.an('object');
+		});
+
 		it('skips associating as it does not have the associate action', async() => {
 			await entity.associateGrade();
 			expect(fetchMock.done());
@@ -196,6 +212,10 @@ describe('GradeCandidateEntity', () => {
 
 		it('can not associate to grade', () => {
 			expect(entity.canAssociateGrade()).to.be.false;
+		});
+
+		it('has a save action', () => {
+			expect(entity.getSaveAction()).to.be.an('object');
 		});
 
 		it('skips associating as it does not have the associate action', async() => {


### PR DESCRIPTION
This will enable support for setting the grade category when creating the new grade, by getting the `save` action from the GradeCandidateEntity (which has the category information on it).

The save logic in `ActivityUsageEntity` functions without any changes.