### PR TITLE
Renaming quiz subentity specific class to be more generic

### DIFF
--- a/src/activities/quizzes/QuizEntity.js
+++ b/src/activities/quizzes/QuizEntity.js
@@ -42,11 +42,11 @@ export class QuizEntity extends Entity {
 	}
 
 	/**
- * @returns {bool} Whether or not hints are enabled for the quiz entity
+ * @returns {bool} Whether or not hints are allowed for the quiz entity
  */
 	getHintsToolEnabled() {
 		const hintsEntity = this._entity.getSubEntityByRel(Rels.Quizzes.hints);
-		return hintsEntity && hintsEntity.hasClass(Classes.quizzes.hintsEnabled);
+		return hintsEntity && hintsEntity.hasClass(Classes.quizzes.checked);
 	}
 
 	async save(quiz) {

--- a/src/hypermedia-constants.js
+++ b/src/hypermedia-constants.js
@@ -328,7 +328,7 @@ export const Classes = {
 		quiz: 'quiz',
 		description: 'description',
 		hints: 'has-hints',
-		hintsEnabled: 'enabled'
+		checked: 'checked'
 	},
 	text: {
 		richtext: 'richtext'

--- a/test/activities/quizzes/data/EditableQuiz.js
+++ b/test/activities/quizzes/data/EditableQuiz.js
@@ -58,7 +58,7 @@ export const editableQuiz = {
 			],
 			'class': [
 				'has-hints',
-				'enabled'
+				'checked'
 			],
 			'actions': [
 				{

--- a/test/activities/quizzes/data/NoneditableQuiz.js
+++ b/test/activities/quizzes/data/NoneditableQuiz.js
@@ -40,7 +40,7 @@ export const nonEditableQuiz = {
 			],
 			'class': [
 				'has-hints',
-				'disabled'
+				'unchecked'
 			],
 		}
 	]


### PR DESCRIPTION
The reason for renaming the `hintsEnabled` constant, is that more quiz subentities are going to be added.

I also renamed the `enabled` string to `checked`. I am working on [US120983](https://rally1.rallydev.com/#/detail/userstory/438844241972?fdp=true) which adds the subentity "DisableRightClick". If DisableRightClick is checked, it can be confusing to include an `enabled` class, likewise a `disabled` class when it is unchecked (i.e. right click not actually disabled).
The backend change is in this PR: https://github.com/Brightspace/lms/pull/3446

Also, disabled could also make it confusing for the future, when someone thinks that class means the checkbox can't be editable or something. 