### PR TITLE
Add content module delete action

### DIFF
--- a/src/activities/content/ContentModuleEntity.js
+++ b/src/activities/content/ContentModuleEntity.js
@@ -88,9 +88,8 @@ export class ContentModuleEntity extends Entity {
 			return;
 		}
 
-		await performSirenAction(this._token, action).then(() => {
-			this.dispose();
-		});
+		await performSirenAction(this._token, action);
+		this.dispose();
 	}
 
 	/**

--- a/src/activities/content/ContentModuleEntity.js
+++ b/src/activities/content/ContentModuleEntity.js
@@ -88,7 +88,9 @@ export class ContentModuleEntity extends Entity {
 			return;
 		}
 
-		await performSirenAction(this._token, action, null);
+		await performSirenAction(this._token, action).then(() => {
+			this.dispose();
+		});
 	}
 
 	/**

--- a/src/activities/content/ContentModuleEntity.js
+++ b/src/activities/content/ContentModuleEntity.js
@@ -77,6 +77,21 @@ export class ContentModuleEntity extends Entity {
 	}
 
 	/**
+	 * Deletes the module
+	 */
+	async deleteModule() {
+		if (!this._entity) {
+			return;
+		}
+		const action = this._entity.getActionByName(Actions.content.deleteModule);
+		if (!action) {
+			return;
+		}
+
+		await performSirenAction(this._token, action, null);
+	}
+
+	/**
 	 * Checks if content module properties passed in match what is currently stored
 	 * @param {object} contentModule Object containing module specific properties
 	 */

--- a/src/hypermedia-constants.js
+++ b/src/hypermedia-constants.js
@@ -449,7 +449,8 @@ export const Actions = {
 	},
 	content: {
 		updateTitle: 'update-title',
-		updateDescription: 'update-description'
+		updateDescription: 'update-description',
+		deleteModule: 'delete-module'
 	},
 	notifications: {
 		getCarrierClass: 'get-carrier',

--- a/test/activities/content/ContentModuleEntity.js
+++ b/test/activities/content/ContentModuleEntity.js
@@ -82,7 +82,7 @@ describe('ContentModuleEntity', () => {
 			expect(fetchMock.called()).to.be.true;
 		});
 
-		it('deletes module', async() => {
+		it('performs delete request', async() => {
 			fetchMock.deleteOnce('https://fake-tenant-id.modules.api.proddev.d2l/6613/modules/12345', moduleData);
 			await contentModuleEntity.deleteModule();
 			expect(fetchMock.called()).to.be.true;

--- a/test/activities/content/ContentModuleEntity.js
+++ b/test/activities/content/ContentModuleEntity.js
@@ -57,7 +57,7 @@ describe('ContentModuleEntity', () => {
 		});
 	});
 
-	describe('Saves', () => {
+	describe('Actions', () => {
 		it('saves title', async() => {
 			fetchMock.patchOnce('https://fake-tenant-id.modules.api.proddev.d2l/6613/modules/12345', moduleData);
 
@@ -79,6 +79,12 @@ describe('ContentModuleEntity', () => {
 			if (!form.notSupported) {
 				expect(form.get('description')).to.equal('<p>New description</p>');
 			}
+			expect(fetchMock.called()).to.be.true;
+		});
+
+		it('deletes module', async() => {
+			fetchMock.deleteOnce('https://fake-tenant-id.modules.api.proddev.d2l/6613/modules/12345', moduleData);
+			await contentModuleEntity.deleteModule();
 			expect(fetchMock.called()).to.be.true;
 		});
 	});

--- a/test/activities/content/data/TestContentModuleEntity.js
+++ b/test/activities/content/data/TestContentModuleEntity.js
@@ -25,6 +25,11 @@ export const contentModuleData = {
 					'value': '<p>description text</p>'
 				}
 			]
+		},
+		{
+			'href': 'https://fake-tenant-id.modules.api.proddev.d2l/6613/modules/12345',
+			'name': 'delete-module',
+			'method': 'DELETE'
 		}
 	],
 	'class': [


### PR DESCRIPTION
Adds delete action to `ContentModuleEntity` so we can call it from the activities UI side when the user cancels the creation of a new module.

**Related PRs**:
- https://github.com/BrightspaceHypermediaComponents/activities/pull/1184
- https://github.com/Brightspace/lms/pull/3414

![create-cancel-delete](https://user-images.githubusercontent.com/64804046/99285950-34761200-2806-11eb-8ce6-ece55442ccf0.gif)
