### PR TITLE
US128779 - Get Category Href from create-new entity

### DIFF
--- a/src/activities/associateGrade/AssociateGradeEntity.js
+++ b/src/activities/associateGrade/AssociateGradeEntity.js
@@ -162,6 +162,16 @@ export class AssociateGradeEntity extends Entity {
 		return link.href;
 	}
 
+	selectedCategoryHref() {
+		const newGradeEntity = this._getNewGradeEntity();
+		if (!newGradeEntity) return;
+
+		const link = newGradeEntity.getLinkByRel(Rels.Grades.category);
+		if (!link) return;
+
+		return link.href;
+	}
+
 	async setGradebookStatus(newStatus) {
 		if (!this.canEditGradebookStatus()) return;
 

--- a/test/activities/associateGrade/AssociateGradeEntity.js
+++ b/test/activities/associateGrade/AssociateGradeEntity.js
@@ -130,6 +130,18 @@ describe('new grade', () => {
 			expect(entity.selectedSchemeHref()).to.be.undefined;
 		});
 	});
+
+	describe('selectedCategoryHref', () => {
+		it('returns true when new grade is editable', () => {
+			const entity = new AssociateGradeEntity(editableEntity);
+			expect(entity.selectedCategoryHref()).to.equal('https://5096e993-e418-4681-81c5-cae06b019fbb.grades.api.dev.brightspace.com/organizations/123171/grade-categories/5258');
+		});
+
+		it('returns false when new grade is uneditable', () => {
+			const entity = new AssociateGradeEntity(nonEditableEntity);
+			expect(entity.selectedCategoryHref()).to.be.undefined;
+		});
+	});
 });
 
 describe('existing grade', () => {


### PR DESCRIPTION
Retrieve the category href. If there is no href, then it is `no category`
Task https://rally1.rallydev.com/#/29180338367d/dashboard?detail=%2Ftask%2F602375615521&fdp=true?fdp=true
for this story https://rally1.rallydev.com/#/29180338367d/dashboard?detail=%2Fuserstory%2F600744235069%2Ftasks&fdp=true?fdp=true