### PR TITLE
Added siren sdk function to determine whether initial quiz Description value is empty

### DIFF
--- a/src/activities/quizzes/QuizEntity.js
+++ b/src/activities/quizzes/QuizEntity.js
@@ -279,6 +279,16 @@ export class QuizEntity extends Entity {
 	}
 
 	/**
+	 * @returns {bool} Description is initially empty for the quiz entity
+	 */
+	originalDescriptionIsEmpty() {
+		const descriptionEntity = this._getDescriptionEntity();
+		return descriptionEntity
+			&& descriptionEntity.properties
+			&& !descriptionEntity.properties.text;
+	}
+
+	/**
 	 * @returns {bool} Introduction is appended to the description for the quiz entity
 	 */
 	introIsAppendedToDescription() {


### PR DESCRIPTION
### Summary of Changes
* Added siren sdk function to return a boolean value that represents whether the original value of description is empty or not
* See this related PR: https://github.com/BrightspaceHypermediaComponents/activities/pull/1597

### Rally Story / Trello Card
https://rally1.rallydev.com/#/29180338367d/custom/486232622040?detail=%2Fuserstory%2F479012712268&fdp=true?fdp=true
https://trello.com/c/uTnkTSwn/329-description-hidden-warning-message-should-not-trigger-while-in-face