### PR TITLE
Show captions from Manage Files on FACE media content page

### DIFF
--- a/src/activities/content/ContentMediaFileCaptionsEntity.js
+++ b/src/activities/content/ContentMediaFileCaptionsEntity.js
@@ -1,0 +1,13 @@
+import { Entity } from '../../es6/Entity';
+
+/**
+ * ContentMediaFileCaptionsEntity class representation of an html file templates entity.
+ */
+export class ContentMediaFileCaptionsEntity extends Entity {
+	/**
+	 * @returns {array|undefined} Array containing the subentites of the file caption entity, if they exist
+	 */
+	getMediaFileCaptions() {
+		return this._entity && this._entity.getSubEntitiesByRel('item');
+	}
+}

--- a/src/activities/content/ContentMediaFileEntity.js
+++ b/src/activities/content/ContentMediaFileEntity.js
@@ -31,6 +31,6 @@ export class ContentMediaFileEntity extends ContentFileEntity {
 	 * @returns {string|null} media captions href
 	 */
 	getMediaCaptionsHref() {
-		return ContentHelperFunctions.getHrefFromRel(Rels.Content.htmlTemplates, this._entity);
+		return ContentHelperFunctions.getHrefFromRel(Rels.Content.mediaCaptions, this._entity);
 	}
 }

--- a/src/activities/content/ContentMediaFileEntity.js
+++ b/src/activities/content/ContentMediaFileEntity.js
@@ -1,4 +1,6 @@
 import { ContentFileEntity } from './ContentFileEntity.js';
+import ContentHelperFunctions from './ContentHelperFunctions';
+import { Rels } from '../../hypermedia-constants';
 
 /**
  *  ContentMediaFileEntity class representation of a d2l audio or video content-file entity.
@@ -23,5 +25,12 @@ export class ContentMediaFileEntity extends ContentFileEntity {
 	 */
 	isAdvancedEditingEnabled() {
 		return this._entity && this._entity.properties && this._entity.properties.isAdvancedEditingEnabled;
+	}
+
+	/**
+	 * @returns {string|null} media captions href
+	 */
+	getMediaCaptionsHref() {
+		return ContentHelperFunctions.getHrefFromRel(Rels.Content.htmlTemplates, this._entity);
 	}
 }

--- a/src/activities/content/ContentMediaFileEntity.js
+++ b/src/activities/content/ContentMediaFileEntity.js
@@ -30,7 +30,7 @@ export class ContentMediaFileEntity extends ContentFileEntity {
 	/**
 	 * @returns {string|null} media captions href
 	 */
-	getMediaCaptionsHref() {
+	getMediaFileCaptionsHref() {
 		return ContentHelperFunctions.getHrefFromRel(Rels.Content.mediaCaptions, this._entity);
 	}
 }

--- a/src/hypermedia-constants.js
+++ b/src/hypermedia-constants.js
@@ -120,7 +120,8 @@ export const Rels = {
 		contentFileEntity: 'https://content.api.brightspace.com/rels/content-file',
 		contentScormActivityEntity: 'https://weblinks.api.brightspace.com/rels/content-scormActivity',
 		lessonViewPage: 'https://content.api.brightspace.com/rels/lesson-view-page',
-		htmlTemplates: 'https://content.api.brightspace.com/rels/content-html-templates'
+		htmlTemplates: 'https://content.api.brightspace.com/rels/content-html-templates',
+		mediaCaptions: 'https://content.api.brightspace.com/rels/content-media-captions'
 	},
 	// Parents API sub-domain rels
 	Parents: {

--- a/test/activities/content/ContentMediaFileEntity.js
+++ b/test/activities/content/ContentMediaFileEntity.js
@@ -28,4 +28,10 @@ describe('ContentHtmlFileEntity', () => {
 			expect(contentMediaFileEntity.isAdvancedEditingEnabled()).to.equal('true');
 		});
 	});
+
+	describe('Links', () => {
+		it('can get captions href', () => {
+			expect(contentMediaFileEntity.getMediaCaptionsHref()).to.equal('https://fake-tenant-id.files.api.proddev.d2l/6614/files/media/captions');
+		});
+	});
 });

--- a/test/activities/content/data/TestContentMediaFileEntity.js
+++ b/test/activities/content/data/TestContentMediaFileEntity.js
@@ -58,6 +58,12 @@ export const contentMediaFileData = {
 		],
 		'type': 'application/vnd.siren+json',
 		'href': 'https://fake-tenant-id.files.api.proddev.d2l/my-file.html/usages/6614'
+	},
+	{
+		'rel': [
+			'https://content.api.brightspace.com/rels/content-media-captions'
+		],
+		'href': 'https://fake-tenant-id.files.api.proddev.d2l/6614/files/media/captions'
 	}],
 	'rel': []
 };


### PR DESCRIPTION
Siren representation for captions on content media entities.

### Related prs:
lms: https://github.com/Brightspace/lms/pull/15522
activities: https://github.com/BrightspaceHypermediaComponents/activities/pull/2111

![image](https://user-images.githubusercontent.com/14796305/139906002-61da5e8d-c73e-462e-8cec-ec40160d2d84.png)

![image](https://user-images.githubusercontent.com/14796305/139906109-b03e932e-9db0-4aff-bd06-473c0190ee08.png)

![image](https://user-images.githubusercontent.com/14796305/139906536-9fe26bc8-6a27-43b7-b10d-b0042ba27543.png)
