### PR TITLE
US133573: add allowDownload method to media file entity

### DIFF
--- a/src/activities/content/ContentMediaFileEntity.js
+++ b/src/activities/content/ContentMediaFileEntity.js
@@ -55,4 +55,10 @@ export class ContentMediaFileEntity extends ContentFileEntity {
 	tenantId() {
 		return this._entity && this._entity.properties && this._entity.properties.tenantId;
 	}
+	/**
+	 * @returns {boolean|undefined} Determines whether the download button is enabled for the embdedded media view.
+	 */
+	allowDownload() {
+		return this._entity && this._entity.properties && this._entity.properties.allowDownload;
+	}
 }

--- a/test/activities/content/ContentMediaFileEntity.js
+++ b/test/activities/content/ContentMediaFileEntity.js
@@ -44,6 +44,10 @@ describe('ContentHtmlFileEntity', () => {
 		it ('reads tenantId', () => {
 			expect(contentMediaFileEntity.tenantId()).to.equal('fake-tenant-id');
 		});
+
+		it ('reads allowDownload property', () => {
+			expect(contentMediaFileEntity.allowDownload()).to.equal('true');
+		});
 	});
 
 	describe('Links', () => {

--- a/test/activities/content/data/TestContentMediaFileEntity.js
+++ b/test/activities/content/data/TestContentMediaFileEntity.js
@@ -46,7 +46,8 @@ export const contentMediaFileData = {
 		'mediaFileName': 'test.mp4',
 		'contentServiceContentId': 'fake-content-service-content-id',
 		'contentServiceEndpoint': 'https://fake-content-service-endpoint/',
-		'tenantId': 'fake-tenant-id'
+		'tenantId': 'fake-tenant-id',
+		'allowDownload': 'true',
 	},
 	'entities': [{
 		'class': ['richtext', 'description'],


### PR DESCRIPTION
## Relevant Rally Links

- [US133573](https://rally1.rallydev.com/#/289692574792/custom/355050439968?detail=%2Fuserstory%2F614271395749&fdp=true): Add download option to embedded media view

## Description

This PR adds access to the `allowDownload` property in the `ContentMediaFileEntity`, which indicates whether or not to enable the download button in the embedded media player.

## Goal/Solution

Have access to the `allowDownload` property.

## Related PRs

- https://github.com/Brightspace/lms/pull/15984
- https://github.com/BrightspaceHypermediaComponents/activities/pull/2139