### PR TITLE
Trigger patch release: change definition from string to boolean

### DIFF
--- a/src/activities/content/ContentLTILinkFrameOptionsEntity.js
+++ b/src/activities/content/ContentLTILinkFrameOptionsEntity.js
@@ -6,7 +6,7 @@ import { Entity } from '../../es6/Entity';
 export class ContentLTILinkFrameOptionsEntity extends Entity {
 
 	/**
-	 * @returns {string|undefined} Bool if the quicklink can be embedded
+	 * @returns {boolean|undefined} Bool if the quicklink can be embedded
 	 */
 	canBeEmbedded() {
 		return this._entity && this._entity.properties && this._entity.properties.canBeEmbedded;


### PR DESCRIPTION
I forgot to squash the commits for PR https://github.com/BrightspaceHypermediaComponents/siren-sdk/pull/343 resulting in a failed release (minor increment instead of patch). The original PR is for addressing [DE43998](https://rally1.rallydev.com/#/289692574792/custom/355050439968?detail=%2Fdefect%2F601841380817&fdp=true).

This PR adds a cherry picked commit from master that has a `fix:` keyword to create a patch release.