### PR TITLE
DE38903 - Add separate start and end date functions to the OrganizationEntity

### DIFF
--- a/src/organizations/OrganizationEntity.js
+++ b/src/organizations/OrganizationEntity.js
@@ -40,8 +40,20 @@ export class OrganizationEntity extends Entity {
 		return this._entity && this._entity.properties && this._entity.properties.endDate;
 	}
 
+	isAfterEndDate() {
+		var nowDate = Date.now();
+		var endDate = Date.parse(this.endDate());
+		return endDate ? endDate <= nowDate : null;
+	}
+
 	startDate() {
 		return this._entity && this._entity.properties && this._entity.properties.startDate;
+	}
+
+	isBeforeStartDate() {
+		var nowDate = Date.now();
+		var startDate = Date.parse(this.startDate());
+		return startDate ? startDate > nowDate : null;
 	}
 
 	isActive() {
@@ -80,8 +92,8 @@ export class OrganizationEntity extends Entity {
 		const dateTime = {
 			type: dateType,
 			date: date,
-			beforeStartDate: startDate ? startDate > nowDate : null,
-			afterEndDate: endDate ? endDate <= nowDate : null
+			beforeStartDate: startDate ? startDate > nowDate : null,  // To delete, use isBeforeStartDate()
+			afterEndDate: endDate ? endDate <= nowDate : null         // To delete, use isAfterEndDate()
 		};
 		return dateTime;
 	}


### PR DESCRIPTION
As explained in [DE38903](https://rally1.rallydev.com/#/15545167705d/detail/defect/388906722124?fdp=true), we don't want the my-courses widget settings around hiding the start and end date on the card to affect the adding of the closed badge, or the behavior around hiding closed courses on the main widget view.  Currently it does both because all three places use the same function (`processedDate`) to get this info, but this function can return `null` depending on the `hideCourseStartDate` and `hideCourseEndDate` values.

In this PR, I add two new functions to get the `beforeStartDate` and `afterEndDate` info separately from the `processedDate` function, so that it's not affected by those widget setting values.

Then I need to update `d2l-organization-date`, `d2l-enrollment-card`, `d2l-enrollment-hero-banner` and my-courses to use the new functions instead.  To avoid a major release or trying to coordinate merging all at the same time, I've left the info in `processedDate` for now, and I'll delete it after those four spots no longer use it.  This will leave the `processedDate` only in charge of deciding what text date info we want to show.