### PR TITLE
Rfegan/add quiz entity

### DIFF
--- a/src/activities/quizzes/QuizEntity.js
+++ b/src/activities/quizzes/QuizEntity.js
@@ -1,0 +1,36 @@
+import { Entity } from '../../es6/Entity';
+import { Actions } from '../../hypermedia-constants';
+import { performSirenAction } from '../../es6/SirenAction';
+
+/**
+ * QuizEntity class representation of a d2l Quiz.
+ */
+export class QuizEntity extends Entity {
+	/**
+	 * @returns {string} Name of the quiz
+	 */
+	name() {
+		return this._entity && this._entity.properties && this._entity.properties.name;
+	}
+
+	/**
+	 * @returns {bool} Whether or not the edit name action is present on the quiz entity
+	 */
+	canEditName() {
+		return this._entity && this._entity.hasActionByName(Actions.quizzes.updateName);
+	}
+
+	/**
+	 * Updates the quiz to have the given name
+	 * @param {string} name Name to set on the quiz
+	 */
+	async setName(name) {
+		const action = this.canEditName() && this._entity.getActionByName(Actions.quizzes.updateName);
+		if (!action) {
+			return;
+		}
+
+		const fields = [{ name: 'name', value: name }];
+		await performSirenAction(this._token, action, fields);
+	}
+}

--- a/src/hypermedia-constants.js
+++ b/src/hypermedia-constants.js
@@ -493,5 +493,8 @@ export const Actions = {
 	},
 	files: {
 		filePreviewLocation: 'file-preview-location'
-	}
+	},
+	quizzes: {
+		updateName: 'update-name',
+	},
 };

--- a/test/activities/quizzes/QuizEntity.html
+++ b/test/activities/quizzes/QuizEntity.html
@@ -1,0 +1,18 @@
+<html>
+	<head>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
+		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
+		<script src="/node_modules/mocha/mocha.js"></script>
+		<script src="/node_modules/chai/chai.js"></script>
+		<script src="/node_modules/@polymer/test-fixture/test-fixture.js"></script>
+		<script src="/node_modules/wct-mocha/wct-mocha.js"></script>
+		<script src="/node_modules/sinon/pkg/sinon.js"></script>
+		<script type="module" src="/node_modules/fetch-mock/es5/client-bundle.js"></script>
+
+		<script type="module" src="../../../../siren-parser/global.js"></script>
+	</head>
+	<body>
+		<script type="module" src="./QuizEntity.js"></script>
+	</body>
+</html>

--- a/test/activities/quizzes/QuizEntity.js
+++ b/test/activities/quizzes/QuizEntity.js
@@ -20,7 +20,6 @@ describe('QuizEntity', () => {
 		it('reads name', () => {
 			var quizEntity = new QuizEntity(nonEditableEntity);
 			expect(quizEntity.name()).to.equal('Whafadfsdfdgreat quiz');
-			throw Error('Noo way');
 		});
 	});
 

