### PR TITLE
Kco/de45099 scorm from content service

### DIFF
--- a/src/activities/content/ContentScormActivityEntity.js
+++ b/src/activities/content/ContentScormActivityEntity.js
@@ -104,8 +104,7 @@ export class ContentScormActivityEntity extends ContentEntity {
 	equals(contentscormActivity) {
 		const diffs = [
 			[this.title(), contentscormActivity.title],
-			[this.isExternalResource(), contentscormActivity.isExternalResource],
-			[this.lastModified(), contentscormActivity.lastModified]
+			[this.isExternalResource(), contentscormActivity.isExternalResource]
 		];
 		for (const [left, right] of diffs) {
 			if (left !== right) {

--- a/src/activities/content/ContentScormActivityEntity.js
+++ b/src/activities/content/ContentScormActivityEntity.js
@@ -1,7 +1,6 @@
 import { Actions, Classes } from '../../hypermedia-constants';
 import { performSirenAction } from '../../es6/SirenAction';
 import { ContentEntity } from './ContentEntity';
-import ContentHelperFunctions from './ContentHelperFunctions';
 
 /**
  * ContentscormActivityEntity class representation of a d2l content-scorm-package entity.

--- a/src/activities/content/ContentScormActivityEntity.js
+++ b/src/activities/content/ContentScormActivityEntity.js
@@ -8,6 +8,20 @@ import { ContentEntity } from './ContentEntity';
 export class ContentScormActivityEntity extends ContentEntity {
 
 	/**
+	 * @returns {string|undefined} Name of the Scorm actvity according to the content service
+	 */
+	 contentServiceTitle() {
+		return this._entity && this._entity.properties && this._entity.properties.contentServiceScormActivityTitle;
+	}
+
+	/**
+	 * @returns {Date|undefined} The date and time the scorm activity was last edited according to the content service
+	 */
+	contentServiceUpdatedAt() {
+		return this._entity && this._entity.properties && this._entity.properties.contentServiceScormActivityUpdatedAt;
+	}
+
+	/**
 	 * @returns {boolean} external resource value (i.e. open in new tab or not)
 	 */
 	isExternalResource() {
@@ -22,20 +36,6 @@ export class ContentScormActivityEntity extends ContentEntity {
 	 */
 	title() {
 		return this._entity && this._entity.properties && this._entity.properties.title;
-	}
-
-	/**
-	 * @returns {Date|undefined} The date and time the scorm activity was last edited according to the content service
-	 */
-	contentServiceLastModified() {
-		return this._entity && this._entity.properties && this._entity.properties.contentServiceScormActivityLastModified;
-	}
-
-	/**
-	 * @returns {string|undefined} Name of the Scorm actvity according to the content service
-	 */
-	contentServiceName() {
-		return this._entity && this._entity.properties && this._entity.properties.contentServiceScormActivityName;
 	}
 
 	/**

--- a/src/activities/content/ContentScormActivityEntity.js
+++ b/src/activities/content/ContentScormActivityEntity.js
@@ -26,16 +26,17 @@ export class ContentScormActivityEntity extends ContentEntity {
 	}
 
 	/**
-	 * @returns {Date|undefined} The date and time the scorm activity was last edited
+	 * @returns {Date|undefined} The date and time the scorm activity was last edited according to the content service
 	 */
-	lastModified() {
-		const lastModifiedSubEntity = ContentHelperFunctions.getLastModifiedSubEntity(this._entity);
+	contentServiceLastModified() {
+		return this._entity && this._entity.properties && this._entity.properties.contentServiceScormActivityLastModified;
+	}
 
-		if (!lastModifiedSubEntity) {
-			return null;
-		}
-
-		return lastModifiedSubEntity.properties.date;
+	/**
+	 * @returns {string|undefined} Name of the Scorm actvity according to the content service
+	 */
+	contentServiceName() {
+		return this._entity && this._entity.properties && this._entity.properties.contentServiceScormActivityName;
 	}
 
 	/**

--- a/src/activities/content/ContentScormActivityEntity.js
+++ b/src/activities/content/ContentScormActivityEntity.js
@@ -10,7 +10,7 @@ export class ContentScormActivityEntity extends ContentEntity {
 	/**
 	 * @returns {string|undefined} Name of the Scorm actvity according to the content service
 	 */
-	 contentServiceTitle() {
+	contentServiceTitle() {
 		return this._entity && this._entity.properties && this._entity.properties.contentServiceScormActivityTitle;
 	}
 


### PR DESCRIPTION
## Relevant Rally Links

- https://rally1.rallydev.com/#/289692574792d/custom/355050439968?detail=/defect/608756964175



## Description

> Editing a SCORM topic should not update the Last Edited time of SCORM package in content service.
> 
> Changing the name of the SCORM topic should not change the title of the SCORM package in the content service



## Goal/Solution

Two new properties have been added to `ContentScormActivityEntity`.

When a ContentScormActivityEntity is built by `ScormActivitiesSerializer.cs` in the LMS, it should now be given two new properties (via AddProperty): **contentServiceScormActivityLastModified** and **contentServiceScormActivityName**.

`contentServiceName()` and `contentServiceLastModified()` on the ContentScormActivityEntity return these two properties directly.

`contentServiceLastModified()` also replaces `lastModified()`, which removes the need for importing `ContentHelperFunctions`.

## Video/Screenshots

See the SCORM package text now correctly showing the actual package name despite being edited in the LMS:

![FACE SCORM Test](https://user-images.githubusercontent.com/89945180/133341144-54a48b62-82f1-432d-94f7-c80d33c99740.PNG)



## Related PRs

- https://github.com/Brightspace/lms/pull/14130
- https://github.com/BrightspaceHypermediaComponents/activities/pull/1976



## Remaining Work

- [ ] Dev Testing: another developer will test this code on their machine
