### PR TITLE
fix: compare score directly without toString

### DIFF
--- a/src/activities/ScoringEntity.js
+++ b/src/activities/ScoringEntity.js
@@ -28,7 +28,7 @@ export class ScoringEntity extends Entity {
 	}
 
 	equals(scoring) {
-		return String(this.scoreOutOf()) === scoring.scoreOutOf;
+		return this.scoreOutOf() === scoring.scoreOutOf;
 	}
 
 	_getUpdateAction() {
@@ -48,9 +48,7 @@ export class ScoringEntity extends Entity {
 			return;
 		}
 
-		const scoreOutOf = this.scoreOutOf() ? this.scoreOutOf().toString() : '';
-
-		if (scoring.scoreOutOf !== scoreOutOf) {
+		if (scoring.scoreOutOf !== this.scoreOutOf()) {
 			const fields = [{ name: this._getUpdateFieldName(), value: scoring.scoreOutOf }];
 			await performSirenAction(this._token, this._getUpdateAction(), fields);
 		}


### PR DESCRIPTION
Now the scoreOutOf will be a number type if it's a number, or a string type if it's empty (no score). Comparisons should be made directly without converting numbers to string.