### PR TITLE
Default IPs to empty strings to prevent weird errors

### DIFF
--- a/src/activities/quizzes/ipRestrictions/QuizIpRestrictionsEntity.js
+++ b/src/activities/quizzes/ipRestrictions/QuizIpRestrictionsEntity.js
@@ -35,7 +35,7 @@ export class QuizIpRestrictionsEntity extends Entity {
 
 		return ipRestrictionEntities.map(({ properties }, index) => {
 
-			const { start, end } = properties;
+			const { start = '', end = '' } = properties;
 			return {
 				start,
 				end,


### PR DESCRIPTION
If IPs were ever loaded from LMS as `undefined` weird things happened...