### PR TITLE
US130155 - Update Show Standards to get from sub-entity

### DIFF
--- a/src/activities/quizzes/submissionViews/QuizSubmissionViewEntity.js
+++ b/src/activities/quizzes/submissionViews/QuizSubmissionViewEntity.js
@@ -65,6 +65,10 @@ export class QuizSubmissionViewEntity extends Entity {
 		return this._entity && this._entity.hasClass(Classes.quizzes.submissionView.primary);
 	}
 
+	isStandardsSupported() {
+		return this._entity && this._entity.hasSubEntityByClass(Classes.quizzes.submissionView.showStandards);
+	}
+
 	async setAttemptRestrictions(value) {
 		const action = this._entity.getActionByName(Actions.quizzes.submissionView.updateAttemptRestrictions);
 		const fields = [
@@ -464,5 +468,15 @@ export class QuizSubmissionViewEntity extends Entity {
 	_gradeRestrictionsSubEntity() {
 		const subEntity = this._attemptRestrictionsSubEntity();
 		return subEntity && subEntity.getSubEntityByClass(Classes.quizzes.submissionView.gradeRestrictions);
+	}
+
+	/** SHOW STANDARDS SUB-ENTITY */
+	standardsTitle() {
+		const subEntity = this._showStandardsSubEntity();
+		return subEntity && subEntity.title;
+	}
+
+	_showStandardsSubEntity() {
+		return this._entity && this._entity.getSubEntityByClass(Classes.quizzes.submissionView.showStandards);
 	}
 }

--- a/test/activities/quizzes/data/submissionViews/SubmissionViewEntity.js
+++ b/test/activities/quizzes/data/submissionViews/SubmissionViewEntity.js
@@ -137,6 +137,15 @@ export const editablePrimaryView = {
 					]
 				}
 			]
+		},
+		{
+			'class': [
+				'show-standards'
+			],
+			'rel': [
+				'related'
+			],
+			'title': 'Show standards for the displayed questions'
 		}
 	],
 	links: [
@@ -237,6 +246,15 @@ export const nonEditablePrimaryView = {
 					properties: {}
 				}
 			]
+		},
+		{
+			'class': [
+				'show-standards'
+			],
+			'rel': [
+				'related'
+			],
+			'title': 'Show standards for the displayed questions'
 		}
 	],
 	links: [
@@ -519,6 +537,15 @@ export const editableSecondaryView = {
 					]
 				}
 			]
+		},
+		{
+			'class': [
+				'show-standards'
+			],
+			'rel': [
+				'related'
+			],
+			'title': 'Show standards for the displayed questions'
 		}
 	],
 	links: [
@@ -695,6 +722,15 @@ export const nonEditableSecondaryView = {
 					properties: {},
 				}
 			]
+		},
+		{
+			'class': [
+				'show-standards'
+			],
+			'rel': [
+				'related'
+			],
+			'title': 'Show standards for the displayed questions'
 		}
 	],
 	links: [

--- a/test/activities/quizzes/submissionViews/QuizSubmissionViewEntity.js
+++ b/test/activities/quizzes/submissionViews/QuizSubmissionViewEntity.js
@@ -33,6 +33,17 @@ describe('QuizSubmissionViewEntity', () => {
 		});
 	});
 
+	describe('Is Standards Supported', () => {
+		it('isStandardsSupported should be true', () => {
+			var entity = new QuizSubmissionViewEntity(editablePrimaryViewEntity);
+			expect(entity.isStandardsSupported()).to.be.true;
+		});
+		it('should be able to get title', () => {
+			var entity = new QuizSubmissionViewEntity(editablePrimaryViewEntity);
+			expect(entity.standardsTitle()).to.equal('Show standards for the displayed questions');
+		});
+	});
+
 	describe('Attempt Restrictions', () => {
 		it('returns correct value from editable secondary view entity', () => {
 			var entity = new QuizSubmissionViewEntity(editableSecondaryViewEntity);


### PR DESCRIPTION
We added a `show-standards` sub-entity we need to extract data from https://github.com/Brightspace/federation-artifacts/pull/23

https://rally1.rallydev.com/#/?detail=/userstory/604749774361&fdp=true