### PR TITLE
Have weblinks extend working copy entity

### DIFF
--- a/src/activities/content/ContentWebLinkEntity.js
+++ b/src/activities/content/ContentWebLinkEntity.js
@@ -1,12 +1,12 @@
-import { Entity } from '../../es6/Entity';
 import { Actions, Classes, Rels } from '../../hypermedia-constants';
 import { performSirenAction } from '../../es6/SirenAction';
 import ContentHelperFunctions from './ContentHelperFunctions.js';
+import { ContentWorkingCopyEntity } from './ContentWorkingCopyEntity.js';
 
 /**
  * ContentWebLinkEntity class representation of a d2l content-weblink entity.
  */
-export class ContentWebLinkEntity extends Entity {
+export class ContentWebLinkEntity extends ContentWorkingCopyEntity {
 
 	/**
 	 * @returns {string|null} Description html of the content-weblink item
@@ -143,36 +143,6 @@ export class ContentWebLinkEntity extends Entity {
 
 		await performSirenAction(this._token, action);
 		this.dispose();
-	}
-
-	/**
-	 * performs a checkout action on the web link, creating a working copy
-	 */
-	async checkoutWebLink() {
-		if (!this._entity) {
-			return;
-		}
-		const action = this._entity.getActionByName(Actions.webLink.checkoutWebLink);
-		if (!action) {
-			return;
-		}
-
-		return await performSirenAction(this._token, action);
-	}
-
-	/**
-	 * performs a commit action on the web link, persisting and terminating a working copy
-	 */
-	async commitWebLink() {
-		if (!this._entity) {
-			return;
-		}
-		const action = this._entity.getActionByName(Actions.webLink.commitWebLink);
-		if (!action) {
-			return;
-		}
-
-		return await performSirenAction(this._token, action);
 	}
 
 	/**

--- a/src/hypermedia-constants.js
+++ b/src/hypermedia-constants.js
@@ -556,9 +556,7 @@ export const Actions = {
 		updateUrl: 'update-url',
 		updateExternalResource: 'update-external-resource',
 		deleteWeblink: 'delete-webLink',
-		deleteLTIlink: 'delete-ltiLink',
-		checkoutWebLink: 'checkout',
-		commitWebLink: 'commit'
+		deleteLTIlink: 'delete-ltiLink'
 	},
 	htmlFile: {
 		updateHtmlContent: 'update-html-content'


### PR DESCRIPTION
## Description

I want to extend the weblink entity to use the working copy entity since they use the same methods (the working copy entity was made after weblink's working copy stuff).

## Goal/Solution

Some code cleanup.

## Related PRs

https://github.com/BrightspaceHypermediaComponents/activities/pull/1879