### PR TITLE
DE45060: FACE > Editing SCORM activities doesn't trigger discard changes dialog

### DIFF
--- a/src/activities/content/ContentScormActivityEntity.js
+++ b/src/activities/content/ContentScormActivityEntity.js
@@ -104,8 +104,7 @@ export class ContentScormActivityEntity extends ContentEntity {
 	equals(contentscormActivity) {
 		const diffs = [
 			[this.title(), contentscormActivity.title],
-			[this.isExternalResource(), contentscormActivity.isExternalResource],
-			[this.lastModified(), contentscormActivity.lastModified]
+			[this.isExternalResource(), contentscormActivity.isExternalResource]
 		];
 		for (const [left, right] of diffs) {
 			if (left !== right) {


### PR DESCRIPTION
## Relevant Rally
- https://rally1.rallydev.com/#/289692574792d/custom/355050439968?detail=%2Fdefect%2F608173754273

## Description
When editing SCORM topics, the discard changes dialog wasn't trigged when updating the title or the external resource property. This PR removes a read-only field from the equality check between two SCORM activity objects.