### PR TITLE
DE42885: Add more null checking on the scoreoutof entity

### DIFF
--- a/src/activities/ActivityUsageEntity.js
+++ b/src/activities/ActivityUsageEntity.js
@@ -597,7 +597,7 @@ export class ActivityUsageEntity extends Entity {
 
 	async fetchLinkedScoreOutOfEntity(fetcher) {
 		const scoreOutOfSubEntity = this._entity && this._entity.getSubEntityByRel(Rels.Activities.scoreOutOf);
-		if (scoreOutOfSubEntity.href) {
+		if (scoreOutOfSubEntity && scoreOutOfSubEntity.href) {
 			this._linkedScoreOutOfEntity = await fetcher(scoreOutOfSubEntity.href, this.token);
 		}
 	}


### PR DESCRIPTION
On the Content FACE pages, we use the generic `activity-usage`, however our entities have no concept of grades or scoreoutof. As a result, our FACE pages were erroring out and dates were not working.  

This pr adds more aggressive null checking so we are not trying to get properties off of something that does not exist.

![image](https://user-images.githubusercontent.com/14796305/111362382-b400da00-865c-11eb-9794-b99935111446.png)

https://rally1.rallydev.com/#/289692574792d/custom/355050439968?detail=%2Fdefect%2F511812392384&fdp=true