### PR TITLE
Add PR reminder checklist

### DIFF
--- a/.github/workflows/prchecklist.yml
+++ b/.github/workflows/prchecklist.yml
@@ -1,11 +1,11 @@
-name: PR Checklist
+name: PR Reminder Checklist
 on:
   pull_request:
     types: [opened]
 jobs:
   fyi:
-    name: Posts a PR checklist
-    runs-on: [self-hosted, Lms, Linux]
+    name: Posts a PR Reminder checklist
+    runs-on: ubuntu-latest
     timeout-minutes: 2
     steps:
       - uses: Brightspace/third-party-actions@actions/github-script
@@ -18,11 +18,11 @@ jobs:
               owner: context.repo.owner,
               repo: context.repo.repo,
               body: `
-            ## Team USA PR Checklist:
+            ## PR Checklist:
             
             **Did you use a semver keyword in a commit message?**
             - [ ] Yes I used one in at least one of my commits
-            - [ ] No but I use a semver keyword in the commit message when I merge and squash
+            - [ ] No but I will use a semver keyword in the commit message when I merge and squash
             
             **Did you paste the Rally US URL in the description?**
             - [ ] Yes

--- a/.github/workflows/prchecklist.yml
+++ b/.github/workflows/prchecklist.yml
@@ -1,0 +1,31 @@
+name: PR Checklist
+on:
+  pull_request:
+    types: [opened]
+jobs:
+  fyi:
+    name: Posts a PR checklist
+    runs-on: [self-hosted, Lms, Linux]
+    timeout-minutes: 2
+    steps:
+      - uses: Brightspace/third-party-actions@actions/github-script
+        # Do this at the step level so that the job shows as passing in the PR
+        # UI (which is less distracting than cancelled)
+        with:
+          script: |
+            github.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `
+            ## Team USA PR Checklist:
+            
+            **Did you use a semver keyword in a commit message?**
+            - [ ] Yes I used one in at least one of my commits
+            - [ ] No but I use a semver keyword in the commit message when I merge and squash
+            
+            **Did you paste the Rally US URL in the description?**
+            - [ ] Yes
+            - [ ] No as there's no corresponding Rally US
+              `
+            })


### PR DESCRIPTION
### Based off the Team USA PR checklist from the LMS repo

Feedback welcomed! Not sure if we should keep this as an opt-in and add some `if` logic to only target interested parties

**Current reminders:**

- Semver keywords in commit message

- Rally US URL if applicable