### PR TITLE
US125529 added ActivityScoreOutOfEntity to activity usage

### DIFF
--- a/src/activities/ActivityScoreOutOfEntity.js
+++ b/src/activities/ActivityScoreOutOfEntity.js
@@ -1,0 +1,12 @@
+import { Entity } from '../es6/Entity';
+
+/**
+ * ActivityScoreOutOf: class representation of the score-out-of for an activity
+ */
+
+export class ActivityScoreOutOfEntity extends Entity {
+
+	scoreOutOf() {
+		return this._entity && this._entity.properties && this._entity.properties.scoreOutOf;
+	}
+}

--- a/src/activities/ActivityUsageEntity.js
+++ b/src/activities/ActivityUsageEntity.js
@@ -440,6 +440,13 @@ export class ActivityUsageEntity extends Entity {
 		const scoreOutOfEntity = this._getScoreOutOfEntity();
 		return scoreOutOfEntity && scoreOutOfEntity.properties ? scoreOutOfEntity.properties.scoreOutOf : undefined;
 	}
+	/**
+	 * @returns {string} Href for linked score-out-of sub-entity
+	 */
+	scoreOutOfHref() {
+		const scoreOutOfEntity = this._getScoreOutOfEntity();
+		return scoreOutOfEntity && scoreOutOfEntity.href;
+	}
 
 	/**
 	 * @returns {string} True if the activity usage is associated with a grade item, False otherwise

--- a/test/activities/ActivityScoreOutOfEntity.html
+++ b/test/activities/ActivityScoreOutOfEntity.html
@@ -1,0 +1,19 @@
+<html>
+	<head>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
+		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
+		<script src="/node_modules/mocha/mocha.js"></script>
+		<script src="/node_modules/chai/chai.js"></script>
+		<script src="/node_modules/@polymer/test-fixture/test-fixture.js"></script>
+		<script src="/node_modules/wct-mocha/wct-mocha.js"></script>
+		<script src="/node_modules/sinon/pkg/sinon.js"></script>
+
+		<script type="module" src="../../../siren-parser/global.js"></script>
+		<script type="module" src="../../src/activities/ActivityScoreOutOfEntity.js"></script>
+	</head>
+
+	<body>
+		<script type="module" src="./ActivityScoreOutOfEntity.js"></script>
+	</body>
+</html>

--- a/test/activities/ActivityScoreOutOfEntity.js
+++ b/test/activities/ActivityScoreOutOfEntity.js
@@ -1,0 +1,12 @@
+import { ActivityScoreOutOfEntity } from '../../src/activities/ActivityScoreOutOfEntity.js';
+import { testData } from './data/ActivityScoreOutOfEntity.js';
+
+describe('ActivityScoreOutOfEntity', () => {
+	describe('scoreOutOf', () => {
+		it('can get score out of', () => {
+			const entityJson = window.D2L.Hypermedia.Siren.Parse(testData);
+			const entity = new ActivityScoreOutOfEntity(entityJson);
+			expect(entity.scoreOutOf()).to.equal(200);
+		});
+	});
+});

--- a/test/activities/data/ActivityScoreOutOfEntity.js
+++ b/test/activities/data/ActivityScoreOutOfEntity.js
@@ -1,0 +1,16 @@
+export const testData = {
+	'class': [
+		'score-out-of'
+	],
+	'properties': {
+		'scoreOutOf': 200
+	},
+	'links': [
+		{
+			'rel': [
+				'self'
+			],
+			'href': 'https://42cc8bed-4414-4840-940e-4bc771cbfb10.activities.api.proddev.d2l/activities/6606_51000_3/usages/6609',
+		}
+	]
+};

--- a/test/index.html
+++ b/test/index.html
@@ -44,6 +44,7 @@
 			'./activities/ActivityUsageCollectionEntity.html',
 			'./activities/ActivityUsageEntity.html',
 			'./activities/ActivityGradeEntity.html',
+			'./activities/ActivityScoreOutOfEntity.html',
 			'./activities/GradeCandidateCollectionEntity.html',
 			'./activities/GradeCandidateEntity.html',
 			'./activities/GradeCategoryEntity.html',


### PR DESCRIPTION
- New function `scoreOutOfHref()` gets the href if the score-out-of sub-entity is a linked entity (i.e. will be used to display total quiz points)
- Created new `ActivityScoreOutOfEntity` class 
- Added a simple test

[US125529](https://rally1.rallydev.com/#/29180338367d/custom/486232622040?detail=%2Fuserstory%2F505601651720&fdp=true?fdp=true): [ui] Display total points for a quiz

https://rally1.rallydev.com/#/29180338367d/custom/486232622040?detail=%2Fuserstory%2F505601651720&fdp=true?fdp=true