### PR TITLE
DE39197 - add get completionTypeValue function

### DIFF
--- a/src/activities/assignments/AssignmentEntity.js
+++ b/src/activities/assignments/AssignmentEntity.js
@@ -456,6 +456,18 @@ export class AssignmentEntity extends Entity {
 		return this._entity.properties.completionType;
 	}
 
+	completionTypeValue() {
+		if (!this._entity) {
+			return;
+		}
+
+		const completionType = this.completionType();
+		if (completionType) {
+			return String(completionType.value);
+		}
+		return String(0);
+	}
+
 	/**
 	 * @returns {Array} Set of all possible completion type options
 	 */
@@ -783,7 +795,7 @@ export class AssignmentEntity extends Entity {
 			[this.isIndividualAssignmentType(), assignment.isIndividualAssignmentType]
 		];
 		if (assignment.hasOwnProperty('completionType')) {
-			diffs.push([this.completionType() && String(this.completionType().value), assignment.completionType]);
+			diffs.push([this.completionTypeValue(), assignment.completionType]);
 		}
 		if (assignment.hasOwnProperty('filesSubmissionLimit')) {
 			diffs.push([this.filesSubmissionLimit(), assignment.filesSubmissionLimit]);

--- a/test/activities/assignments/AssignmentEntity.js
+++ b/test/activities/assignments/AssignmentEntity.js
@@ -45,7 +45,7 @@ describe('AssignmentEntity', () => {
 				name: 'Extra Special Assignment',
 				instructions: '<p>These are your instructions</p>',
 				submissionType: undefined,
-				completionType: undefined,
+				completionType: String(0),
 				isAnonymous: false,
 				annotationToolsAvailable: true,
 				isIndividualAssignmentType: false,
@@ -54,13 +54,13 @@ describe('AssignmentEntity', () => {
 			})).to.be.true;
 		});
 
-		it('return false when equal', () => {
+		it('return false when not equal', () => {
 			var assignmentEntity = new AssignmentEntity(editableEntity);
 			expect(assignmentEntity.equals({
 				name: 'Extra Special Assignment',
 				instructions: '<p>These are your instructions</p>',
 				submissionType: undefined,
-				completionType: undefined,
+				completionType: String(0),
 				isAnonymous: false,
 				annotationToolsAvailable: true,
 				isIndividualAssignmentType: true,


### PR DESCRIPTION
Because the dirty/equals check sits in siren-sdk, the dirty check doesn't know that we were substituting an undefined completionType value with String(0) in activities, so the dirty check always fails. Here, we add a get `completionTypeValue` function to siren-sdk that can be used by both activities code and the siren-sdk dirty/equals check.