### PR TITLE
Getting IP href based on rel instead of class

### DIFF
--- a/src/activities/quizzes/QuizEntity.js
+++ b/src/activities/quizzes/QuizEntity.js
@@ -373,10 +373,10 @@ export class QuizEntity extends Entity {
 	 * @returns {string} Ip restrictions Href of the quiz entity, if present
 	*/
 	ipRestrictionsHref() {
-		if (!this._entity || !this._entity.hasSubEntityByClass(Classes.quizzes.ip.restrictions)) {
+		if (!this._entity || !this._entity.hasSubEntityByRel(Rels.Quizzes.ipRestrictions)) {
 			return;
 		}
-		return this._entity.getSubEntityByClass(Classes.quizzes.ip.restrictions).href;
+		return this._entity.getSubEntityByRel(Rels.Quizzes.ipRestrictions).href;
 	}
 
 	async save(quiz) {

--- a/test/activities/quizzes/data/EditableQuiz.js
+++ b/test/activities/quizzes/data/EditableQuiz.js
@@ -265,7 +265,7 @@ export const editableQuiz = {
 				'collection'
 			],
 			'rel': [
-				'related'
+				'https://quizzes.api.brightspace.com/rels/ip'
 			],
 			'href': 'https://afe99802-9130-4320-a770-8d138b941e74.quizzes.api.proddev.d2l/6606/quizzes/39/ip'
 		},


### PR DESCRIPTION
https://rally1.rallydev.com/#/29180338367d/iterationstatus?detail=%2Fuserstory%2F502226480152

The working copy IP entity doesn't have a class so need to fetch based on rel.

Looks something like:

```
        {
            "rel": [
                "https://quizzes.api.brightspace.com/rels/ip"
            ],
            "href": "https://74728563-1618-4c49-s5b6-ddb108a6c965.quizzes.api.dev.brightspace.com/123504/quizzes/1602/ip?workingCopyId=6cdc390b-a8bd-4ec0-8126-22affa9e47ea"
        }
```