### PR TITLE
DE38903 - Remove unused info from the object response of processedDate function

### DIFF
--- a/src/organizations/OrganizationEntity.js
+++ b/src/organizations/OrganizationEntity.js
@@ -91,9 +91,7 @@ export class OrganizationEntity extends Entity {
 
 		const dateTime = {
 			type: dateType,
-			date: date,
-			beforeStartDate: startDate ? startDate > nowDate : null,  // To delete, use isBeforeStartDate()
-			afterEndDate: endDate ? endDate <= nowDate : null         // To delete, use isAfterEndDate()
+			date: date
 		};
 		return dateTime;
 	}


### PR DESCRIPTION
Now that all usages of `beforeStartDate` and `afterEndDate` have been removed, we can delete them.