### PR TITLE
Setup basic content entity

### DIFF
--- a/src/activities/content/ContentEntity.js
+++ b/src/activities/content/ContentEntity.js
@@ -8,6 +8,6 @@ export class ContentEntity extends Entity {
 	 * @returns {string} Name of the content item
 	 */
 	name() {
-		return this._entity && this._entity.properties && this._entity.properties.name;
+		return this._entity && this._entity.properties && this._entity.properties.title;
 	}
 }

--- a/src/activities/content/ContentEntity.js
+++ b/src/activities/content/ContentEntity.js
@@ -7,7 +7,7 @@ export class ContentEntity extends Entity {
 	/**
 	 * @returns {string} Name of the content item
 	 */
-	name() {
+	title() {
 		return this._entity && this._entity.properties && this._entity.properties.title;
 	}
 }

--- a/src/activities/content/ContentEntity.js
+++ b/src/activities/content/ContentEntity.js
@@ -5,7 +5,7 @@ import { Entity } from '../../es6/Entity';
  */
 export class ContentEntity extends Entity {
 	/**
-	 * @returns {string} Name of the assignment
+	 * @returns {string} Name of the content item
 	 */
 	name() {
 		return this._entity && this._entity.properties && this._entity.properties.name;

--- a/src/activities/content/ContentEntity.js
+++ b/src/activities/content/ContentEntity.js
@@ -1,0 +1,13 @@
+import { Entity } from '../../es6/Entity';
+
+/**
+ * ContentEntity class representation of a d2l content entity.
+ */
+export class ContentEntity extends Entity {
+	/**
+	 * @returns {string} Name of the assignment
+	 */
+	name() {
+		return this._entity && this._entity.properties && this._entity.properties.name;
+	}
+}

--- a/src/activities/content/ContentEntity.js
+++ b/src/activities/content/ContentEntity.js
@@ -5,7 +5,7 @@ import { Entity } from '../../es6/Entity';
  */
 export class ContentEntity extends Entity {
 	/**
-	 * @returns {string} Name of the content item
+	 * @returns {string} Title of the content item
 	 */
 	title() {
 		return this._entity && this._entity.properties && this._entity.properties.title;

--- a/test/activities/content/ContentEntity.html
+++ b/test/activities/content/ContentEntity.html
@@ -1,0 +1,18 @@
+<html>
+	<head>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
+		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
+		<script src="/node_modules/mocha/mocha.js"></script>
+		<script src="/node_modules/chai/chai.js"></script>
+		<script src="/node_modules/@polymer/test-fixture/test-fixture.js"></script>
+		<script src="/node_modules/wct-mocha/wct-mocha.js"></script>
+		<script src="/node_modules/sinon/pkg/sinon.js"></script>
+		<script type="module" src="/node_modules/fetch-mock/es5/client-bundle.js"></script>
+
+		<script type="module" src="../../../../siren-parser/global.js"></script>
+	</head>
+	<body>
+		<script type="module" src="./ContentEntity.js"></script>
+	</body>
+</html>

--- a/test/activities/content/ContentEntity.js
+++ b/test/activities/content/ContentEntity.js
@@ -1,5 +1,3 @@
-/* global fetchMock */
-
 import { ContentEntity } from '../../../src/activities/content/ContentEntity.js';
 import { editableContent } from './data/EditableContent.js';
 
@@ -10,14 +8,10 @@ describe('ContentEntity', () => {
 		editableEntity = window.D2L.Hypermedia.Siren.Parse(editableContent);
 	});
 
-	afterEach(() => {
-		fetchMock.reset();
-	});
-
 	describe('Basic loading', () => {
 		it('reads name', () => {
 			var contentEntity = new ContentEntity(editableEntity);
-			expect(contentEntity.name()).to.equal('Extra Special Content');
+			expect(contentEntity.name()).to.equal('Test Content Name');
 		});
 	});
 });

--- a/test/activities/content/ContentEntity.js
+++ b/test/activities/content/ContentEntity.js
@@ -1,0 +1,23 @@
+/* global fetchMock */
+
+import { ContentEntity } from '../../../src/activities/content/ContentEntity.js';
+import { editableContent } from './data/EditableContent.js';
+
+describe('ContentEntity', () => {
+	let editableEntity;
+
+	beforeEach(() => {
+		editableEntity = window.D2L.Hypermedia.Siren.Parse(editableContent);
+	});
+
+	afterEach(() => {
+		fetchMock.reset();
+	});
+
+	describe('Basic loading', () => {
+		it('reads name', () => {
+			var contentEntity = new ContentEntity(editableEntity);
+			expect(contentEntity.name()).to.equal('Extra Special Content');
+		});
+	});
+});

--- a/test/activities/content/ContentEntity.js
+++ b/test/activities/content/ContentEntity.js
@@ -9,9 +9,9 @@ describe('ContentEntity', () => {
 	});
 
 	describe('Basic loading', () => {
-		it('reads name', () => {
+		it('reads title', () => {
 			var contentEntity = new ContentEntity(editableEntity);
-			expect(contentEntity.name()).to.equal('Test Content Name');
+			expect(contentEntity.title()).to.equal('Test Content Title');
 		});
 	});
 });

--- a/test/activities/content/data/EditableContent.js
+++ b/test/activities/content/data/EditableContent.js
@@ -1,0 +1,10 @@
+export const editableContent = {
+	'class': [
+		'content'
+	],
+	'properties': {
+		'name': 'Extra Special Content'
+	},
+	'entities': [],
+	'rel': []
+};

--- a/test/activities/content/data/EditableContent.js
+++ b/test/activities/content/data/EditableContent.js
@@ -3,7 +3,7 @@ export const editableContent = {
 		'content-activity'
 	],
 	'properties': {
-		'title': 'Test Content Name'
+		'title': 'Test Content Title'
 	},
 	'entities': [],
 	'rel': []

--- a/test/activities/content/data/EditableContent.js
+++ b/test/activities/content/data/EditableContent.js
@@ -1,9 +1,9 @@
 export const editableContent = {
 	'class': [
-		'content'
+		'content-activity'
 	],
 	'properties': {
-		'name': 'Extra Special Content'
+		'title': 'Test Content Name'
 	},
 	'entities': [],
 	'rel': []

--- a/test/index.html
+++ b/test/index.html
@@ -30,6 +30,7 @@
 			'./UserSettingsEntity/UserSettingsEntity.html',
 			'./AlertsEntity/AlertsEntity.html',
 			'./helpers/StateTree.html',
+			'./activities/content/ContentEntity.html',
 			'./activities/assignments/AssignmentActivityUsageEntity.html',
 			'./activities/assignments/AssignmentEntity.html',
 			'./activities/ActivitySpecialAccessEntity.html',


### PR DESCRIPTION
Setting up basic content entity in `siren-sdk` so activities repo can initialize a content store with this entity type. Basing this off a similar approach assignments took when setting up there `assignments-store.js` [here](https://github.com/BrightspaceHypermediaComponents/activities/blob/master/components/d2l-activity-editor/d2l-activity-assignment-editor/state/assignment-store.js#L7).  Assignments initializes an entity in their state and bases it off the entity definition in this repo. The use of it in the activities repo can be seen [here](https://github.com/BrightspaceHypermediaComponents/activities/blob/master/components/d2l-activity-editor/d2l-activity-assignment-editor/state/assignment.js#L32). 

This is just the initialization of the entity with a basic name property so I can setup a `content` store in activities. I assume this is the structure it will take but can easily adjust if it is not. 