### PR TITLE
DE39814 - Stop calling `score-out-of` api if a new grade is created

### DIFF
--- a/src/activities/ActivityUsageEntity.js
+++ b/src/activities/ActivityUsageEntity.js
@@ -635,7 +635,12 @@ export class ActivityUsageEntity extends Entity {
 			return;
 		}
 
-		return !this._shouldCreateAssociationToNewGrade(scoreAndGrade) &&
+		let isCreatingAssociationToNewGrade = this._shouldCreateAssociationToNewGrade(scoreAndGrade);
+
+		// Required override for 20.20.9 for BG (green ui / blue server) reasons. Remove for 20.20.10 release.
+		isCreatingAssociationToNewGrade = isCreatingAssociationToNewGrade && !this.scoreOutOf();
+
+		return !isCreatingAssociationToNewGrade &&
 			(this._shouldCreateAssociationToExistingGrade(scoreAndGrade)
 			|| scoreAndGrade.scoreOutOf !== this.scoreOutOf().toString()
 			|| scoreAndGrade.inGrades !== this.inGrades());


### PR DESCRIPTION
https://rally1.rallydev.com/#/29180338367d/iterationstatus?detail=%2Fdefect%2F405157847512

**Associated PRs**
https://git.dev.d2l/projects/CORE/repos/lms/pull-requests/14588/overview
https://github.com/BrightspaceHypermediaComponents/activities/pull/1033