### PR TITLE
fix: added extra error handling to account for new scoreOutOf link su…

### DIFF
--- a/src/activities/ActivityUsageEntity.js
+++ b/src/activities/ActivityUsageEntity.js
@@ -438,7 +438,7 @@ export class ActivityUsageEntity extends Entity {
 			return action.getFieldByName('scoreOutOf').value;
 		}
 		const scoreOutOfEntity = this._getScoreOutOfEntity();
-		return scoreOutOfEntity ? scoreOutOfEntity.properties.scoreOutOf : undefined;
+		return scoreOutOfEntity && scoreOutOfEntity.properties ? scoreOutOfEntity.properties.scoreOutOf : undefined;
 	}
 
 	/**
@@ -450,7 +450,7 @@ export class ActivityUsageEntity extends Entity {
 			return action.getFieldByName('inGrades').value;
 		}
 		const scoreOutOfEntity = this._getScoreOutOfEntity();
-		return scoreOutOfEntity ? scoreOutOfEntity.properties.inGrades : undefined;
+		return scoreOutOfEntity && scoreOutOfEntity.properties ? scoreOutOfEntity.properties.inGrades : undefined;
 	}
 
 	/**
@@ -465,7 +465,7 @@ export class ActivityUsageEntity extends Entity {
 			}
 		}
 		const scoreOutOfEntity = this._getScoreOutOfEntity();
-		return scoreOutOfEntity ? scoreOutOfEntity.properties.gradeType : undefined;
+		return scoreOutOfEntity && scoreOutOfEntity.properties ? scoreOutOfEntity.properties.gradeType : undefined;
 	}
 
 	/**
@@ -560,7 +560,7 @@ export class ActivityUsageEntity extends Entity {
 	 */
 	canEditScoreOutOf() {
 		const scoreOutOfEntity = this._getScoreOutOfEntity();
-		return scoreOutOfEntity
+		return scoreOutOfEntity && scoreOutOfEntity.hasActionByName
 			&& scoreOutOfEntity.hasActionByName(Actions.activities.scoreOutOf.update);
 	}
 
@@ -569,7 +569,7 @@ export class ActivityUsageEntity extends Entity {
 	 */
 	canSeeGrades() {
 		const scoreOutOfEntity = this._getScoreOutOfEntity();
-		return scoreOutOfEntity
+		return scoreOutOfEntity && scoreOutOfEntity.properties
 			&& scoreOutOfEntity.properties.hasOwnProperty('inGrades');
 	}
 
@@ -590,7 +590,7 @@ export class ActivityUsageEntity extends Entity {
 	_getScoreOutOfAction() {
 		const scoreOutOfEntity = this._getScoreOutOfEntity();
 		return scoreOutOfEntity
-			&& scoreOutOfEntity.getActionByName(Actions.activities.scoreOutOf.update);
+			&& scoreOutOfEntity.getActionByName && scoreOutOfEntity.getActionByName(Actions.activities.scoreOutOf.update);
 	}
 
 	async validate(activity) {


### PR DESCRIPTION
…bEntity

- Added extra error handling to account for the new scoreOutOf linked subentity which was added to the quiz activity usage API
- The new sub-entity is a basic linked sub-entity which doesn't have actions or properties, which is why the extra validation is required