### PR TITLE
US127570 - update template entity definition to provide a title function

### DIFF
--- a/src/activities/content/ContentHtmlFileTemplatesEntity.js
+++ b/src/activities/content/ContentHtmlFileTemplatesEntity.js
@@ -4,14 +4,6 @@ import { Entity } from '../../es6/Entity';
  * ContentHtmlFileTemplatesEntity class representation of an html file templates entity.
  */
 export class ContentHtmlFileTemplatesEntity extends Entity {
-
-	/**
-	 * @returns {string|undefined} Title of the content HTML file template entity
-	 */
-	title() {
-		return this._entity && this._entity.properties && this._entity.properties.title;
-	}
-
 	/**
 	 * @returns {array|undefined} Array containing the subentites of the file template entity, if they exist
 	 */

--- a/src/activities/content/ContentHtmlFileTemplatesEntity.js
+++ b/src/activities/content/ContentHtmlFileTemplatesEntity.js
@@ -6,6 +6,13 @@ import { Entity } from '../../es6/Entity';
 export class ContentHtmlFileTemplatesEntity extends Entity {
 
 	/**
+	 * @returns {string|undefined} Title of the content HTML file template entity
+	 */
+	title() {
+		return this._entity && this._entity.properties && this._entity.properties.title;
+	}
+
+	/**
 	 * @returns {array|undefined} Array containing the subentites of the file template entity, if they exist
 	 */
 	getHtmlFileTemplates() {

--- a/src/files/FileEntity.js
+++ b/src/files/FileEntity.js
@@ -4,6 +4,12 @@ import { Entity } from '../es6/Entity';
  * FileEntity class representation of a d2l content file entity.
  */
 export class FileEntity extends Entity {
+	/**
+	 * @returns {string|undefined} Title of the content HTML file template entity
+	 */
+	title() {
+		return this._entity && this._entity.properties && this._entity.properties.title;
+	}
 
 	/**
 	 * @returns {string|null} File's location


### PR DESCRIPTION
## Relevant Rally Links

- [US127570](https://rally1.rallydev.com/#/289692574792d/dashboard?detail=%2Fuserstory%2F602050357608&fdp=true?fdp=true): FACE HTML file - Support Sorting HTML Templates By Name



## Description

We need access to the HTML template entity's title.



## Goal/Solution

Provide a `title()` function on the entity that returns the title and does appropriate null checking.



## Video/Screenshots

N/A



## Related PRs

- https://github.com/BrightspaceHypermediaComponents/activities/pull/1860



## Remaining Work

If applicable...

- [ ] Dev Testing: another developer will test this code on their machine