### PR TITLE
support create-form link

### DIFF
--- a/src/activities/ActivityUsageEntity.js
+++ b/src/activities/ActivityUsageEntity.js
@@ -139,6 +139,17 @@ export class ActivityUsageEntity extends Entity {
 		return this._entity.getLinkByRel(Rels.IANA.edit).href;
 	}
 
+	/**
+	 * @returns {string} URL to create the activity usage, if present
+	 */
+	createFormHref() {
+		if (!this._entity || !this._entity.hasLinkByRel(Rels.IANA.createForm)) {
+			return;
+		}
+
+		return this._entity.getLinkByRel(Rels.IANA.createForm).href;
+	}
+
 	competenciesHref() {
 		if (!this._entity || !this._entity.hasLinkByRel(Rels.Alignments.legacyCompetencies)) {
 			return;

--- a/src/hypermedia-constants.js
+++ b/src/hypermedia-constants.js
@@ -204,7 +204,8 @@ export const Rels = {
 	},
 	IANA: {
 		edit: 'edit',
-		preview: 'preview'
+		preview: 'preview',
+		createForm: 'create-form'
 	}
 };
 

--- a/test/activities/ActivityUsageEntity.js
+++ b/test/activities/ActivityUsageEntity.js
@@ -68,6 +68,16 @@ describe('ActivityUsageEntity', () => {
 		it('can get special access url', () => {
 			expect(entity.specialAccessHref()).to.equal('http://vlx1-mdulat.desire2learn.d2l:44444/d2l/api/hm/activities/activities/6606_2000_31/usages/6609/special-access');
 		});
+
+		it('can get create-form url', () => {
+			expect(entity.createFormHref()).to.equal('http://vlx1-mdulat.desire2learn.d2l:44444/d2l/api/hm/activities/activities/6606_2000_31/usages/6609?mode=creating');
+		});
+	});
+
+	describe('read only loading', () => {
+		it('create-form url returns blank', () => {
+			expect(readonlyEntity.createFormHref()).to.be.null;
+		});
 	});
 
 	describe('Functionality', () => {

--- a/test/activities/ActivityUsageEntity.js
+++ b/test/activities/ActivityUsageEntity.js
@@ -76,7 +76,7 @@ describe('ActivityUsageEntity', () => {
 
 	describe('read only loading', () => {
 		it('create-form url returns blank', () => {
-			expect(readonlyEntity.createFormHref()).to.be.null;
+			expect(readonlyEntity.createFormHref()).to.be.undefined;
 		});
 	});
 

--- a/test/activities/data/ActivityUsageEntity.js
+++ b/test/activities/data/ActivityUsageEntity.js
@@ -138,6 +138,13 @@ export const testData = {
 			},
 			{
 				'rel': [
+					'https://activities.api.brightspace.com/rels/activity-usage',
+					'create-form'
+				],
+				'href': 'http://vlx1-mdulat.desire2learn.d2l:44444/d2l/api/hm/activities/activities/6606_2000_31/usages/6609?mode=creating'
+			},
+			{
+				'rel': [
 					'https://activities.api.brightspace.com/rels/user-activity-usage',
 					'https://activities.api.brightspace.com/rels/my-activity-usage'
 				],


### PR DESCRIPTION
US122312

```Context```
Learning paths is adding a create-form link to redirect new activity usages to the different variation of the edit page. Siren-sdk activty entity needs to support the create-form rel.

https://rally1.rallydev.com/#/357252966636d/custom/367300408400?detail=%2Fuserstory%2F455165215100

```Quality```
Unit tests added to validate positive and negative response from createFormHref()
