### PR TITLE
US123841 format siren action based on intro is appended to description class

### DIFF
--- a/src/activities/quizzes/QuizEntity.js
+++ b/src/activities/quizzes/QuizEntity.js
@@ -635,10 +635,11 @@ export class QuizEntity extends Entity {
 
 	_formatUpdateDescriptionAction(quiz) {
 		const { description } = quiz || {};
+		const hasDescriptionChanged = this.introIsAppendedToDescription() || this._hasDescriptionChanged(description);
 
 		if (typeof description === 'undefined') return;
 
-		if (!this._hasDescriptionChanged(description) && this.descriptionIsDisplayed()) return;
+		if (!hasDescriptionChanged && this.descriptionIsDisplayed()) return;
 
 		const descriptionEntity = this._getDescriptionEntity();
 

--- a/src/activities/quizzes/QuizEntity.js
+++ b/src/activities/quizzes/QuizEntity.js
@@ -279,6 +279,14 @@ export class QuizEntity extends Entity {
 	}
 
 	/**
+	 * @returns {bool} Introduction is appended to the description for the quiz entity
+	 */
+	introIsAppendedToDescription() {
+		const descriptionEntity = this._getDescriptionEntity();
+		return descriptionEntity && descriptionEntity.hasClass(Classes.quizzes.introIsAppendedToDescription);
+	}
+
+	/**
 	 * @returns {string} Quiz header in plaintext (HTML stripped)
 	 */
 	headerPlaintext() {

--- a/src/hypermedia-constants.js
+++ b/src/hypermedia-constants.js
@@ -352,6 +352,7 @@ export const Classes = {
 		quiz: 'quiz',
 		description: 'description',
 		descriptionIsDisplayed: 'description-is-displayed',
+		introIsAppendedToDescription: 'intro-is-appended-to-description',
 		header: 'header',
 		headerIsDisplayed: 'header-is-displayed',
 		shuffle: 'shuffle',


### PR DESCRIPTION
### Motivation/Context
This is part of the initiative to retire the Quiz Introduction field that used to exist in the legacy quiz editor. In FACE the introduction field doesn't exist, so for existing quizzes with content in the Introduction quiz we want to append that to the Description field and warn users that the intro field content has been moved and whatever that was invisible could be visible to students now.

### Summary of Changes
* Added `intro-is-appended-to-description` to hypermedia constants
* Checked if quiz entity contains the class `intro-is-appended-to-description`
  * If the class is there -> we treat it as the quiz description has changed so that the merged desc + intro could be saved
  * If the class isn't there -> proceed with regular checks

### Rally Story
https://rally1.rallydev.com/#/29180338367d/dashboard?detail=%2Fuserstory%2F480496567460&fdp=true?fdp=true