### PR TITLE
TA158698: Open subtitles dialog for content media files

### DIFF
--- a/src/activities/content/ContentFileEntity.js
+++ b/src/activities/content/ContentFileEntity.js
@@ -43,6 +43,13 @@ export class ContentFileEntity extends ContentWorkingCopyEntity {
 	}
 
 	/**
+	 * @returns {string|undefined} path to where the content file is stored
+	 */
+	orgUnitPath() {
+		return this._entity && this._entity.properties && this._entity.properties.orgUnitPath;
+	}
+
+	/**
 	 * @returns {string|null} Activity usage link
 	 */
 	getActivityUsageHref() {

--- a/test/activities/content/ContentFileEntity.js
+++ b/test/activities/content/ContentFileEntity.js
@@ -28,6 +28,10 @@ describe('ContentFileEntity', () => {
 		it('reads text description', () => {
 			expect(contentFileEntity.descriptionText()).to.equal('description text');
 		});
+
+		it('reads org unit path', () => {
+			expect(contentFileEntity.orgUnitPath()).to.equal('/content/course500/');
+		});
 	});
 
 	describe('Equality tests', () => {

--- a/test/activities/content/data/TestContentFileEntity.js
+++ b/test/activities/content/data/TestContentFileEntity.js
@@ -39,7 +39,8 @@ export const contentFileData = {
 	],
 	'properties': {
 		'title': 'Test File Title',
-		'url': 'https://phoenix-is-the-best.com'
+		'url': 'https://phoenix-is-the-best.com',
+		'orgUnitPath': '/content/course500/'
 	},
 	'entities': [{
 		'class': ['richtext', 'description'],


### PR DESCRIPTION
This pr adds the property for org unit path which is needed to build up the path to the subtitles dialog

lms: https://github.com/Brightspace/lms/pull/15361
siren-sdk: https://github.com/BrightspaceHypermediaComponents/siren-sdk/pull/402
activities: https://github.com/BrightspaceHypermediaComponents/activities/pull/2084

![image](https://user-images.githubusercontent.com/14796305/138738879-fcdb85ea-08c7-47aa-8e34-e974897dcbea.png)


![captionzzz](https://user-images.githubusercontent.com/14796305/138738743-a499e105-1b6e-4db1-8f27-f56e1148a315.gif)
