### PR TITLE
Add web-link definition to siren-sdk

### DIFF
--- a/src/activities/content/ContentEntity.js
+++ b/src/activities/content/ContentEntity.js
@@ -3,7 +3,8 @@ import { Rels } from '../../hypermedia-constants';
 
 export const CONTENT_TYPES = {
 	module: 'module',
-	topic: 'topic'
+	topic: 'topic',
+	weblink: 'weblink'
 };
 
 /**
@@ -12,17 +13,19 @@ export const CONTENT_TYPES = {
 export class ContentEntity extends Entity {
 
 	/**
-	 * @returns {string} content-module link
+	 * @returns {string} content type
 	 */
 	getEntityType() {
 		// TODO - add more specific entity types to the activity-usage class array
-		// once we start working on non-module content types
+		// as we start working on new content types
 		if (!this._entity) {
 			return null;
 		} else if (this._entity.hasClass(CONTENT_TYPES.module)) {
 			return CONTENT_TYPES.module;
 		} else if (this._entity.hasClass(CONTENT_TYPES.topic)) {
 			return CONTENT_TYPES.topic;
+		}  else if (this._entity.hasClass(CONTENT_TYPES.weblink)) {
+			return CONTENT_TYPES.weblink;
 		} else {
 			return null;
 		}
@@ -35,5 +38,14 @@ export class ContentEntity extends Entity {
 		return this._entity
 			&& this._entity.hasLinkByRel(Rels.Content.moduleEntity)
 			&& this._entity.getLinkByRel(Rels.Content.moduleEntity).href;
+	}
+
+	/**
+	 * @returns {string} content-weblink link
+	 */
+	getWebLinkHref() {
+		return this._entity
+			&& this._entity.hasLinkByRel(Rels.Content.weblinkEntity)
+			&& this._entity.getLinkByRel(Rels.Content.weblinkEntity).href;
 	}
 }

--- a/src/activities/content/ContentEntity.js
+++ b/src/activities/content/ContentEntity.js
@@ -22,10 +22,10 @@ export class ContentEntity extends Entity {
 			return null;
 		} else if (this._entity.hasClass(CONTENT_TYPES.module)) {
 			return CONTENT_TYPES.module;
+		} else if (this._entity.hasClass(CONTENT_TYPES.weblink)) {
+			return CONTENT_TYPES.weblink;
 		} else if (this._entity.hasClass(CONTENT_TYPES.topic)) {
 			return CONTENT_TYPES.topic;
-		}  else if (this._entity.hasClass(CONTENT_TYPES.weblink)) {
-			return CONTENT_TYPES.weblink;
 		} else {
 			return null;
 		}

--- a/src/activities/content/ContentEntity.js
+++ b/src/activities/content/ContentEntity.js
@@ -1,5 +1,6 @@
 import { Entity } from '../../es6/Entity';
 import { Rels } from '../../hypermedia-constants';
