### PR TITLE
fix: action fields already work

### DIFF
--- a/src/activities/associateGrade/AssociateGradeEntity.js
+++ b/src/activities/associateGrade/AssociateGradeEntity.js
@@ -200,7 +200,7 @@ export class AssociateGradeEntity extends Entity {
 	 * Other action methods (PATCH/POST/DELETE work correctly without this helper.)
 	*/
 	_performGetActionWithWorkingCopy(action) {
-		const fields = action.fields || [];
+		const fields = [];
 		// HACK adding query param as field due to bug in performSirenAction (_getSirenFields function)
 		const url = new URL(action.href, window.location.origin);
 		const wcId = url.searchParams.get('workingCopyId');


### PR DESCRIPTION
action fields were already handled correctly by performSirenAction, so this was unneeded.