### PR TITLE
DE43500: Adding getter to raw data endpoint

### DIFF
--- a/src/files/FileEntity.js
+++ b/src/files/FileEntity.js
@@ -9,10 +9,21 @@ export class FileEntity extends Entity {
 	 * @returns {string|null} File's location
 	 */
 	getFileLocationHref() {
-		if (!this._entity || !this._entity.hasLinkByRel('alternate')) {
+		if (!this._entity || !this._entity.hasLinkByClass('filtered-data')) {
 			return null;
 		}
 
-		return this._entity.getLinkByRel('alternate').href;
+		return this._entity.getLinkByClass('filtered-data').href;
+	}
+
+	/**
+	 * @returns {string|null} File's raw data location
+	 */
+	getFileDataLocationHref() {
+		if (!this._entity || !this._entity.hasLinkByClass('raw-data')) {
+			return null;
+		}
+
+		return this._entity.getLinkByClass('raw-data').href;
 	}
 }


### PR DESCRIPTION
## Relevant Rally Links 

[DE43500](https://rally1.rallydev.com/#/289692574792/custom/355050439968?detail=%2Fdefect%2F603973776280&fdp=true): FACE HTML > Head scripts are duplicated when saving html files

## Description

A new endpoint was added to the files response which returns the raw file data. We need to access this endpoint in order for it to be consumed in activities when editing html files. We now have two `alternate` links, so they are now being distinguished by their classes.

## Goal/Solution

We need access to the raw data link when editing html files in order to not have the extra head scripts show up in the html editor (a more in depth explanation can be [found in this PR](https://github.com/Brightspace/lms/pull/10645)).

## Related PRs

- https://github.com/Brightspace/lms/pull/10645
- https://github.com/BrightspaceHypermediaComponents/activities/pull/1733