+import ContentHelperFunctions from './ContentHelperFunctions.js';
 
 export const CONTENT_TYPES = {
 	module: 'module',
@@ -20,9 +21,9 @@ export class ContentEntity extends Entity {
 		// as we start working on new content types
 		if (!this._entity) {
 			return null;
-		} else if (this._entity.hasClass(CONTENT_TYPES.module)) {
+		} else if (this._entity.hasLinkByRel(Rels.Content.moduleEntity)) {
 			return CONTENT_TYPES.module;
-		} else if (this._entity.hasClass(CONTENT_TYPES.weblink)) {
+		} else if (this._entity.hasLinkByRel(Rels.Content.weblinkEntity)) {
 			return CONTENT_TYPES.weblink;
 		} else if (this._entity.hasClass(CONTENT_TYPES.topic)) {
 			return CONTENT_TYPES.topic;
@@ -35,17 +36,13 @@ export class ContentEntity extends Entity {
 	 * @returns {string} content-module link
 	 */
 	getModuleHref() {
-		return this._entity
-			&& this._entity.hasLinkByRel(Rels.Content.moduleEntity)
-			&& this._entity.getLinkByRel(Rels.Content.moduleEntity).href;
+		return ContentHelperFunctions.getHrefFromRel(Rels.Content.moduleEntity, this._entity);
 	}
 
 	/**
 	 * @returns {string} content-weblink link
 	 */
 	getWebLinkHref() {
-		return this._entity
-			&& this._entity.hasLinkByRel(Rels.Content.weblinkEntity)
-			&& this._entity.getLinkByRel(Rels.Content.weblinkEntity).href;
+		return ContentHelperFunctions.getHrefFromRel(Rels.Content.weblinkEntity, this._entity);
 	}
 }

--- a/src/activities/content/ContentEntity.js
+++ b/src/activities/content/ContentEntity.js
@@ -14,7 +14,7 @@ export const CONTENT_TYPES = {
 export class ContentEntity extends Entity {
 
 	/**
-	 * @returns {string} content type
+	 * @returns {string|null} content type
 	 */
 	getEntityType() {
 		// TODO - add more specific entity types to the activity-usage class array

--- a/src/activities/content/ContentHelperFunctions.js
+++ b/src/activities/content/ContentHelperFunctions.js
@@ -1,0 +1,18 @@
+import { Classes } from '../../hypermedia-constants';
+
+const ContentHelperFunctions = {
+	getHrefFromRel: (rel, entity) => {
+		return entity
+			&& entity.hasLinkByRel(rel)
+			&& entity.getLinkByRel(rel).href;
+	},
+	getDescriptionSubEntity: (entity) => {
+		const [subEntity] = entity.getSubEntitiesByClass(Classes.content.description);
+		if (!subEntity || !subEntity.properties) {
+			return null;
+		}
+		return subEntity;
+	}
+};
+
+export default ContentHelperFunctions;

--- a/src/activities/content/ContentModuleEntity.js
+++ b/src/activities/content/ContentModuleEntity.js
@@ -1,6 +1,7 @@
 import { Entity } from '../../es6/Entity';
-import { Actions, Classes } from '../../hypermedia-constants';
+import { Actions } from '../../hypermedia-constants';
 import { performSirenAction } from '../../es6/SirenAction';
+import ContentHelperFunctions from './ContentHelperFunctions.js';
 
 /**
  * ContentModuleEntity class representation of a d2l content-module entity.
@@ -11,28 +12,22 @@ export class ContentModuleEntity extends Entity {
 	 * @returns {string} Description html of the content-module item
 	 */
 	descriptionRichText() {
-		if (!this._entity) {
+		const descriptionSubEntity = ContentHelperFunctions.getDescriptionSubEntity(this._entity);
+		if (!descriptionSubEntity) {
 			return null;
 		}
-		const subEntity = this._entity.getSubEntitiesByClass(Classes.content.description)[0];
-		if (!subEntity || !subEntity.properties) {
-			return null;
-		}
-		return subEntity.properties.html || '';
+		return descriptionSubEntity.properties.html || '';
 	}
 
 	/**
 	 * @returns {string} Description text of the content-module item
 	 */
 	descriptionText() {
-		if (!this._entity) {
+		const descriptionSubEntity = ContentHelperFunctions.getDescriptionSubEntity(this._entity);
+		if (!descriptionSubEntity) {
 			return null;
 		}
-		const subEntity = this._entity.getSubEntitiesByClass(Classes.content.description)[0];
-		if (!subEntity || !subEntity.properties) {
-			return null;
-		}
-		return subEntity.properties.text || '';
+		return descriptionSubEntity.properties.text || '';
 	}
 
 	/**
@@ -83,7 +78,7 @@ export class ContentModuleEntity extends Entity {
 		if (!this._entity) {
 			return;
 		}
-		const action = this._entity.getActionByName(Actions.content.deleteModule);
+		const action = this._entity.getActionByName(Actions.module.deleteModule);
 		if (!action) {
 			return;
 		}

--- a/src/activities/content/ContentModuleEntity.js
+++ b/src/activities/content/ContentModuleEntity.js
@@ -9,7 +9,7 @@ import ContentHelperFunctions from './ContentHelperFunctions.js';
 export class ContentModuleEntity extends Entity {
 
 	/**
-	 * @returns {string} Description html of the content-module item
+	 * @returns {string|null} Description html of the content-module item
 	 */
 	descriptionRichText() {
 		const descriptionSubEntity = ContentHelperFunctions.getDescriptionSubEntity(this._entity);
@@ -20,7 +20,7 @@ export class ContentModuleEntity extends Entity {
 	}
 
 	/**
-	 * @returns {string} Description text of the content-module item
+	 * @returns {string|null} Description text of the content-module item
 	 */
 	descriptionText() {
 		const descriptionSubEntity = ContentHelperFunctions.getDescriptionSubEntity(this._entity);
@@ -39,7 +39,7 @@ export class ContentModuleEntity extends Entity {
 
 	/**
 	 * Updates the module to have the given description
-	 * @param {string} title rich text description to set on the module
+	 * @param {string} richText description to set on the module
 	 */
 	async setModuleDescription(richText) {
 		if (!this._entity) {

--- a/src/activities/content/ContentWebLinkEntity.js
+++ b/src/activities/content/ContentWebLinkEntity.js
@@ -106,7 +106,7 @@ export class ContentWebLinkEntity extends Entity {
 			return;
 		}
 
-		const fields = [{ url: 'url', value: url }];
+		const fields = [{ name: 'url', value: url }];
 		await performSirenAction(this._token, action, fields);
 	}
 
@@ -123,7 +123,7 @@ export class ContentWebLinkEntity extends Entity {
 			return;
 		}
 
-		const fields = [{ isExternalResource: 'isExternalResource', value: isExternalResource }];
+		const fields = [{ name: 'isExternalResource', value: isExternalResource }];
 		await performSirenAction(this._token, action, fields);
 	}
 
@@ -149,8 +149,8 @@ export class ContentWebLinkEntity extends Entity {
 	 */
 	equals(contentWebLink) {
 		const diffs = [
-			[this.title(), contentModule.title],
-			[this.descriptionRichText(), contentModule.descriptionRichText],
+			[this.title(), contentWebLink.title],
+			[this.descriptionRichText(), contentWebLink.descriptionRichText],
 			[this.url(), contentWebLink.url],
 			[this.isExternalResource(), contentWebLink.isExternalResource]
 		];

--- a/src/activities/content/ContentWebLinkEntity.js
+++ b/src/activities/content/ContentWebLinkEntity.js
@@ -1,0 +1,164 @@
+import { Entity } from '../../es6/Entity';
+import { Actions, Classes } from '../../hypermedia-constants';
+import { performSirenAction } from '../../es6/SirenAction';
+
+/**
+ * ContentWebLinkEntity class representation of a d2l content-weblink entity.
+ */
+export class ContentWebLinkEntity extends Entity {
+
+	/**
+	 * @returns {string} Description html of the content-weblink item
+	 */
+	descriptionRichText() {
+		if (!this._entity) {
+			return null;
+		}
+		const subEntity = this._entity.getSubEntitiesByClass(Classes.content.description)[0];
+		if (!subEntity || !subEntity.properties) {
+			return null;
+		}
+		return subEntity.properties.html || '';
+	}
+
+	/**
+	 * @returns {string} Description text of the content-weblink item
+	 */
+	descriptionText() {
+		if (!this._entity) {
+			return null;
+		}
+		const subEntity = this._entity.getSubEntitiesByClass(Classes.content.description)[0];
+		if (!subEntity || !subEntity.properties) {
+			return null;
+		}
+		return subEntity.properties.text || '';
+	}
+
+	/**
+	 * @returns {boolean} external resource value (i.e. open in new tab or not)
+	 */
+	isExternalResource() {
+		if (!this._entity) {
+			return null;
+		}
+		return this._entity.hasClass(Classes.content.externalResource);
+	}
+
+	/**
+	 * @returns {string} Title of the content-weblink item
+	 */
+	title() {
+		return this._entity && this._entity.properties && this._entity.properties.title;
+	}
+
+	/**
+	 * @returns {string} Url of the content-weblink item
+	 */
+	url() {
+		return this._entity && this._entity.properties && this._entity.properties.url;
+	}
+
+	/**
+	 * Updates the web link to have the given description
+	 * @param {string} title rich text description to set on the web link
+	 */
+	async setWebLinkDescription(richText) {
+		if (!this._entity) {
+			return;
+		}
+		const action = this._entity.getActionByName(Actions.content.updateDescription);
+		if (!action) {
+			return;
+		}
+
+		const fields = [{ name: 'description', value: richText }];
+		await performSirenAction(this._token, action, fields);
+	}
+
+	/**
+	 * Updates the web link to have the given title
+	 * @param {string} title Title to set on the web link
+	 */
+	async setWebLinkTitle(title) {
+		if (!this._entity) {
+			return;
+		}
+		const action = this._entity.getActionByName(Actions.content.updateTitle);
+		if (!action) {
+			return;
+		}
+
+		const fields = [{ name: 'title', value: title }];
+		await performSirenAction(this._token, action, fields);
+	}
+
+	/**
+	 * Updates the web link to have the given url
+	 * @param {string} url Url to set on the web link
+	 */
+	async setWebLinkUrl(url) {
+		if (!this._entity) {
+			return;
+		}
+		const action = this._entity.getActionByName(Actions.content.updateUrl);
+		if (!action) {
+			return;
+		}
+
+		const fields = [{ url: 'url', value: url }];
+		await performSirenAction(this._token, action, fields);
+	}
+
+	/**
+	 * Updates the web link to have the given external resource value
+	 * @param {boolean} isExternalResource boolean value that represents external resource status
+	 */
+	async setWebLinkExternalResource(isExternalResource) {
+		if (!this._entity) {
+			return;
+		}
+		const action = this._entity.getActionByName(Actions.content.updateExternalResource);
+		if (!action) {
+			return;
+		}
+
+		const fields = [{ isExternalResource: 'isExternalResource', value: isExternalResource }];
+		await performSirenAction(this._token, action, fields);
+	}
+
+	/**
+	 * Deletes the web link
+	 */
+	async deleteWebLink() {
+		if (!this._entity) {
+			return;
+		}
+		const action = this._entity.getActionByName(Actions.content.deleteWeblink);
+		if (!action) {
+			return;
+		}
+
+		await performSirenAction(this._token, action);
+		this.dispose();
+	}
+
+	/**
+	 * Checks if content web link properties passed in match what is currently stored
+	 * @param {object} contentWebLink Object containing web link specific properties
+	 */
+	equals(contentWebLink) {
+		const diffs = [
+			[this.title(), contentModule.title],
+			[this.descriptionRichText(), contentModule.descriptionRichText],
+			[this.url(), contentWebLink.url],
+			[this.isExternalResource(), contentWebLink.isExternalResource]
+		];
+		for (const [left, right] of diffs) {
+			if (left !== right) {
+				return false;
+			}
+		}
+		return true;
+	}
+}

--- a/src/activities/content/ContentWebLinkEntity.js
+++ b/src/activities/content/ContentWebLinkEntity.js
@@ -145,7 +145,6 @@ export class ContentWebLinkEntity extends Entity {
 	equals(contentWebLink) {
 		const diffs = [
 			[this.title(), contentWebLink.title],
-			[this.descriptionRichText(), contentWebLink.descriptionRichText],
 			[this.url(), contentWebLink.url],
 			[this.isExternalResource(), contentWebLink.isExternalResource]
 		];

--- a/src/activities/content/ContentWebLinkEntity.js
+++ b/src/activities/content/ContentWebLinkEntity.js
@@ -9,7 +9,7 @@ import ContentHelperFunctions from './ContentHelperFunctions.js';
 export class ContentWebLinkEntity extends Entity {
 
 	/**
-	 * @returns {string} Description html of the content-weblink item
+	 * @returns {string|null} Description html of the content-weblink item
 	 */
 	descriptionRichText() {
 		const descriptionSubEntity = ContentHelperFunctions.getDescriptionSubEntity(this._entity);
@@ -20,7 +20,7 @@ export class ContentWebLinkEntity extends Entity {
 	}
 
 	/**
-	 * @returns {string} Description text of the content-weblink item
+	 * @returns {string|null} Description text of the content-weblink item
 	 */
 	descriptionText() {
 		const descriptionSubEntity = ContentHelperFunctions.getDescriptionSubEntity(this._entity);

--- a/src/activities/content/ContentWebLinkEntity.js
+++ b/src/activities/content/ContentWebLinkEntity.js
@@ -1,6 +1,7 @@
 import { Entity } from '../../es6/Entity';
 import { Actions, Classes } from '../../hypermedia-constants';
 import { performSirenAction } from '../../es6/SirenAction';
+import ContentHelperFunctions from './ContentHelperFunctions.js';
 
 /**
  * ContentWebLinkEntity class representation of a d2l content-weblink entity.
@@ -11,28 +12,22 @@ export class ContentWebLinkEntity extends Entity {
 	 * @returns {string} Description html of the content-weblink item
 	 */
 	descriptionRichText() {
-		if (!this._entity) {
+		const descriptionSubEntity = ContentHelperFunctions.getDescriptionSubEntity(this._entity);
+		if (!descriptionSubEntity) {
 			return null;
 		}
-		const subEntity = this._entity.getSubEntitiesByClass(Classes.content.description)[0];
-		if (!subEntity || !subEntity.properties) {
-			return null;
-		}
-		return subEntity.properties.html || '';
+		return descriptionSubEntity.properties.html || '';
 	}
 
 	/**
 	 * @returns {string} Description text of the content-weblink item
 	 */
 	descriptionText() {
-		if (!this._entity) {
+		const descriptionSubEntity = ContentHelperFunctions.getDescriptionSubEntity(this._entity);
+		if (!descriptionSubEntity) {
 			return null;
 		}
-		const subEntity = this._entity.getSubEntitiesByClass(Classes.content.description)[0];
-		if (!subEntity || !subEntity.properties) {
-			return null;
-		}
-		return subEntity.properties.text || '';
+		return descriptionSubEntity.properties.text || '';
 	}
 
 	/**
@@ -40,9 +35,9 @@ export class ContentWebLinkEntity extends Entity {
 	 */
 	isExternalResource() {
 		if (!this._entity) {
-			return null;
+			return false;
 		}
-		return this._entity.hasClass(Classes.content.externalResource);
+		return this._entity.hasClass(Classes.webLink.externalResource);
 	}
 
 	/**
@@ -61,7 +56,7 @@ export class ContentWebLinkEntity extends Entity {
 
 	/**
 	 * Updates the web link to have the given description
-	 * @param {string} title rich text description to set on the web link
+	 * @param {string} richText rich text description to set on the web link
 	 */
 	async setWebLinkDescription(richText) {
 		if (!this._entity) {
@@ -101,7 +96,7 @@ export class ContentWebLinkEntity extends Entity {
 		if (!this._entity) {
 			return;
 		}
-		const action = this._entity.getActionByName(Actions.content.updateUrl);
+		const action = this._entity.getActionByName(Actions.webLink.updateUrl);
 		if (!action) {
 			return;
 		}
@@ -118,7 +113,7 @@ export class ContentWebLinkEntity extends Entity {
 		if (!this._entity) {
 			return;
 		}
-		const action = this._entity.getActionByName(Actions.content.updateExternalResource);
+		const action = this._entity.getActionByName(Actions.webLink.updateExternalResource);
 		if (!action) {
 			return;
 		}
@@ -134,7 +129,7 @@ export class ContentWebLinkEntity extends Entity {
 		if (!this._entity) {
 			return;
 		}
-		const action = this._entity.getActionByName(Actions.content.deleteWeblink);
+		const action = this._entity.getActionByName(Actions.webLink.deleteWeblink);
 		if (!action) {
 			return;
 		}

--- a/src/hypermedia-constants.js
+++ b/src/hypermedia-constants.js
@@ -276,10 +276,9 @@ export const Classes = {
 	content: {
 		content: 'content',
 		sequencedActivity: 'sequenced-activity',
-		topic: 'topic',
-		module: 'module',
-		description: 'description',
-		weblink: 'weblink',
+		description: 'description'
+	},
+	webLink: {
 		externalResource: 'external-resource'
 	},
 	courseImage: {
@@ -468,9 +467,13 @@ export const Actions = {
 	content: {
 		updateTitle: 'update-title',
 		updateDescription: 'update-description',
+	},
+	module: {
+		deleteModule: 'delete-module'
+	},
+	webLink: {
 		updateUrl: 'update-url',
 		updateExternalResource: 'update-external-resource',
-		deleteModule: 'delete-module',
 		deleteWeblink: 'delete-webLink'
 	},
 	notifications: {

--- a/src/hypermedia-constants.js
+++ b/src/hypermedia-constants.js
@@ -104,7 +104,8 @@ export const Rels = {
 		checklistItem: 'https://checklists.api.brightspace.com/rels/checklist-item'
 	},
 	Content: {
-		moduleEntity: 'https://modules.api.brightspace.com/rels/content-module'
+		moduleEntity: 'https://modules.api.brightspace.com/rels/content-module',
+		weblinkEntity: 'https://weblinks.api.brightspace.com/rels/content-weblink'
 	},
 	// Parents API sub-domain rels
 	Parents: {
@@ -277,7 +278,9 @@ export const Classes = {
 		sequencedActivity: 'sequenced-activity',
 		topic: 'topic',
 		module: 'module',
-		description: 'description'
+		description: 'description',
+		weblink: 'weblink',
+		externalResource: 'external-resource'
 	},
 	courseImage: {
 		courseImage: 'course-image',
@@ -465,7 +468,10 @@ export const Actions = {
 	content: {
 		updateTitle: 'update-title',
 		updateDescription: 'update-description',
-		deleteModule: 'delete-module'
+		updateUrl: 'update-url',
+		updateExternalResource: 'update-external-resource',
+		deleteModule: 'delete-module',
+		deleteWeblink: 'delete-webLink'
 	},
 	notifications: {
 		getCarrierClass: 'get-carrier',

--- a/test/activities/content/ContentEntity.js
+++ b/test/activities/content/ContentEntity.js
@@ -1,20 +1,38 @@
 import { ContentEntity, CONTENT_TYPES } from '../../../src/activities/content/ContentEntity.js';
-import { contentEntityData } from './data/TestContentEntity.js';
+import { contentModuleEntityData, contentWebLinkEntityData } from './data/TestContentEntity.js';
 
-describe('ContentEntity', () => {
+describe('Module ContentEntity', () => {
 	let contentData;
 	let contentEntity;
 
 	beforeEach(() => {
-		contentData = window.D2L.Hypermedia.Siren.Parse(contentEntityData);
+		contentData = window.D2L.Hypermedia.Siren.Parse(contentModuleEntityData);
 		contentEntity = new ContentEntity(contentData);
 	});
 
-	it('gets entity type', () => {
+	it('gets module entity type', () => {
 		expect(contentEntity.getEntityType()).to.equal(CONTENT_TYPES.module);
 	});
 
 	it('gets content-module href', () => {
 		expect(contentEntity.getModuleHref()).to.equal('https://fake-tenant-id.modules.api.proddev.d2l/6613/modules/12345');
+	});
+});
+
+describe('Web Link ContentEntity', () => {
+	let contentData;
+	let contentEntity;
+
+	beforeEach(() => {
+		contentData = window.D2L.Hypermedia.Siren.Parse(contentWebLinkEntityData);
+		contentEntity = new ContentEntity(contentData);
+	});
+
+	it('gets web link entity type', () => {
+		expect(contentEntity.getEntityType()).to.equal(CONTENT_TYPES.weblink);
+	});
+
+	it('gets content-weblink href', () => {
+		expect(contentEntity.getWebLinkHref()).to.equal('https://fake-tenant-id.weblinks.api.proddev.d2l/6613/weblinks/12345');
 	});
 });

--- a/test/activities/content/ContentWebLinkEntity.html
+++ b/test/activities/content/ContentWebLinkEntity.html
@@ -1,0 +1,17 @@
+<html>
+	<head>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
+		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
+		<script src="/node_modules/mocha/mocha.js"></script>
+		<script src="/node_modules/chai/chai.js"></script>
+		<script src="/node_modules/@polymer/test-fixture/test-fixture.js"></script>
+		<script src="/node_modules/wct-mocha/wct-mocha.js"></script>
+		<script src="/node_modules/sinon/pkg/sinon.js"></script>
+		<script type="module" src="/node_modules/fetch-mock/es5/client-bundle.js"></script>
+		<script type="module" src="../../../../siren-parser/global.js"></script>
+	</head>
+	<body>
+		<script type="module" src="./ContentWebLinkEntity.js"></script>
+	</body>
+</html>

--- a/test/activities/content/ContentWebLinkEntity.js
+++ b/test/activities/content/ContentWebLinkEntity.js
@@ -1,0 +1,148 @@
+/* global fetchMock */
+import { ContentWebLinkEntity } from '../../../src/activities/content/ContentWebLinkEntity.js';
+import { contentWebLinkData } from './data/TestContentWebLinkEntity.js';
+import { getFormData } from '../../utility/test-helpers.js';
+
+describe('ContentModuleEntity', () => {
+	let webLinkData;
+	let contentWebLinkEntity;
+
+	beforeEach(() => {
+		webLinkData = window.D2L.Hypermedia.Siren.Parse(contentWebLinkData);
+		contentWebLinkEntity = new ContentWebLinkEntity(webLinkData);
+	});
+
+	afterEach(() => {
+		fetchMock.reset();
+	});
+
+	describe('Reads properties', () => {
+		it('reads title', () => {
+			expect(contentWebLinkEntity.title()).to.equal('Test Web Link Title');
+		});
+
+		it('reads rich text description', () => {
+			expect(contentWebLinkEntity.descriptionRichText()).to.equal('<p>description text</p>');
+		});
+
+		it('reads text description', () => {
+			expect(contentWebLinkEntity.descriptionText()).to.equal('description text');
+		});
+
+		it('reads url', () => {
+			expect(contentWebLinkEntity.url()).to.equal('https://phoenix-is-the-best.com');
+		});
+
+		it('reads isExternalResources', () => {
+			expect(contentWebLinkEntity.isExternalResource()).to.equal(true);
+		});
+	});
+
+	describe('Equality tests', () => {
+		it('Equality should return true when details match', () => {
+			const webLinkData = {
+				title: 'Test Web Link Title',
+				descriptionRichText: '<p>description text</p>',
+				url: 'https://phoenix-is-the-best.com',
+				isExternalResource: true
+			};
+			expect(contentWebLinkEntity.equals(webLinkData)).to.equal(true);
+		});
+
+		it('Equality should return false when title is different', () => {
+			const webLinkData = {
+				title: 'New Title',
+				descriptionRichText: '<p>description text</p>',
+				url: 'https://phoenix-is-the-best.com',
+				isExternalResource: true
+			};
+			expect(contentWebLinkEntity.equals(webLinkData)).to.equal(false);
+		});
+
+		it('Equality should return false when description is different', () => {
+			const webLinkData = {
+				title: 'New Title',
+				descriptionRichText: '<p>New description text</p>',
+				url: 'https://phoenix-is-the-best.com',
+				isExternalResource: true
+			};
+			expect(contentWebLinkEntity.equals(webLinkData)).to.equal(false);
+		});
+
+		it('Equality should return false when url is different', () => {
+			const webLinkData = {
+				title: 'New Title',
+				descriptionRichText: '<p>New description text</p>',
+				url: 'https://phoenix-is-the-very-best.com',
+				isExternalResource: true
+			};
+			expect(contentWebLinkEntity.equals(webLinkData)).to.equal(false);
+		});
+
+		it('Equality should return false when isExternalResource is different', () => {
+			const webLinkData = {
+				title: 'New Title',
+				descriptionRichText: '<p>New description text</p>',
+				url: 'https://phoenix-is-the-very-best.com',
+				isExternalResource: false
+			};
+			expect(contentWebLinkEntity.equals(webLinkData)).to.equal(false);
+		});
+	});
+
+	describe('Actions', () => {
+		it('saves title', async() => {
+			fetchMock.patchOnce('https://fake-tenant-id.weblinks.api.proddev.d2l/6613/weblinks/12345', webLinkData);
+
+			await contentWebLinkEntity.setWebLinkTitle('New Title');
+
+			const form = await getFormData(fetchMock.lastCall().request);
+			if (!form.notSupported) {
+				expect(form.get('title')).to.equal('New Title');
+			}
+			expect(fetchMock.called()).to.be.true;
+		});
+
+		it('saves description', async() => {
+			fetchMock.patchOnce('https://fake-tenant-id.weblinks.api.proddev.d2l/6613/weblinks/12345', webLinkData);
+
+			await contentWebLinkEntity.setWebLinkDescription('<p>New description</p>');
+
+			const form = await getFormData(fetchMock.lastCall().request);
+			if (!form.notSupported) {
+				expect(form.get('description')).to.equal('<p>New description</p>');
+			}
+			expect(fetchMock.called()).to.be.true;
+		});
+
+		it('saves url', async() => {
+			fetchMock.patchOnce('https://fake-tenant-id.weblinks.api.proddev.d2l/6613/weblinks/12345', webLinkData);
+
+			await contentWebLinkEntity.setWebLinkUrl('https://phoenix-is-the-very-best.com');
+
+			const form = await getFormData(fetchMock.lastCall().request);
+			if (!form.notSupported) {
+				expect(form.get('url')).to.equal('https://phoenix-is-the-very-best.com');
+			}
+			expect(fetchMock.called()).to.be.true;
+		});
+
+		it('saves isExternalResource', async() => {
+			fetchMock.putOnce('https://fake-tenant-id.weblinks.api.proddev.d2l/6613/weblinks/12345/external', webLinkData);
+
+			await contentWebLinkEntity.setWebLinkExternalResource(false);
+
+			const form = await getFormData(fetchMock.lastCall().request);
+			if (!form.notSupported) {
+				expect(form.get('isExternalResource')).to.equal('false');
+			}
+			expect(fetchMock.called()).to.be.true;
+		});
+
+		it('performs delete request', async() => {
+			fetchMock.deleteOnce('https://fake-tenant-id.weblinks.api.proddev.d2l/6613/weblinks/12345', webLinkData);
+			await contentWebLinkEntity.deleteWebLink();
+			expect(fetchMock.called()).to.be.true;
+		});
+	});
+});

--- a/test/activities/content/ContentWebLinkEntity.js
+++ b/test/activities/content/ContentWebLinkEntity.js
@@ -3,7 +3,7 @@ import { ContentWebLinkEntity } from '../../../src/activities/content/ContentWeb
 import { contentWebLinkData } from './data/TestContentWebLinkEntity.js';
 import { getFormData } from '../../utility/test-helpers.js';
 
-describe('ContentModuleEntity', () => {
+describe('ContentWebLinkEntity', () => {
 	let webLinkData;
 	let contentWebLinkEntity;
 

--- a/test/activities/content/data/TestContentEntity.js
+++ b/test/activities/content/data/TestContentEntity.js
@@ -1,4 +1,4 @@
-export const contentEntityData = {
+export const contentModuleEntityData = {
 	'class': [
 		'activity-usage',
 		'content-activity',
@@ -10,8 +10,24 @@ export const contentEntityData = {
 	'links': [{
 		'href': 'https://fake-tenant-id.modules.api.proddev.d2l/6613/modules/12345',
 		'rel': ['https://modules.api.brightspace.com/rels/content-module']
-	}
+	}],
+	'entities': [],
+	'rel': []
+};
+
+export const contentWebLinkEntityData = {
+	'class': [
+		'activity-usage',
+		'content-activity',
+		'weblink'
 	],
+	'properties': {
+		'title': 'Test Web Link Title'
+	},
+	'links': [{
+		'href': 'https://fake-tenant-id.weblinks.api.proddev.d2l/6613/weblinks/12345',
+		'rel': ['https://weblinks.api.brightspace.com/rels/content-weblink']
+	}],
 	'entities': [],
 	'rel': []
 };

--- a/test/activities/content/data/TestContentWebLinkEntity.js
+++ b/test/activities/content/data/TestContentWebLinkEntity.js
@@ -53,7 +53,7 @@ export const contentWebLinkData = {
 		},
 		{
 			'href': 'https://fake-tenant-id.weblinks.api.proddev.d2l/6613/weblinks/12345',
-			'name': 'delete-weblink',
+			'name': 'delete-webLink',
 			'method': 'DELETE'
 		}
 	],

--- a/test/activities/content/data/TestContentWebLinkEntity.js
+++ b/test/activities/content/data/TestContentWebLinkEntity.js
@@ -59,7 +59,7 @@ export const contentWebLinkData = {
 	],
 	'class': [
 		'describable-entity',
-		'weblink',
+		'topic',
 		'external-resource'
 	],
 	'properties': {

--- a/test/activities/content/data/TestContentWebLinkEntity.js
+++ b/test/activities/content/data/TestContentWebLinkEntity.js
@@ -1,0 +1,75 @@
+export const contentWebLinkData = {
+	'actions': [
+		{
+			'href': 'https://fake-tenant-id.weblinks.api.proddev.d2l/6613/weblinks/12345',
+			'name': 'update-title',
+			'method': 'PATCH',
+			'fields': [
+				{
+					'class': ['required'],
+					'type': 'text',
+					'name': 'title',
+					'value': 'Test Web Link Title'
+				}
+			]
+		},
+		{
+			'href': 'https://fake-tenant-id.weblinks.api.proddev.d2l/6613/weblinks/12345',
+			'name': 'update-description',
+			'method': 'PATCH',
+			'fields': [
+				{
+					'class': ['required'],
+					'type': 'text',
+					'name': 'description',
+					'value': '<p>description text</p>'
+				}
+			]
+		},
+		{
+			'href': 'https://fake-tenant-id.weblinks.api.proddev.d2l/6613/weblinks/12345',
+			'name': 'update-url',
+			'method': 'PATCH',
+			'fields': [
+				{
+					'class': ['required'],
+					'type': 'text',
+					'name': 'url',
+					'value': 'https://phoenix-is-the-best.com'
+				}
+			]
+		},
+		{
+			'href': 'https://fake-tenant-id.weblinks.api.proddev.d2l/6613/weblinks/12345/external',
+			'name': 'update-external-resource',
+			'method': 'PUT',
+			'fields': [
+				{
+					'type': 'checkbox',
+					'name': 'isExternalResource',
+					'value': true
+				}
+			]
+		},
+		{
+			'href': 'https://fake-tenant-id.weblinks.api.proddev.d2l/6613/weblinks/12345',
+			'name': 'delete-weblink',
+			'method': 'DELETE'
+		}
+	],
+	'class': [
+		'describable-entity',
+		'weblink',
+		'external-resource'
+	],
+	'properties': {
+		'title': 'Test Web Link Title',
+		'url': 'https://phoenix-is-the-best.com'
+	},
+	'entities': [{
+		'class': ['richtext', 'description'],
+		'properties': {'text': 'description text', 'html': '<p>description text</p>'},
+		'rel': []
+	}],
+	'rel': []
+};

--- a/test/index.html
+++ b/test/index.html
@@ -32,6 +32,7 @@
 			'./helpers/StateTree.html',
 			'./activities/content/ContentEntity.html',
 			'./activities/content/ContentModuleEntity.html',
+			'./activities/content/ContentWebLinkEntity.html',
 			'./activities/assignments/AssignmentActivityUsageEntity.html',
 			'./activities/assignments/AssignmentEntity.html',
 			'./activities/quizzes/QuizEntity.html',


### PR DESCRIPTION
**NOTE:** I am on a new team starting on Jan 4th and would appreciate if someone could take over this PR for me. I'd be more than happy to help with clarification and add feedback where necessary but would be good if someone else could address the improvements/fixes necessary to get this merged.

Aligning siren-sdk with new work Dave Harris has added in the back-end [here](https://github.com/Brightspace/lms/pull/4949#event-4141743719). Adding all classes, properties and actions as defined so we can later access them in the activities repo.

Rally ticket: https://rally1.rallydev.com/#/289692574792d/custom/355050439968?detail=%2Fuserstory%2F463420383076