### PR TITLE
Add a lesson-view-page alt html link to activity-usage entities for content topics

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "siren-sdk",
-  "version": "1.49.0",
+  "version": "1.50.0",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/activities/content/ContentEntity.js
+++ b/src/activities/content/ContentEntity.js
@@ -39,35 +39,35 @@ export class ContentEntity extends Entity {
 	}
 
 	/**
-	 * @returns {string} content-module link
+	 * @returns {string|null} content-module link
 	 */
 	getModuleHref() {
 		return ContentHelperFunctions.getHrefFromRel(Rels.Content.moduleEntity, this._entity);
 	}
 
 	/**
-	 * @returns {string} content-weblink link
+	 * @returns {string|null} content-weblink link
 	 */
 	getWebLinkHref() {
 		return ContentHelperFunctions.getHrefFromRel(Rels.Content.weblinkEntity, this._entity);
 	}
 
 	/**
-	 * @returns {string} content-ltilink link
+	 * @returns {string|null} content-ltilink link
 	 */
 	getLTILinkHref() {
 		return ContentHelperFunctions.getHrefFromRel(Rels.Content.ltilinkEntity, this._entity);
 	}
 
 	/**
-	 * @returns {string} content-htmlfile link
+	 * @returns {string|null} content-htmlfile link
 	 */
 	getHtmlFileHref() {
 		return ContentHelperFunctions.getHrefFromRel(Rels.Content.htmlFileEntity, this._entity);
 	}
 
 	/**
-	 * @returns {string} lesson-view-page link
+	 * @returns {string|null} lesson-view-page link
 	 */
 	getLessonViewPageHref() {
 		return ContentHelperFunctions.getHrefFromRel(Rels.Content.lessonViewPage, this._entity);

--- a/src/activities/content/ContentEntity.js
+++ b/src/activities/content/ContentEntity.js
@@ -65,4 +65,12 @@ export class ContentEntity extends Entity {
 	getHtmlFileHref() {
 		return ContentHelperFunctions.getHrefFromRel(Rels.Content.htmlFileEntity, this._entity);
 	}
+
+	/**
+	 * @returns {string} lesson-view-page link
+	 */
+	getLessonViewPageHref() {
+		return ContentHelperFunctions.getHrefFromRel(Rels.Content.lessonViewPage, this._entity);
+	}
+
 }

--- a/src/activities/content/ContentWebLinkEntity.js
+++ b/src/activities/content/ContentWebLinkEntity.js
@@ -1,5 +1,5 @@
 import { Entity } from '../../es6/Entity';
-import { Actions, Classes } from '../../hypermedia-constants';
+import { Actions, Classes, Rels } from '../../hypermedia-constants';
 import { performSirenAction } from '../../es6/SirenAction';
 import ContentHelperFunctions from './ContentHelperFunctions.js';
 
@@ -38,6 +38,13 @@ export class ContentWebLinkEntity extends Entity {
 			return false;
 		}
 		return this._entity.hasClass(Classes.webLink.externalResource);
+	}
+
+	/**
+	 * @returns {string} activity usage link
+	 */
+	getActivityUsageHref() {
+		return ContentHelperFunctions.getHrefFromRel(Rels.Activities.activityUsage, this._entity);
 	}
 
 	/**

--- a/src/activities/content/ContentWebLinkEntity.js
+++ b/src/activities/content/ContentWebLinkEntity.js
@@ -41,7 +41,7 @@ export class ContentWebLinkEntity extends Entity {
 	}
 
 	/**
-	 * @returns {string} activity usage link
+	 * @returns {string|null} activity usage link
 	 */
 	getActivityUsageHref() {
 		return ContentHelperFunctions.getHrefFromRel(Rels.Activities.activityUsage, this._entity);

--- a/src/hypermedia-constants.js
+++ b/src/hypermedia-constants.js
@@ -112,7 +112,8 @@ export const Rels = {
 		moduleEntity: 'https://modules.api.brightspace.com/rels/content-module',
 		weblinkEntity: 'https://weblinks.api.brightspace.com/rels/content-weblink',
 		ltilinkEntity: 'https://weblinks.api.brightspace.com/rels/content-ltilink',
-		htmlFileEntity: 'https://content.api.brightspace.com/rels/content-html-file'
+		htmlFileEntity: 'https://content.api.brightspace.com/rels/content-html-file',
+		lessonViewPage: 'https://content.api.brightspace.com/rels/lesson-view-page'
 	},
 	// Parents API sub-domain rels
 	Parents: {


### PR DESCRIPTION
## Relevant Rally Links 

[US126672](https://rally1.rallydev.com/#/289692574792d/custom/355050439968?detail=%2Fuserstory%2F519007142480&fdp=true?fdp=true): Modify activities saveHref to handle new working copy items

## Description

Adds a method to retrieve the `lesson-view-page` link from the `ContentEntity`, as well as the `activitiy-usage` link from the `ContentWebLink` entity.

## Goal/Solution

The `lesson-view-page` link will allow the FACE UI to navigate back to the correct topic after saving (especially useful for creating a new topic).

The `activity-usage` link allows the web link to raise an event with the updated activity-usage href value when saving. This is important when committing a new unsaved weblink for the first time as the activity usage href will change and the parent control needs to be aware so it can fetch this updated entity.

## Video/Screenshots

n/a