--- a/test/activities/quizzes/QuizEntity.js
+++ b/test/activities/quizzes/QuizEntity.js
@@ -19,7 +19,7 @@ describe('QuizEntity', () => {
 	describe('Basic loading', () => {
 		it('reads name', () => {
 			var quizEntity = new QuizEntity(nonEditableEntity);
-			expect(quizEntity.name()).to.equal('Whafadfsdfdgreat quiz');
+			expect(quizEntity.name()).to.equal('What a great quiz');
 		});
 	});
 

--- a/test/activities/quizzes/QuizEntity.js
+++ b/test/activities/quizzes/QuizEntity.js
@@ -1,0 +1,40 @@
+/* global fetchMock */
+
+import { QuizEntity } from '../../../src/activities/quizzes/QuizEntity.js';
+import { nonEditableQuiz } from './data/NoneditableQuiz';
+import { editableQuiz } from './data/EditableQuiz.js';
+
+describe('QuizEntity', () => {
+	var editableEntity, nonEditableEntity;
+
+	beforeEach(() => {
+		nonEditableEntity = window.D2L.Hypermedia.Siren.Parse(nonEditableQuiz);
+		editableEntity = window.D2L.Hypermedia.Siren.Parse(editableQuiz);
+	});
+
+	afterEach(() => {
+		fetchMock.reset();
+	});
+
+	describe('Basic loading', () => {
+		it('reads name', () => {
+			var quizEntity = new QuizEntity(nonEditableEntity);
+			expect(quizEntity.name()).to.equal('Whafadfsdfdgreat quiz');
+			throw Error('Noo way');
+		});
+	});
+
+	describe('Editable', () => {
+		it('sets canEditName to true', () => {
+			var quizEntity = new QuizEntity(editableEntity);
+			expect(quizEntity.canEditName()).to.be.true;
+		});
+	});
+
+	describe('Non Editable', () => {
+		it('sets canEditName to false', () => {
+			var quizEntity = new QuizEntity(nonEditableEntity);
+			expect(quizEntity.canEditName()).to.be.false;
+		});
+	});
+});

--- a/test/activities/quizzes/data/EditableQuiz.js
+++ b/test/activities/quizzes/data/EditableQuiz.js
@@ -1,0 +1,41 @@
+export const editableQuiz = {
+	'class': [
+		'quiz'
+	],
+	'properties': {
+		'name': 'What a great quiz'
+	},
+	'actions': [
+		{
+			'class': [
+				'required'
+			],
+			'href': 'https://f5aa43d7-c082-485c-84f5-4808147fe98a.assignments.api.dev.brightspace.com/123060/folders/7',
+			'name': 'update-name',
+			'method': 'PATCH',
+			'fields': [
+				{
+					'type': 'text',
+					'name': 'name',
+				}
+			]
+		},
+	],
+	'links': [
+		{
+			'rel': [
+				'self'
+			],
+			'href': 'https://f5aa43d7-c082-485c-84f5-4808147fe98a.quizzes.api.dev.brightspace.com/123060/folders/7'
+		},
+		{
+			'rel': [
+				'https://activities.api.brightspace.com/rels/activity-usage'
+			],
+			'href': 'https://f5aa43d7-c082-485c-84f5-4808147fe98a.activities.api.dev.brightspace.com/activities/6606_51000_7/usages/123060'
+		},
+	],
+	'rel': [
+		'https://quizzes.api.brightspace.com/rels/quiz'
+	]
+};

--- a/test/activities/quizzes/data/EditableQuiz.js
+++ b/test/activities/quizzes/data/EditableQuiz.js
@@ -10,7 +10,7 @@ export const editableQuiz = {
 			'class': [
 				'required'
 			],
-			'href': 'https://f5aa43d7-c082-485c-84f5-4808147fe98a.assignments.api.dev.brightspace.com/123060/folders/7',
+			'href': 'https://f5aa43d7-c082-485c-84f5-4808147fe98a.quizzes.api.dev.brightspace.com/123060/folders/7',
 			'name': 'update-name',
 			'method': 'PATCH',
 			'fields': [

--- a/test/activities/quizzes/data/NoneditableQuiz.js
+++ b/test/activities/quizzes/data/NoneditableQuiz.js
@@ -1,0 +1,25 @@
+export const nonEditableQuiz = {
+	'class': [
+		'quiz'
+	],
+	'properties': {
+		'name': 'What a great quiz'
+	},
+	'links': [
+		{
+			'rel': [
+				'self'
+			],
+			'href': 'https://f5aa43d7-c082-485c-84f5-4808147fe98a.quizzes.api.dev.brightspace.com/123060/folders/7'
+		},
+		{
+			'rel': [
+				'https://activities.api.brightspace.com/rels/activity-usage'
+			],
+			'href': 'https://f5aa43d7-c082-485c-84f5-4808147fe98a.activities.api.dev.brightspace.com/activities/6606_51000_7/usages/123060'
+		},
+	],
+	'rel': [
+		'https://quizzes.api.brightspace.com/rels/quiz'
+	]
+};

--- a/test/index.html
+++ b/test/index.html
@@ -33,6 +33,7 @@
 			'./activities/content/ContentEntity.html',
 			'./activities/assignments/AssignmentActivityUsageEntity.html',
 			'./activities/assignments/AssignmentEntity.html',
+			'./activities/quizzes/QuizEntity.html',
 			'./activities/ActivitySpecialAccessEntity.html',
 			'./activities/ActivityUsageCollectionEntity.html',
 			'./activities/ActivityUsageEntity.html',


### PR DESCRIPTION
Part of [US119416](https://rally1.rallydev.com/#/29180338367d/iterationstatus?detail=/userstory/413005808740) new siren-sdk quiz entity to facilitate functionality related to updating quiz names.