### PR TITLE
fix: set descriptionIsDisplayed to true on save even if there are no …

### DIFF
--- a/src/activities/quizzes/QuizEntity.js
+++ b/src/activities/quizzes/QuizEntity.js
@@ -537,7 +537,7 @@ export class QuizEntity extends Entity {
 
 		if (typeof description === 'undefined') return;
 
-		if (!this._hasDescriptionChanged(description)) return;
+		if (!this._hasDescriptionChanged(description) && this.descriptionIsDisplayed()) return;
 
 		const descriptionEntity = this._getDescriptionEntity();
 


### PR DESCRIPTION
…changes to quiz
https://trello.com/c/DnJCmzRK/308-description-visible-alert-does-not-go-away-after-save-in-place-or-save-close-with-no-changes

If descriptionIsDisplayed is false, we want to make sure the PATCH API is called on save so that it can update that value on the quiz entity, even if the user made no changes to the quiz.