### PR TITLE
FACE HTML file - Support Template Selection - Dropdown Menu

### DIFF
--- a/src/activities/content/ContentFileEntity.js
+++ b/src/activities/content/ContentFileEntity.js
@@ -141,4 +141,11 @@ export class ContentFileEntity extends ContentWorkingCopyEntity {
 		}
 		return null;
 	}
+
+	/**
+	 * @returns {string|null} html templates link
+	 */
+	 getHtmlTemplatesHref() {
+		return ContentHelperFunctions.getHrefFromRel(Rels.Content.htmlTemplates, this._entity);
+	}
 }

--- a/src/activities/content/ContentFileEntity.js
+++ b/src/activities/content/ContentFileEntity.js
@@ -145,7 +145,7 @@ export class ContentFileEntity extends ContentWorkingCopyEntity {
 	/**
 	 * @returns {string|null} html templates link
 	 */
-	 getHtmlTemplatesHref() {
+	getHtmlTemplatesHref() {
 		return ContentHelperFunctions.getHrefFromRel(Rels.Content.htmlTemplates, this._entity);
 	}
 }

--- a/src/activities/content/ContentHtmlFileTemplatesEntity.js
+++ b/src/activities/content/ContentHtmlFileTemplatesEntity.js
@@ -1,14 +1,14 @@
 import { Entity } from '../../es6/Entity';
 
 /**
- * ContentHtmlFileTemplatesEntity class representation of a html files templates entity.
+ * ContentHtmlFileTemplatesEntity class representation of an html file templates entity.
  */
 export class ContentHtmlFileTemplatesEntity extends Entity {
 
 	/**
 	 * @returns {array|undefined} Array containing the subentites of the file template entity, if they exist
 	 */
-	getHtmlFileTemplates() {    
+	getHtmlFileTemplates() {
 		return this._entity && this._entity.getSubEntitiesByRel('about');
 	}
 }

--- a/src/activities/content/ContentHtmlFileTemplatesEntity.js
+++ b/src/activities/content/ContentHtmlFileTemplatesEntity.js
@@ -1,0 +1,14 @@
+import { Entity } from '../../es6/Entity';
+
+/**
+ * ContentHtmlFileTemplatesEntity class representation of a html files templates entity.
+ */
+export class ContentHtmlFileTemplatesEntity extends Entity {
+
+	/**
+	 * @returns {array|undefined} Array containing the subentites of the file template entity, if they exist
+	 */
+	getHtmlFileTemplates() {    
+		return this._entity && this._entity.getSubEntitiesByRel('about');
+	}
+}

--- a/src/hypermedia-constants.js
+++ b/src/hypermedia-constants.js
@@ -115,7 +115,8 @@ export const Rels = {
 		ltilinkEntity: 'https://weblinks.api.brightspace.com/rels/content-ltilink',
 		ltilinkFrameOptionsEntity: 'https://content.api.brightspace.com/rels/frame-options',
 		contentFileEntity: 'https://content.api.brightspace.com/rels/content-file',
-		lessonViewPage: 'https://content.api.brightspace.com/rels/lesson-view-page'
+		lessonViewPage: 'https://content.api.brightspace.com/rels/lesson-view-page',
+		htmlTemplates: 'https://content.api.brightspace.com/rels/content-html-templates'
 	},
 	// Parents API sub-domain rels
 	Parents: {


### PR DESCRIPTION
## Relevant Rally Links

https://rally1.rallydev.com/#/289692574792d/custom/355050439968?detail=%2Fuserstory%2F424774442084

## Description

As part of the new Feature work for HTML FACE pages, we would like to support HTML File Template selection. The first piece to this is to fetch the relevant Siren Entities for this, and and display the list of templates in a dropdown menu. (See Rally link for link to designs).

## Goal/Solution

This PR defines the ContentHtmlFileTemplatesEntity class that allows for easier retrieval of HTML File Templates.

## Video/Screenshots

![Demo](https://user-images.githubusercontent.com/29843252/123664263-cc0bfc00-d7fc-11eb-94f3-42fd8941f14b.gif)

## Related PRs

- https://github.com/BrightspaceHypermediaComponents/activities/pull/1849

## Remaining Work

- [ ] Dev Testing: another developer will test this code on their machine
