### PR TITLE
Fix quiz hints dirty check

### DIFF
--- a/src/activities/quizzes/QuizEntity.js
+++ b/src/activities/quizzes/QuizEntity.js
@@ -134,7 +134,7 @@ export class QuizEntity extends Entity {
 	equals(quiz) {
 		const diffs = [
 			[this.name(), quiz.name],
-			[this.canEditHints(), quiz.allowHints]
+			[this.getHintsToolEnabled(), quiz.allowHints]
 		];
 
 		for (const [left, right] of diffs) {

--- a/test/activities/quizzes/QuizEntity.js
+++ b/test/activities/quizzes/QuizEntity.js
@@ -39,20 +39,30 @@ describe('QuizEntity', () => {
 	});
 
 	describe('Equals', () => {
-		it('return true when equal', () => {
-			var quizEntity = new QuizEntity(editableEntity);
-			expect(quizEntity.equals({
+		var modifiedEntity;
+
+		beforeEach(() => {
+			modifiedEntity = {
 				name: 'What a great quiz',
 				allowHints: true
-			})).to.be.true;
+			};
 		});
 
-		it('return false when not equal', () => {
+		it('return true when equal', () => {
 			var quizEntity = new QuizEntity(editableEntity);
-			expect(quizEntity.equals({
-				name: 'This is a terrible quiz',
-				allowHints: undefined
-			})).to.be.false;
+			expect(quizEntity.equals(modifiedEntity)).to.be.true;
+		});
+
+		it('return false when name not equal', () => {
+			var quizEntity = new QuizEntity(editableEntity);
+			modifiedEntity.name = 'This is a terrible quiz';
+			expect(quizEntity.equals(modifiedEntity)).to.be.false;
+		});
+
+		it('return false when hints not equal', () => {
+			var quizEntity = new QuizEntity(editableEntity);
+			modifiedEntity.allowHints = false;
+			expect(quizEntity.equals(modifiedEntity)).to.be.false;
 		});
 	});
 


### PR DESCRIPTION
The dirty check should be checking the original value of `has-hints` instead of whether we can edit it or not.