### PR TITLE
US123360 - Update how automatic-zero is detected

### DIFF
--- a/src/activities/quizzes/timing/QuizTimingEntity.js
+++ b/src/activities/quizzes/timing/QuizTimingEntity.js
@@ -41,8 +41,10 @@ export class QuizTimingEntity extends Entity {
 		return field.value;
 	}
 
-	isTimingEnforced() {
-		return this.hasClass(Classes.quizzes.timing.enforced);
+	isTimingEnforced(data) {
+		const enforcedClass = Classes.quizzes.timing.enforced;
+		if (data) return data === enforcedClass;
+		return this.hasClass(enforcedClass);
 	}
 
 	submissionLateType() {
@@ -90,10 +92,12 @@ export class QuizTimingEntity extends Entity {
 		return field.value;
 	}
 
-	isAutomaticZero() {
+	isAutomaticZero(data) {
+		const automaticZeroClass = Classes.quizzes.timing.automaticZero;
+		if (data) return data === automaticZeroClass;
 		const entity = this.getEnforcedTimingSubEntity();
 		if (!entity) return;
-		return entity.hasClass(Classes.quizzes.timing.automaticZero);
+		return entity.hasClass(automaticZeroClass);
 	}
 
 	showClock() {

--- a/src/activities/quizzes/timing/QuizTimingEntity.js
+++ b/src/activities/quizzes/timing/QuizTimingEntity.js
@@ -93,7 +93,7 @@ export class QuizTimingEntity extends Entity {
 	isAutomaticZero() {
 		const entity = this.getEnforcedTimingSubEntity();
 		if (!entity) return;
-		return entity.hasSubEntityByClass(Classes.quizzes.timing.automaticZero);
+		return entity.hasClass(Classes.quizzes.timing.automaticZero);
 	}
 
 	showClock() {

--- a/test/activities/quizzes/timing/QuizTimingEntity.js
+++ b/test/activities/quizzes/timing/QuizTimingEntity.js
@@ -1,6 +1,7 @@
 import { recommendedQuizTiming, enforcedQuizTiming } from '../data/timing/EditableQuizTimingEntity';
 import { nonEditableRecommendedQuizTiming, nonEditableEnforcedQuizTiming } from '../data/timing/NonEditableQuizTimingEntity';
 import { QuizTimingEntity } from '../../../../src/activities/quizzes/timing/QuizTimingEntity.js';
+import { Classes } from '../../../../src/hypermedia-constants.js';
 
 describe('QuizTimingEntity', () => {
 	var enforcedTimingEntity, recommendedTimingEntity, nonEditableEnforcedTimingEntity, nonEditableRecommendedTimingEntity;
@@ -45,6 +46,14 @@ describe('QuizTimingEntity', () => {
 				expect(entity.isTimingEnforced()).to.be.false;
 				entity = new QuizTimingEntity(nonEditableRecommendedTimingEntity);
 				expect(entity.isTimingEnforced()).to.be.false;
+			});
+			it('returns true when passed a value matching enforced class', () => {
+				var entity = new QuizTimingEntity(recommendedTimingEntity);
+				expect(entity.isTimingEnforced(Classes.quizzes.timing.enforced)).to.be.true;
+			});
+			it('returns false when passed a value not matching enforced class', () => {
+				var entity = new QuizTimingEntity(enforcedTimingEntity);
+				expect(entity.isTimingEnforced('not an enforced class')).to.be.false;
 			});
 		});
 	});
@@ -162,6 +171,14 @@ describe('QuizTimingEntity', () => {
 			it('returns true extended deadline automatic zero is selected', () => {
 				var entity = new QuizTimingEntity(enforcedTimingEntity);
 				expect(entity.isAutomaticZero()).to.be.true;
+			});
+			it('returns true if passed value matching automatic zero class', () => {
+				var entity = new QuizTimingEntity(enforcedTimingEntity);
+				expect(entity.isAutomaticZero(Classes.quizzes.timing.automaticZero)).to.be.true;
+			});
+			it('returns false if passed value not matching automatic zero class', () => {
+				var entity = new QuizTimingEntity(enforcedTimingEntity);
+				expect(entity.isAutomaticZero('not true')).to.be.false;
 			});
 		});
 	});


### PR DESCRIPTION
With optimistic rendering, both enforced and recommended entities and this "uselatelimit/automaticzero" entity is always included. So we must determine whether to show it based on whether the enforced timing entity type has the class, rather than the presence of the sub-entity.

https://rally1.rallydev.com/#/29180338367d/iterationstatus?detail=%2Fuserstory%2F464625055264%2Ftasks