### PR TITLE
Replacing <br> tags with '\n' in description

### DIFF
--- a/src/organizations/OrganizationEntity.js
+++ b/src/organizations/OrganizationEntity.js
@@ -123,7 +123,7 @@ export class OrganizationEntity extends Entity {
 	description() {
 		let description = this._entity && this._entity.properties && this._entity.properties.description;
 		if (description) {
-			description = description.replace(/<br\s*\/?>/gi, '\n');
+			description = description.replace(/<br\s*\/?>/gi, '\r\n');
 			description = description.replace(/<[^>]*>/g, '');
 		}
 		return description;

--- a/src/organizations/OrganizationEntity.js
+++ b/src/organizations/OrganizationEntity.js
@@ -123,6 +123,7 @@ export class OrganizationEntity extends Entity {
 	description() {
 		let description = this._entity && this._entity.properties && this._entity.properties.description;
 		if (description) {
+			description = description.replace(/<br\s*\/?>/gi,' ');
 			description = description.replace(/<[^>]*>/g, '');
 		}
 		return description;

--- a/src/organizations/OrganizationEntity.js
+++ b/src/organizations/OrganizationEntity.js
@@ -123,7 +123,7 @@ export class OrganizationEntity extends Entity {
 	description() {
 		let description = this._entity && this._entity.properties && this._entity.properties.description;
 		if (description) {
-			description = description.replace(/<br\s*\/?>/gi,' ');
+			description = description.replace(/<br\s*\/?>/gi,'\n');
 			description = description.replace(/<[^>]*>/g, '');
 		}
 		return description;

--- a/src/organizations/OrganizationEntity.js
+++ b/src/organizations/OrganizationEntity.js
@@ -123,7 +123,7 @@ export class OrganizationEntity extends Entity {
 	description() {
 		let description = this._entity && this._entity.properties && this._entity.properties.description;
 		if (description) {
-			description = description.replace(/<br\s*\/?>/gi,'\n');
+			description = description.replace(/<br\s*\/?>/gi, '\n');
 			description = description.replace(/<[^>]*>/g, '');
 		}
 		return description;


### PR DESCRIPTION
[Rally Defect Link - DE41781](https://rally1.rallydev.com/#/357252275780d/custom/367300408400?detail=%2Fdefect%2F465993045240&fdp=true)

When editing a course's description, pressing enter creates a new \<p> element, and separates the previous and new \<p> elements with a newline.

On the other hand, pressing shift+enter creates a new \<br /> element, which is sandwiched (i.e. no whitespace) between the previous and the next word.

Currently, HTML tags are stripped from the description by regex replace: `description.replace(/<[^>]*>/g, '');`. Once this happens, \<p> elements are removed but the newline is left behind to continue separating the previous and next paragraph. However, \<br> elements are removed without leaving behind any whitespace to separate words.

This was fixed by doing a regex replace that converts all \<br> elements into a '\n' first before other HTML tags are stripped.

Sample description: 
```
The quick brown fox

jumps over

the
lazy
dog
```

In HTML:
```
<p>The quick brown fox</p>
<p>jumps over</p>
<p>the<br />lazy<br />dog</p>
```

### Return value of description()
Before:
```
The quick brown fox
jumps over
thelazydog
```

After:
```
The quick brown fox
jumps over
the
lazy
dog
```

