### PR TITLE
US116718 Support ActivityUsage direct-associations href

### DIFF
--- a/src/activities/ActivityUsageEntity.js
+++ b/src/activities/ActivityUsageEntity.js
@@ -647,6 +647,14 @@ export class ActivityUsageEntity extends Entity {
 		return this._entity.getLinkByRel(Rels.Activities.associations).href;
 	}
 
+	getDirectRubricAssociationsHref() {
+		if (!this._entity || !this._entity.hasLinkByRel(Rels.Activities.directAssociations)) {
+			return;
+		}
+
+		return this._entity.getLinkByRel(Rels.Activities.directAssociations).href;
+	}
+
 	alignmentsHref() {
 		if (!this._entity || !this._entity.hasLinkByRel(Rels.Alignments.alignments)) {
 			return;

--- a/src/hypermedia-constants.js
+++ b/src/hypermedia-constants.js
@@ -64,6 +64,7 @@ export const Rels = {
 		scoreOutOf: 'https://activities.api.brightspace.com/rels/score-out-of',
 		gradeCandidates: 'https://activities.api.brightspace.com/rels/grade-candidates',
 		associations: 'https://activities.api.brightspace.com/rels/associations',
+		directAssociations: 'https://activities.api.brightspace.com/rels/direct-associations',
 		newGradeAssociation: 'https://activities.api.brightspace.com/rels/new-grade-association'
 	},
 	Conditions: {

--- a/test/activities/ActivityUsageEntity.js
+++ b/test/activities/ActivityUsageEntity.js
@@ -58,11 +58,11 @@ describe('ActivityUsageEntity', () => {
 		});
 
 		it('can get associations url', () => {
-			expect(entity.competenciesHref()).to.equal('http://vlx1-mdulat.desire2learn.d2l:44444/d2l/api/hm/activities/activities/6606_2000_31/usages/6609/associations');
+			expect(entity.getRubricAssociationsHref()).to.equal('http://vlx1-mdulat.desire2learn.d2l:44444/d2l/api/hm/activities/activities/6606_2000_31/usages/6609/associations');
 		});
 
 		it('can get direct associations url', () => {
-			expect(entity.competenciesHref()).to.equal('http://vlx1-mdulat.desire2learn.d2l:44444/d2l/api/hm/activities/activities/6606_2000_31/usages/6609/associations?direct=1');
+			expect(entity.getDirectRubricAssociationsHref()).to.equal('http://vlx1-mdulat.desire2learn.d2l:44444/d2l/api/hm/activities/activities/6606_2000_31/usages/6609/associations?direct=1');
 		});
 	});
 

--- a/test/activities/ActivityUsageEntity.js
+++ b/test/activities/ActivityUsageEntity.js
@@ -56,6 +56,14 @@ describe('ActivityUsageEntity', () => {
 		it('can get legacy competencies url', () => {
 			expect(entity.competenciesHref()).to.equal('http://vlx1-mdulat.desire2learn.d2l:44444/d2l/api/hm/alignments/activity-usage/6606/legacy-competencies?ActivityBatchId=6606_2000_7');
 		});
+
+		it('can get associations url', () => {
+			expect(entity.competenciesHref()).to.equal('http://vlx1-mdulat.desire2learn.d2l:44444/d2l/api/hm/activities/activities/6606_2000_31/usages/6609/associations');
+		});
+
+		it('can get direct associations url', () => {
+			expect(entity.competenciesHref()).to.equal('http://vlx1-mdulat.desire2learn.d2l:44444/d2l/api/hm/activities/activities/6606_2000_31/usages/6609/associations?direct=1');
+		});
 	});
 
 	describe('Functionality', () => {

--- a/test/activities/data/ActivityUsageEntity.js
+++ b/test/activities/data/ActivityUsageEntity.js
@@ -197,6 +197,18 @@ export const testData = {
 					'https://alignments.api.brightspace.com/rels/legacy-competencies'
 				],
 				'href': 'http://vlx1-mdulat.desire2learn.d2l:44444/d2l/api/hm/alignments/activity-usage/6606/legacy-competencies?ActivityBatchId=6606_2000_7'
+			},
+			{
+				'rel': [
+					'https://alignments.api.brightspace.com/rels/associations'
+				],
+				'href': 'http://vlx1-mdulat.desire2learn.d2l:44444/d2l/api/hm/activities/activities/6606_2000_31/usages/6609/associations'
+			},
+			{
+				'rel': [
+					'https://alignments.api.brightspace.com/rels/direct-associations'
+				],
+				'href': 'http://vlx1-mdulat.desire2learn.d2l:44444/d2l/api/hm/activities/activities/6606_2000_31/usages/6609/associations?direct=1'
 			}
 		],
 		'actions': [

--- a/test/activities/data/ActivityUsageEntity.js
+++ b/test/activities/data/ActivityUsageEntity.js
@@ -200,13 +200,13 @@ export const testData = {
 			},
 			{
 				'rel': [
-					'https://alignments.api.brightspace.com/rels/associations'
+					'https://activities.api.brightspace.com/rels/associations'
 				],
 				'href': 'http://vlx1-mdulat.desire2learn.d2l:44444/d2l/api/hm/activities/activities/6606_2000_31/usages/6609/associations'
 			},
 			{
 				'rel': [
-					'https://alignments.api.brightspace.com/rels/direct-associations'
+					'https://activities.api.brightspace.com/rels/direct-associations'
 				],
 				'href': 'http://vlx1-mdulat.desire2learn.d2l:44444/d2l/api/hm/activities/activities/6606_2000_31/usages/6609/associations?direct=1'
 			}


### PR DESCRIPTION
Adds support to get the new `direct-associations` activities href `.../activities/{activityId}/usages/{orgUnitId}/associations?direct=1` on the activity-usage entity.

https://rally1.rallydev.com/#/29180338367d/detail/userstory/391870800084