### PR TITLE
Fix Entity fetch error not accessible

### DIFF
--- a/src/es6/Entity.js
+++ b/src/es6/Entity.js
@@ -127,9 +127,9 @@ export class Entity extends EntitySirenProperties {
 			dispose(this._subEntities.get(link.href));
 		}
 		this._subEntitiesLoadStatus.push(new Promise((resolve) => {
-			entityFactory(entityType, link, this._token, (entity) => {
+			entityFactory(entityType, link, this._token, (entity, error) => {
 				this._subEntities.set(link.href, entity);
-				onChange(entity);
+				onChange(entity, error);
 				Promise.all(entity._subEntitiesLoadStatus).then(() => {
 					resolve && resolve();
 					resolve = null;


### PR DESCRIPTION
Entity fetch error to exposed when fetching subEntityByHref but not
subEntityByEntity even though a fetch is still performed (and response
can therefore be malformed) when subEntity is seed-less