### PR TITLE
US123692 - changes to support working copy dirty check

### DIFF
--- a/src/activities/quizzes/QuizEntity.js
+++ b/src/activities/quizzes/QuizEntity.js
@@ -212,9 +212,10 @@ export class QuizEntity extends Entity {
 	 */
 	descriptionHtml() {
 		const descriptionEntity = this._getDescriptionEntity();
-		return descriptionEntity
-			&& descriptionEntity.properties
-			&& descriptionEntity.properties.html;
+		if (!descriptionEntity || !descriptionEntity.properties || !descriptionEntity.properties.html) {
+			return;
+		}
+		return descriptionEntity.properties.html;
 	}
 
 	/**
@@ -292,9 +293,10 @@ export class QuizEntity extends Entity {
 	 */
 	headerHtml() {
 		const headerEntity = this._getHeaderEntity();
-		return headerEntity
-			&& headerEntity.properties
-			&& headerEntity.properties.html;
+		if (!headerEntity || !headerEntity.properties || !headerEntity.properties.html) {
+			return;
+		}
+		return headerEntity.properties.html;
 	}
 
 	/**
@@ -776,7 +778,7 @@ export class QuizEntity extends Entity {
 		return this._entity && this._entity.hasActionByName(Actions.workingCopy.checkout);
 	}
 
-	_canCheckin() {
+	canCheckin() {
 		return this._entity && this._entity.hasActionByName(Actions.workingCopy.checkin);
 	}
 
@@ -796,7 +798,7 @@ export class QuizEntity extends Entity {
 	 * Checkin quiz working copy
 	 */
 	async checkin() {
-		if (this._canCheckin()) {
+		if (this.canCheckin()) {
 			const action = this.getActionByName(Actions.workingCopy.checkin);
 			const entity = await performSirenAction(this._token, action);
 			if (!entity) return;


### PR DESCRIPTION
The reason for changing the recently added `headerHtml` and `descriptionHtml` functions is that the functions return booleans instead of undefined. When a quiz entity which does not have these entities, such as a working copy, calls the `equals` function, the header and description data passed to the `equals` function is `false`, while it compares against `this.descriptionEditorHtml()` and `this.headerEditorHtml()` which will return undefined as the header and description entities do not exist.

Changing `_canCheckin` to not be marked private as it will be called by the `activities` repo.

https://rally1.rallydev.com/#/29180338367d/iterationstatus?detail=%2Fuserstory%2F478606416460%2Ftasks