### PR TITLE
files can be sent as strings

### DIFF
--- a/src/activities/AttachmentCollectionEntity.js
+++ b/src/activities/AttachmentCollectionEntity.js
@@ -113,10 +113,19 @@ export class AttachmentCollectionEntity extends Entity {
 	}
 
 	async _addFileAttachment(action, fileSystemType, fileId) {
-		const fields = [
+		let fields = [
 			{ name: 'fileSystemType', value: fileSystemType },
 			{ name: 'fileId', value: fileId }
 		];
+		if (action.hasFieldByName('value')) {
+			fields = [
+				{
+					name: 'value',
+					value: JSON.stringify({ FileSystemType: fileSystemType, FileId: fileId})
+				}
+			];
+		}
+
 		await performSirenAction(this._token, action, fields);
 	}
 


### PR DESCRIPTION
This allows file uploads to work with consistent eval, which expects a single value field 