### PR TITLE
fix: DE46108 saving no score should be empty string

### DIFF
--- a/src/activities/ScoringEntity.js
+++ b/src/activities/ScoringEntity.js
@@ -49,7 +49,7 @@ export class ScoringEntity extends Entity {
 		}
 
 		if (scoring.gradeMaxPoints !== this.gradeMaxPoints()) {
-			const fields = [{ name: this._getUpdateFieldName(), value: scoring.gradeMaxPoints }];
+			const fields = [{ name: this._getUpdateFieldName(), value: scoring.gradeMaxPoints || '' }];
 			return await performSirenAction(this._token, this._getUpdateAction(), fields);
 		}
 	}


### PR DESCRIPTION
https://rally1.rallydev.com/#/?detail=/defect/615608209587&fdp=true

This fixes one small issue where saving "ungraded" did a PATCH on score-out-of endpoint with value "undefined" instead of empty string, which resulted in error.