### PR TITLE
fix: export `getEntityUrl`

### DIFF
--- a/src/es6/SirenAction.js
+++ b/src/es6/SirenAction.js
@@ -230,3 +230,5 @@ export const performSirenAction = function(token, action, fields, immediate, byp
 			}) : _performSirenAction(action, fields, tokenValue, bypassCache);
 		});
 };
+
+export const getEntityUrl = _getEntityUrl;


### PR DESCRIPTION
This is used in rubrics and would nice to not have to copy/paste the code.