### PR TITLE
Update categories to handle new permissions checks

### DIFF
--- a/src/activities/assignments/CategoriesEntity.js
+++ b/src/activities/assignments/CategoriesEntity.js
@@ -72,19 +72,25 @@ export class CategoriesEntity extends Entity {
 		return selectedCategory;
 	}
 
+	getSelectedCategoryName() {
+		if (!this._entity) {
+			return;
+		}
+
+		return this._entity.properties.selectedCategory;
+	}
+
 	equals(category) {
 		const selectedCategory = this.getSelectedCategory();
 		if (!selectedCategory) {
 			return category.categoryId === selectedCategory;
 		}
 
-		return category.categoryId === selectedCategory.properties.categoryId;
+		return Number(category.categoryId) === Number(selectedCategory.properties.categoryId);
 	}
 
-	_generateDeselectCategoryAction(category) {
-		if (!this._hasCategoryIdChanged(category.categoryId)) {
-			return;
-		}
+	_generateDeselectCategoryAction() {
+		if (!this.canEditCategories()) return;
 
 		const selectedCategory = this.getSelectedCategory();
 		if (!selectedCategory) return;
@@ -95,6 +101,8 @@ export class CategoriesEntity extends Entity {
 	}
 
 	_generateNewCategoryAction(categoryName) {
+		if (!this.canAddCategories()) return;
+
 		const newCategoryAction = this._entity.getActionByName(Actions.assignments.categories.add);
 		if (!newCategoryAction) return;
 		const currentFields = newCategoryAction.getFieldByName('categoryName');
@@ -104,9 +112,7 @@ export class CategoriesEntity extends Entity {
 	}
 
 	_generateSelectCategoryAction(category) {
-		if (!this._hasCategoryIdChanged(category.categoryId)) {
-			return;
-		}
+		if (!this.canEditCategories()) return;
 
 		const categoryEntity = this._getCategoryById(category.categoryId);
 		const selectCategoryAction = categoryEntity && categoryEntity.getActionByName(Actions.assignments.categories.select);
@@ -118,27 +124,30 @@ export class CategoriesEntity extends Entity {
 
 	_hasCategoryIdChanged(categoryId) {
 		const selectedCategory = this.getSelectedCategory();
-		const initialId = selectedCategory && selectedCategory.categoryId;
+		const initialId = selectedCategory && selectedCategory.properties.categoryId;
 
 		return categoryId !== initialId;
 	}
 
 	async save(category) {
-		if (!this.canAddCategories()) return;
+		const hasCategoryIdChanged = category.categoryId && this._hasCategoryIdChanged(category.categoryId);
 
-		if (category.categoryId && category.categoryId !== UNSET_CATEGORY_ID) {
-			const { action, fields } = this._generateSelectCategoryAction(category);
-			return await performSirenAction(this._token, action, fields);
+		if (hasCategoryIdChanged && category.categoryId !== UNSET_CATEGORY_ID) {
+			const { action, fields } = this._generateSelectCategoryAction(category) || {};
+
+			return action && await performSirenAction(this._token, action, fields);
 		}
 
-		if (category.categoryId && category.categoryId === UNSET_CATEGORY_ID) {
-			const { action, fields } = this._generateDeselectCategoryAction(category);
-			return await performSirenAction(this._token, action, fields);
+		if (hasCategoryIdChanged && category.categoryId === UNSET_CATEGORY_ID) {
+			const { action, fields } = this._generateDeselectCategoryAction(category) || {};
+
+			return action && await performSirenAction(this._token, action, fields);
 		}
 
 		if (category.categoryName) {
-			const { action, fields } = this._generateNewCategoryAction(category.categoryName);
-			return await performSirenAction(this._token, action, fields);
+			const { action, fields } = this._generateNewCategoryAction(category.categoryName) || {};
+
+			return action && await performSirenAction(this._token, action, fields);
 		}
 	}
 }

--- a/src/hypermedia-constants.js
+++ b/src/hypermedia-constants.js
@@ -273,7 +273,8 @@ export const Classes = {
 		annotationEnabled: 'enabled',
 		annotationDisabled: 'disabled',
 		category: 'category',
-		selected: 'selected'
+		selected: 'selected',
+		collection: 'collection'
 	},
 	associations: {
 		singleAssociation: 'single-association',

--- a/test/activities/assignments/CategoriesEntity.js
+++ b/test/activities/assignments/CategoriesEntity.js
@@ -143,11 +143,11 @@ describe('CategoriesEntity', () => {
 			var categoriesEntity = new CategoriesEntity(editableEntity);
 
 			await categoriesEntity.save({
-				categoryId: '123',
+				categoryId: '456',
 			});
 			const form = await getFormData(fetchMock.lastCall().request);
 			if (!form.notSupported) {
-				expect(form.get('categoryId')).to.equal('123');
+				expect(form.get('categoryId')).to.equal('456');
 			}
 			expect(fetchMock.called()).to.be.true;
 		});

--- a/test/activities/assignments/data/EditableCategories.js
+++ b/test/activities/assignments/data/EditableCategories.js
@@ -66,7 +66,7 @@ export const editableCategories = {
 			],
 			'properties': {
 				'name': 'category3',
-				'categoryId': '123'
+				'categoryId': '456'
 			},
 			'actions': [
 				{
@@ -77,7 +77,7 @@ export const editableCategories = {
 						{
 							'type': 'hidden',
 							'name': 'categoryId',
-							'value': '1002'
+							'value': '456'
 						}
 					]
 				}

--- a/test/activities/assignments/data/NonEdtiableCategories.js
+++ b/test/activities/assignments/data/NonEdtiableCategories.js
@@ -1,7 +1,6 @@
 export const nonEditableCategories = {
 	'class': [
 		'categories',
-		'collection'
 	],
 	'entities': [
 		{


### PR DESCRIPTION
https://rally1.rallydev.com/#/29180338367d/custom/486232622040?detail=%2Fuserstory%2F516602039000
https://trello.com/c/3nsAWve6/372-when-a-course-has-no-categories-categories-cannot-be-added-in-face

Handling new categories permissions by checking for the "collection" class. Also cleaned up how dirty check is handled here.