### PR TITLE
US116840: Add method to retrieve activity-usage link from ContentFileEntity

### DIFF
--- a/src/activities/content/ContentFileEntity.js
+++ b/src/activities/content/ContentFileEntity.js
@@ -35,7 +35,7 @@ export class ContentFileEntity extends ContentWorkingCopyEntity {
 	}
 
 	/**
-	 * @returns {string|null} activity usage link
+	 * @returns {string|null} Activity usage link
 	 */
 	getActivityUsageHref() {
 		return ContentHelperFunctions.getHrefFromRel(Rels.Activities.activityUsage, this._entity);

--- a/src/activities/content/ContentFileEntity.js
+++ b/src/activities/content/ContentFileEntity.js
@@ -35,6 +35,13 @@ export class ContentFileEntity extends ContentWorkingCopyEntity {
 	}
 
 	/**
+	 * @returns {string|null} activity usage link
+	 */
+	getActivityUsageHref() {
+		return ContentHelperFunctions.getHrefFromRel(Rels.Activities.activityUsage, this._entity);
+	}
+
+	/**
 	 * @returns {string|undefined} Title of the content-file item
 	 */
 	title() {


### PR DESCRIPTION
## Relevant Rally Links 
[US116840](https://rally1.rallydev.com/#/289692574792/custom/355050439968?detail=%2Fuserstory%2F393033401500&fdp=true): FACE HTML file - Add HTML field via new HTML editor
[US126672](https://rally1.rallydev.com/#/289692574792d/custom/355050439968?detail=%2Fuserstory%2F519007142480&fdp=true?fdp=true): Modify activities saveHref to handle new working copy items


## Description
Adding method to retrieve the `activity-usage` link from the ContentFileEntity.

## Goal/Solution
Similar to [this PR](https://github.com/BrightspaceHypermediaComponents/siren-sdk/pull/313), we will need the `activity-usage` link in the content file entity in order to get the updated `lesson-view-page` link, which allows the FACE UI to navigate back to the correct topic in lessons after saving.
