### PR TITLE
Added new method to check if a user can add categories

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "siren-sdk",
-  "version": "1.56.0",
+  "version": "1.57.0",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/activities/assignments/CategoriesEntity.js
+++ b/src/activities/assignments/CategoriesEntity.js
@@ -33,14 +33,26 @@ export class CategoriesEntity extends Entity {
 	}
 
 	/**
-	 * @returns {Boolean} Whether or not a user can edit categories
+	 * @returns {Boolean} Whether or not a user can add categories
 	*/
-	canEditCategories() {
+	canAddCategories() {
 		if (!this._entity) {
 			return;
 		}
 
 		return this._entity.hasActionByName(Actions.assignments.add);
+	}
+
+	/**
+	 * @returns {Boolean} Whether or not a user can edit categories
+	*/
+	canEditCategories() {
+		const categories = this.getCategories();
+		if (!categories || !categories.length) {
+			return;
+		}
+
+		return categories[0].hasActionByName(Actions.assignments.categories.select);
 	}
 
 	/**

--- a/src/activities/assignments/CategoriesEntity.js
+++ b/src/activities/assignments/CategoriesEntity.js
@@ -52,7 +52,8 @@ export class CategoriesEntity extends Entity {
 			return;
 		}
 
-		return categories[0].hasActionByName(Actions.assignments.categories.select);
+		return (categories[0].hasActionByName(Actions.assignments.categories.select)
+			|| categories[0].hasActionByName(Actions.assignments.categories.deselect));
 	}
 
 	/**

--- a/test/activities/assignments/CategoriesEntity.js
+++ b/test/activities/assignments/CategoriesEntity.js
@@ -95,6 +95,24 @@ describe('CategoriesEntity', () => {
 		});
 	});
 
+	describe('Can add', () => {
+		it('sets canAddCategories to true', () => {
+			var categoriesEntity = new CategoriesEntity(editableEntity);
+
+			const res = categoriesEntity.canAddCategories();
+			expect(res).to.be.true;
+		});
+	});
+
+	describe('Cannot add', () => {
+		it('sets canAddCategories to false', () => {
+			var categoriesEntity = new CategoriesEntity(nonEditableEntity);
+
+			const res = categoriesEntity.canAddCategories();
+			expect(res).to.be.false;
+		});
+	});
+
 	describe('equals', () => {
 		it('returns true when equal', () => {
 			var categoriesEntity = new CategoriesEntity(editableEntity);


### PR DESCRIPTION
Part of the fix for [this trello card](https://trello.com/c/PPE1Nhce/364-categories-if-user-has-add-edit-assignment-submission-folders-permission-they-see-read-only-view-they-should-have-the-ability-to).

In the initial implementation I was only using `canEditCategories` to determine a user's interaction with categories but in fact there is a need to check if they can edit categories AND if they can add new categories.