### PR TITLE
US117892 - fix readonly assignment type marked as unequal

### DIFF
--- a/src/activities/assignments/AssignmentEntity.js
+++ b/src/activities/assignments/AssignmentEntity.js
@@ -840,7 +840,7 @@ export class AssignmentEntity extends Entity {
 			}
 		}
 
-		if (!assignment.isIndividualAssignmentType && !this.isGroupAssignmentTypeDisabled()) {
+		if (!this.isAssignmentTypeReadOnly() && !assignment.isIndividualAssignmentType && !this.isGroupAssignmentTypeDisabled()) {
 			const selected = this.getAssignmentTypeGroupCategoryOptions().find(x => x.selected);
 			if (String(selected && selected.value) !== assignment.groupTypeId) {
 				return false;


### PR DESCRIPTION
We should not be trying to find the selected category when the assignment is readonly. It will always be `undefined` since the assignment `setToGroup` action will be missing and so we won't be able to find a selected option from an empty array of groupCategoryOptions.

https://rally1.rallydev.com/#/29180338367d/iterationstatus?detail=%2Fuserstory%2F399772334476