### PR TITLE
DE44237: Add font size property to html entity

### DIFF
--- a/src/activities/content/ContentFileEntity.js
+++ b/src/activities/content/ContentFileEntity.js
@@ -141,11 +141,4 @@ export class ContentFileEntity extends ContentWorkingCopyEntity {
 		}
 		return null;
 	}
-
-	/**
-	 * @returns {string|null} html templates href
-	 */
-	getHtmlTemplatesHref() {
-		return ContentHelperFunctions.getHrefFromRel(Rels.Content.htmlTemplates, this._entity);
-	}
 }

--- a/src/activities/content/ContentHtmlFileEntity.js
+++ b/src/activities/content/ContentHtmlFileEntity.js
@@ -1,11 +1,26 @@
-import { Actions } from '../../hypermedia-constants.js';
+import { Actions, Rels } from '../../hypermedia-constants.js';
 import { performSirenAction } from '../../es6/SirenAction.js';
 import { ContentFileEntity } from './ContentFileEntity.js';
+import ContentHelperFunctions from './ContentHelperFunctions.js';
 
 /**
  *  ContentHtmlFileEntity class representation of a d2l html content-file entity.
  */
 export class ContentHtmlFileEntity extends ContentFileEntity {
+	/**
+	 * @returns {string|undefined} Default font-size for the html editor
+	 */
+	fontSize() {
+		return this._entity && this._entity.properties && this._entity.properties.contentFontSize;
+	}
+
+	/**
+	 * @returns {string|null} html templates href
+	 */
+	getHtmlTemplatesHref() {
+		return ContentHelperFunctions.getHrefFromRel(Rels.Content.htmlTemplates, this._entity);
+	}
+
 	/**
 	 * Updates the html file content with the given html
 	 * @param {html} html to set on the html file

--- a/test/activities/content/ContentHtmlFileEntity.js
+++ b/test/activities/content/ContentHtmlFileEntity.js
@@ -28,6 +28,10 @@ describe('ContentHtmlFileEntity', () => {
 		it('reads text description', () => {
 			expect(contentHtmlFileEntity.descriptionText()).to.equal('description text');
 		});
+
+		it('reads font size', () => {
+			expect(contentHtmlFileEntity.fontSize()).to.equal('24');
+		});
 	});
 
 	describe('Equality tests', () => {
@@ -103,6 +107,10 @@ describe('ContentHtmlFileEntity', () => {
 	describe('Links', () => {
 		it('can get file href', () => {
 			expect(contentHtmlFileEntity.getFileHref()).to.equal('https://fake-tenant-id.files.api.proddev.d2l/my-file.html/usages/6614');
+		});
+
+		it('can get templates href', () => {
+			expect(contentHtmlFileEntity.getHtmlTemplatesHref()).to.equal('https://fake-tenant-id.files.api.proddev.d2l/6614/files/html/templates');
 		});
 	});
 

--- a/test/activities/content/data/TestContentHtmlFileEntity.js
+++ b/test/activities/content/data/TestContentHtmlFileEntity.js
@@ -52,7 +52,8 @@ export const contentHtmlFileData = {
 	],
 	'properties': {
 		'title': 'Test Html File Title',
-		'url': 'https://phoenix-is-the-best.com'
+		'url': 'https://phoenix-is-the-best.com',
+		'contentFontSize': '24'
 	},
 	'entities': [{
 		'class': ['richtext', 'description'],
@@ -68,6 +69,12 @@ export const contentHtmlFileData = {
 		],
 		'type': 'application/vnd.siren+json',
 		'href': 'https://fake-tenant-id.files.api.proddev.d2l/my-file.html/usages/6614'
+	},
+	{
+		'rel': [
+			'https://content.api.brightspace.com/rels/content-html-templates'
+		],
+		'href': 'https://fake-tenant-id.files.api.proddev.d2l/6614/files/html/templates'
 	}],
 	'rel': []
 };


### PR DESCRIPTION
## Relevant Rally Links

[DE44237](https://rally1.rallydev.com/#/289692574792/custom/355050439968?detail=%2Fdefect%2F603035824797&fdp=true): `d2l.Tools.Content.FontSize` is not reflecting in content

## Description

Now that the content default font size is being returned (added in [this PR](https://github.com/Brightspace/lms/pull/12481)), we need to add the getter in `ContentHtmlFileEntity`. 

I also noticed that `getHtmlTemplatesHref` is in `ContentFileEntity`, so this PR also moves it to `ContentHtmlFileEntity`.

## Goal/Solution

Add getter for the content font size for html files. 

## Related PRs
- https://github.com/Brightspace/lms/pull/12481
- https://github.com/BrightspaceHypermediaComponents/activities/pull/1896