### PR TITLE
Update ci.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 on: pull_request
 jobs:
   test:
-    timeout-minutes: 5
+    timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
       - uses: Brightspace/third-party-actions@actions/checkout


### PR DESCRIPTION
bump timeout to 10 minutes

I added a few more tests in my latest PR and CI was failing because `The job running on runner GitHub Actions 4 has exceeded the maximum execution time of 5 minutes.` Looking to increase the timeout time.