### PR TITLE
fix: save empty quiz description

### DIFF
--- a/src/activities/quizzes/QuizEntity.js
+++ b/src/activities/quizzes/QuizEntity.js
@@ -527,7 +527,8 @@ export class QuizEntity extends Entity {
 	_formatUpdateDescriptionAction(quiz) {
 		const { description } = quiz || {};
 
-		if (!description) return;
+		if (typeof description === 'undefined') return;
+
 		if (!this._hasDescriptionChanged(description)) return;
 
 		const descriptionEntity = this._getDescriptionEntity();


### PR DESCRIPTION
Fixes https://trello.com/c/Bg8eQ5Xy/302-new-html-editor-cannot-clear-the-content-from-the-description-field
