### PR TITLE
Revert "Fix to cover BG (green UI / blue server) issues"

### DIFF
--- a/src/activities/ActivityUsageEntity.js
+++ b/src/activities/ActivityUsageEntity.js
@@ -635,12 +635,7 @@ export class ActivityUsageEntity extends Entity {
 			return;
 		}
 
-		let isCreatingAssociationToNewGrade = this._shouldCreateAssociationToNewGrade(scoreAndGrade);
-
-		// Required override for 20.20.9 for BG (green ui / blue server) reasons. Remove for 20.20.10 release.
-		isCreatingAssociationToNewGrade = isCreatingAssociationToNewGrade && !this.scoreOutOf();
-
-		return !isCreatingAssociationToNewGrade &&
+		return !this._shouldCreateAssociationToNewGrade(scoreAndGrade) &&
 			(this._shouldCreateAssociationToExistingGrade(scoreAndGrade)
 			|| scoreAndGrade.scoreOutOf !== this.scoreOutOf().toString()
 			|| scoreAndGrade.inGrades !== this.inGrades());


### PR DESCRIPTION
This reverts commit b4c6a59129a9240033e9ed1f636095a37fad5c6e.

That commit added some code to make it safe for the 20.09 release when the server is blue and the UI is green.
But the code can be removed for the 20.10 release.

See Rally for details: https://rally1.rallydev.com/#/29180338367d/iterationstatus?detail=%2Fuserstory%2F411093071188