### PR TITLE
US123706 FACE Quizzes: Attempt Condition update values of 0 are handled correctly

### DIFF
--- a/src/activities/quizzes/attempts/QuizAttemptsEntity.js
+++ b/src/activities/quizzes/attempts/QuizAttemptsEntity.js
@@ -166,11 +166,13 @@ export class QuizAttemptsEntity extends Entity {
 	_hasAttemptConditionChanged(attemptCondition) {
 		const original = this.getAttemptConditionSubEntity(attemptCondition.attempt);
 		if (!original || !original.properties) return false;
-		if (!original.properties.min && attemptCondition.min !== undefined) return true;
-		if (!original.properties.max && attemptCondition.max !== undefined) return true;
 		// when `min` or `max` has a value of `undefined` we are deleting the original value for `min` or `max`
-		if ('min' in attemptCondition && original.properties.min && original.properties.min !== attemptCondition.min) return true;
-		if ('max' in attemptCondition && original.properties.max && original.properties.max !== attemptCondition.max) return true;
+		if ('min' in attemptCondition) {
+			return (original.properties.min !== attemptCondition.min);
+		}
+		if ('max' in attemptCondition) {
+			return (original.properties.max !== attemptCondition.max);
+		}
 
 		return false;
 	}

--- a/src/activities/quizzes/attempts/QuizAttemptsEntity.js
+++ b/src/activities/quizzes/attempts/QuizAttemptsEntity.js
@@ -166,8 +166,8 @@ export class QuizAttemptsEntity extends Entity {
 	_hasAttemptConditionChanged(attemptCondition) {
 		const original = this.getAttemptConditionSubEntity(attemptCondition.attempt);
 		if (!original || !original.properties) return false;
-		if (!original.properties.min && attemptCondition.min) return true;
-		if (!original.properties.max && attemptCondition.max) return true;
+		if (!original.properties.min && attemptCondition.min !== undefined) return true;
+		if (!original.properties.max && attemptCondition.max !== undefined) return true;
 		// when `min` or `max` has a value of `undefined` we are deleting the original value for `min` or `max`
 		if ('min' in attemptCondition && original.properties.min && original.properties.min !== attemptCondition.min) return true;
 		if ('max' in attemptCondition && original.properties.max && original.properties.max !== attemptCondition.max) return true;
@@ -238,8 +238,8 @@ export class QuizAttemptsEntity extends Entity {
 		if (!action) return;
 		const fields = [];
 
-		if (attemptCondition.min) fields.push({ name: 'min', value: attemptCondition.min });
-		if (attemptCondition.max) fields.push({ name: 'max', value: attemptCondition.max });
+		if (attemptCondition.min !== undefined) fields.push({ name: 'min', value: attemptCondition.min });
+		if (attemptCondition.max !== undefined) fields.push({ name: 'max', value: attemptCondition.max });
 
 		return { action, fields };
 	}

--- a/src/activities/quizzes/attempts/QuizAttemptsEntity.js
+++ b/src/activities/quizzes/attempts/QuizAttemptsEntity.js
@@ -167,14 +167,7 @@ export class QuizAttemptsEntity extends Entity {
 		const original = this.getAttemptConditionSubEntity(attemptCondition.attempt);
 		if (!original || !original.properties) return false;
 		// when `min` or `max` has a value of `undefined` we are deleting the original value for `min` or `max`
-		if ('min' in attemptCondition) {
-			return (original.properties.min !== attemptCondition.min);
-		}
-		if ('max' in attemptCondition) {
-			return (original.properties.max !== attemptCondition.max);
-		}
-
-		return false;
+		return (original.properties.min !== attemptCondition.min) || (original.properties.max !== attemptCondition.max);
 	}
 
 	/**


### PR DESCRIPTION
[US123706](https://rally1.rallydev.com/#/29180338367d/iterationstatus?detail=%2Fuserstory%2F478977336380&fdp=true?fdp=true): [ui] Manage Attempts (Attempts allowed, RIO, Attempt conditions)

`0` is also `false` when evaluated in conditionals, this is currently preventing `0` being set as a value for `min` or `max`