### PR TITLE
US123692 - Return rejected promise if checkin fails (server error)

### DIFF
--- a/src/activities/quizzes/QuizEntity.js
+++ b/src/activities/quizzes/QuizEntity.js
@@ -800,7 +800,12 @@ export class QuizEntity extends Entity {
 	async checkin() {
 		if (this.canCheckin()) {
 			const action = this.getActionByName(Actions.workingCopy.checkin);
-			const entity = await performSirenAction(this._token, action);
+			let entity;
+			try {
+				entity = await performSirenAction(this._token, action);
+			} catch (e) {
+				return Promise.reject(e);
+			}
 			if (!entity) return;
 			return new QuizEntity(entity, this._token);
 		}


### PR DESCRIPTION
For the activity component to know that the checkin failed because of a server error, we need to reject the promise here instead of silently returning.
https://rally1.rallydev.com/#/29180338367d/iterationstatus?detail=%2Fuserstory%2F478606416460%2Ftasks