### PR TITLE
US118882 Only include isAnonymous in assignment entity dirty check if it is present

### DIFF
--- a/src/activities/assignments/AssignmentEntity.js
+++ b/src/activities/assignments/AssignmentEntity.js
@@ -820,11 +820,13 @@ export class AssignmentEntity extends Entity {
 			[this.name(), assignment.name],
 			[this.instructionsEditorHtml(), assignment.instructions],
 			[this.submissionType() && String(this.submissionType().value), assignment.submissionType],
-			[this.isAnonymousMarkingEnabled(), assignment.isAnonymous],
 			[this.getAvailableAnnotationTools(), assignment.annotationToolsAvailable],
 			[this.isIndividualAssignmentType(), assignment.isIndividualAssignmentType],
 			[this.getDefaultScoringRubric(), assignment.defaultScoringRubricId]
 		];
+		if (assignment.hasOwnProperty('isAnonymous')) {
+			diffs.push([this.isAnonymousMarkingEnabled(), assignment.isAnonymous]);
+		}
 		if (assignment.hasOwnProperty('completionType')) {
 			diffs.push([this.completionTypeValue(), assignment.completionType]);
 		}

--- a/test/activities/assignments/AssignmentEntity.js
+++ b/test/activities/assignments/AssignmentEntity.js
@@ -68,6 +68,19 @@ describe('AssignmentEntity', () => {
 				filesSubmissionLimit: 'unlimited'
 			})).to.be.false;
 		});
+
+		it('ignores props that are not set', () => {
+			var assignmentEntity = new AssignmentEntity(editableEntity);
+			expect(assignmentEntity.equals({
+				name: 'Extra Special Assignment',
+				instructions: '<p>These are your instructions</p>',
+				submissionType: undefined,
+				annotationToolsAvailable: true,
+				isIndividualAssignmentType: false,
+				groupTypeId: '314',
+				defaultScoringRubricId: '-1'
+			})).to.be.true;
+		});
 	});
 
 	describe('Saves', () => {


### PR DESCRIPTION
The prop is being excluded in the case of submission types that don't support anonymous marking (on-paper and in-person), in which case it should be ignored here. 