### PR TITLE
US126109 modifyed fetchLinkedScoreOutOfEntity to take bypassCache param

### DIFF
--- a/src/activities/ActivityUsageEntity.js
+++ b/src/activities/ActivityUsageEntity.js
@@ -595,10 +595,10 @@ export class ActivityUsageEntity extends Entity {
 			&& scoreOutOfEntity.getActionByName && scoreOutOfEntity.getActionByName(Actions.activities.scoreOutOf.update);
 	}
 
-	async fetchLinkedScoreOutOfEntity(fetcher) {
+	async fetchLinkedScoreOutOfEntity(fetcher, bypassCache) {
 		const scoreOutOfSubEntity = this._entity && this._entity.getSubEntityByRel(Rels.Activities.scoreOutOf);
 		if (scoreOutOfSubEntity && scoreOutOfSubEntity.href) {
-			this._linkedScoreOutOfEntity = await fetcher(scoreOutOfSubEntity.href, this.token);
+			this._linkedScoreOutOfEntity = await fetcher(scoreOutOfSubEntity.href, this.token, bypassCache);
 		}
 	}
 


### PR DESCRIPTION
Modified the `fetchLinkedScoreOutOfEntity` method to take a `bypassCache` param. We want to bypass the cache when refreshing the Total Points component on FACE Quiz when an individual question is edited. 

**Related PRs:**
`hmc`: https://github.com/BrightspaceHypermediaComponents/foundation-components/pull/150
`activities`: BrightspaceHypermediaComponents/activities#1624

[US126109](https://rally1.rallydev.com/#/29180338367d/custom/486232622040?detail=%2Fuserstory%2F512322551332&fdp=true?fdp=true): Refresh total points on edit

https://rally1.rallydev.com/#/29180338367d/custom/486232622040?detail=%2Fuserstory%2F512322551332&fdp=true?fdp=true