### PR TITLE
Don't call toString when scoreOutOf() returns undefined

### DIFF
--- a/src/activities/ActivityUsageEntity.js
+++ b/src/activities/ActivityUsageEntity.js
@@ -635,9 +635,11 @@ export class ActivityUsageEntity extends Entity {
 			return;
 		}
 
+		const scoreOutOf = this.scoreOutOf() ? this.scoreOutOf().toString() : undefined;
+
 		return !this._shouldCreateAssociationToNewGrade(scoreAndGrade) &&
 			(this._shouldCreateAssociationToExistingGrade(scoreAndGrade)
-			|| scoreAndGrade.scoreOutOf !== this.scoreOutOf()?.toString()
+			|| scoreAndGrade.scoreOutOf !== scoreOutOf
 			|| scoreAndGrade.inGrades !== this.inGrades());
 	}
 

--- a/src/activities/ActivityUsageEntity.js
+++ b/src/activities/ActivityUsageEntity.js
@@ -635,9 +635,11 @@ export class ActivityUsageEntity extends Entity {
 			return;
 		}
 
+		const scoreOutOf = this.scoreOutOf() ? this.scoreOutOf().toString() : undefined;
+
 		return !this._shouldCreateAssociationToNewGrade(scoreAndGrade) &&
 			(this._shouldCreateAssociationToExistingGrade(scoreAndGrade)
-			|| scoreAndGrade.scoreOutOf !== this.scoreOutOf().toString()
+			|| scoreAndGrade.scoreOutOf !== scoreOutOf
 			|| scoreAndGrade.inGrades !== this.inGrades());
 	}
 

--- a/src/activities/ActivityUsageEntity.js
+++ b/src/activities/ActivityUsageEntity.js
@@ -635,11 +635,9 @@ export class ActivityUsageEntity extends Entity {
 			return;
 		}
 
-		const scoreOutOf = this.scoreOutOf() ? this.scoreOutOf().toString() : undefined;
-
 		return !this._shouldCreateAssociationToNewGrade(scoreAndGrade) &&
 			(this._shouldCreateAssociationToExistingGrade(scoreAndGrade)
-			|| scoreAndGrade.scoreOutOf !== scoreOutOf
+			|| scoreAndGrade.scoreOutOf !== this.scoreOutOf()?.toString()
 			|| scoreAndGrade.inGrades !== this.inGrades());
 	}
 


### PR DESCRIPTION
Issue in save workflow where `toString` is called on `scoreOutOf()` even when it returns undefined. This throws an error and the save workflow is not properly executed. Mitigating this by preventing `toString` being called when `scoreOutOf()` returns undefined. 