### PR TITLE
US128071 - get file type class from entity

### DIFF
--- a/src/activities/content/ContentFileEntity.js
+++ b/src/activities/content/ContentFileEntity.js
@@ -1,10 +1,14 @@
-import { Actions, Rels, Classes } from '../../hypermedia-constants.js';
+import { Actions, Rels } from '../../hypermedia-constants.js';
 import { performSirenAction } from '../../es6/SirenAction.js';
 import ContentHelperFunctions from './ContentHelperFunctions.js';
 import { ContentWorkingCopyEntity } from './ContentWorkingCopyEntity.js';
 
 export const FILE_TYPES = {
 	html: 'html',
+};
+
+const CLASS_FILE_TYPE_MAP = {
+	html: FILE_TYPES.html,
 };
 
 /**
@@ -126,12 +130,15 @@ export class ContentFileEntity extends ContentWorkingCopyEntity {
 	 * @returns {string|null} Returns the File type
 	 */
 	getFileType() {
-		if (!this._entity && !this._entity.hasLinkByClass(Classes.files.file)) {
+		if (!this._entity) {
 			return null;
-		} else if (this._entity.hasLinkByClass(Classes.files.html)) {
-			return FILE_TYPES.html;
 		}
 
+		for (const [key, value] of Object.entries(CLASS_FILE_TYPE_MAP)) {
+			if (this._entity.hasClass(key)) {
+				return value;
+			}
+		}
 		return null;
 	}
 }

--- a/test/activities/content/ContentFileEntity.js
+++ b/test/activities/content/ContentFileEntity.js
@@ -92,7 +92,9 @@ describe('ContentFileEntity', () => {
 		it('can get file href', () => {
 			expect(contentFileEntity.getFileHref()).to.equal('https://fake-tenant-id.files.api.proddev.d2l/my-file.file/usages/6614');
 		});
+	});
 
+	describe('Classes', () => {
 		it('can get file type', () => {
 			expect(contentFileEntity.getFileType()).to.equal('html');
 		});

--- a/test/activities/content/ContentHtmlFileEntity.js
+++ b/test/activities/content/ContentHtmlFileEntity.js
@@ -104,7 +104,9 @@ describe('ContentHtmlFileEntity', () => {
 		it('can get file href', () => {
 			expect(contentHtmlFileEntity.getFileHref()).to.equal('https://fake-tenant-id.files.api.proddev.d2l/my-file.html/usages/6614');
 		});
+	});
 
+	describe('Classes', () => {
 		it('can get file type', () => {
 			expect(contentHtmlFileEntity.getFileType()).to.equal('html');
 		});

--- a/test/activities/content/data/TestContentFileEntity.js
+++ b/test/activities/content/data/TestContentFileEntity.js
@@ -34,7 +34,8 @@ export const contentFileData = {
 	],
 	'class': [
 		'describable-entity',
-		'topic'
+		'content-file',
+		'html'
 	],
 	'properties': {
 		'title': 'Test File Title',
@@ -51,7 +52,6 @@ export const contentFileData = {
 		],
 		'class': [
 			'file',
-			'html'
 		],
 		'type': 'application/vnd.siren+json',
 		'href': 'https://fake-tenant-id.files.api.proddev.d2l/my-file.file/usages/6614'

--- a/test/activities/content/data/TestContentHtmlFileEntity.js
+++ b/test/activities/content/data/TestContentHtmlFileEntity.js
@@ -47,7 +47,8 @@ export const contentHtmlFileData = {
 	],
 	'class': [
 		'describable-entity',
-		'topic'
+		'content-file',
+		'html'
 	],
 	'properties': {
 		'title': 'Test Html File Title',
@@ -64,7 +65,6 @@ export const contentHtmlFileData = {
 		],
 		'class': [
 			'file',
-			'html'
 		],
 		'type': 'application/vnd.siren+json',
 		'href': 'https://fake-tenant-id.files.api.proddev.d2l/my-file.html/usages/6614'


### PR DESCRIPTION
## Relevant Rally Links 

- [US128071](https://rally1.rallydev.com/#/289692574792d/dashboard?detail=%2Fuserstory%2F604152072952&fdp=true?fdp=true): (FE) FACE HTML file - Don't load file usage link if not present, change where to check for type



## Description

To handle the fact that we don't want to have a file entity usage link when the file activity is new, we have removed the link from the entity response when it's a new entity. Because of this, we can't rely on the file-type class being on this link, so we've moved it to the entity itself. The SDK needs to be updated to look in the right spot for the file-type class.



## Goal/Solution

The update here is to check the entity's classes rather than the link's classes for a matching type. I also updated this to use a map rather than a series of if-statements. This might sacrifice some readability but will stop the check from becoming huge and allow us to add other class-type mappings in the future as one-liners. I'm not sure that this tradeoff is worth it, so I'm happy to go back to an if-statement or a switch-statement!

I don't know what's going on with the whitespace changes, the spacing is still tabs and line endings didn't change.



## Video/Screenshots

N/A



## Related PRs

- https://github.com/BrightspaceHypermediaComponents/activities/pull/1727 the activities PR can be merged after this PR goes in



## Remaining Work

N/A