### PR TITLE
US123692 - Fix EntityStore updating incorrect entity

### DIFF
--- a/src/es6/SirenAction.js
+++ b/src/es6/SirenAction.js
@@ -146,6 +146,10 @@ const _performSirenAction = function(action, fields, tokenValue) {
 				if (!entity) {
 					return window.D2L.Siren.EntityStore.remove(url.href, token);
 				}
+				const selfLink = entity.getLinkByRel('self');
+				if (selfLink && selfLink.href !== url.href) {
+					return window.D2L.Siren.EntityStore.update(selfLink.href, token, entity);
+				}
 				return window.D2L.Siren.EntityStore.update(url.href, token, entity);
 			});
 		});


### PR DESCRIPTION
A base quiz entity contains a checkout action with a quiz href. After POSTing to it, the response is the working copy entity that ends with a workingCopy queryParam. Wtihout my change, the EntityStore was updating the base quiz entity with the returned working copy entity, when in fact, it should be adding a new object to the entity store with the self href of the returned working copy entity.

https://rally1.rallydev.com/#/29180338367d/iterationstatus?detail=%2Fuserstory%2F478606416460%2Ftasks
