### PR TITLE
Support getting activity usage gradeType title from unselected numeric gradeType

### DIFF
--- a/src/activities/ActivityUsageEntity.js
+++ b/src/activities/ActivityUsageEntity.js
@@ -468,8 +468,8 @@ export class ActivityUsageEntity extends Entity {
 				return numericGradeType.title;
 			}
 		}
-		const scoreOutOfEntity = this._getScoreOutOfEntity();
-		return scoreOutOfEntity ? scoreOutOfEntity.properties.gradeType : undefined;
+
+		return '';
 	}
 
 	/**

--- a/src/activities/ActivityUsageEntity.js
+++ b/src/activities/ActivityUsageEntity.js
@@ -458,6 +458,21 @@ export class ActivityUsageEntity extends Entity {
 	}
 
 	/**
+	 * @returns {string} Grade type title for the numeric grade type.
+	 */
+	numericGradeTypeTitle() {
+		const action = this._getScoreOutOfAction();
+		if (action && action.hasFieldByName('gradeType')) {
+			const numericGradeType = action.getFieldByName('gradeType').value.find(x => x.value === 'Numeric');
+			if (numericGradeType) {
+				return numericGradeType.title;
+			}
+		}
+		const scoreOutOfEntity = this._getScoreOutOfEntity();
+		return scoreOutOfEntity ? scoreOutOfEntity.properties.gradeType : undefined;
+	}
+
+	/**
 	 * @returns {string} URL of the grade associated with the activity usage, if present
 	 */
 	gradeHref() {

--- a/test/activities/ActivityUsageEntity.js
+++ b/test/activities/ActivityUsageEntity.js
@@ -193,6 +193,10 @@ describe('ActivityUsageEntity', () => {
 					expect(entity.gradeType()).to.equal('Points');
 				});
 
+				it('gets numeric gradeType title', () => {
+					expect(entity.numericGradeTypeTitle()).to.equal('Points');
+				});
+
 				it('can edit score out of', () => {
 					expect(entity.canEditScoreOutOf()).to.be.true;
 				});
@@ -230,6 +234,10 @@ describe('ActivityUsageEntity', () => {
 
 				it('gets gradeType', () => {
 					expect(readonlyEntity.gradeType()).to.equal('Points');
+				});
+
+				it('gets numeric gradeType title', () => {
+					expect(entity.numericGradeTypeTitle()).to.equal('Points');
 				});
 
 				it('can edit score out of', () => {


### PR DESCRIPTION
https://trello.com/c/ss2PQ5ho/232-points-string-not-translated-for-assignments-not-originally-in-grades

In support of activities PR: https://github.com/BrightspaceHypermediaComponents/activities/pull/1012