### PR TITLE
Changed URL to tool specific

### DIFF
--- a/test/activities/CategoriesEntity.js
+++ b/test/activities/CategoriesEntity.js
@@ -12,7 +12,7 @@ const expectedCategory = {
 	'properties':{'name':'category1', 'categoryId': '123'},
 	'class':['category', 'selected'],
 	'actions':[{'name':'select',
-		'href':'https://afe99802-9130-4320-a770-8d138b941e74.activities.api.proddev.d2l/6606/folders/13',
+		'href':'https://afe99802-9130-4320-a770-8d138b941e74.assignments.api.proddev.d2l/6606/folders/13',
 		'method':'PATCH',
 		'type':'application/x-www-form-urlencoded',
 		'fields':[{'name':'categoryId', 'type':'hidden', 'value':'123'}]}]
@@ -138,7 +138,7 @@ describe('CategoriesEntity', () => {
 
 	describe('Saves', () => {
 		it('saves categoryId', async() => {
-			await fetchMock.patchOnce('https://afe99802-9130-4320-a770-8d138b941e74.activities.api.proddev.d2l/6606/folders/13', editableEntity);
+			await fetchMock.patchOnce('https://afe99802-9130-4320-a770-8d138b941e74.assignments.api.proddev.d2l/6606/folders/13', editableEntity);
 
 			var categoriesEntity = new CategoriesEntity(editableEntity);
 
@@ -153,7 +153,7 @@ describe('CategoriesEntity', () => {
 		});
 
 		it('saves name', async() => {
-			await fetchMock.postOnce('https://afe99802-9130-4320-a770-8d138b941e74.activities.api.proddev.d2l/6606/folders/13/categories', editableEntity);
+			await fetchMock.postOnce('https://afe99802-9130-4320-a770-8d138b941e74.assignments.api.proddev.d2l/6606/folders/13/categories', editableEntity);
 
 			var categoriesEntity = new CategoriesEntity(editableEntity);
 

--- a/test/activities/data/EditableCategories.js
+++ b/test/activities/data/EditableCategories.js
@@ -18,7 +18,7 @@ export const editableCategories = {
 			},
 			'actions': [
 				{
-					'href': 'https://afe99802-9130-4320-a770-8d138b941e74.activities.api.proddev.d2l/6606/folders/13',
+					'href': 'https://afe99802-9130-4320-a770-8d138b941e74.assignments.api.proddev.d2l/6606/folders/13',
 					'name': 'select',
 					'method': 'PATCH',
 					'fields': [
@@ -44,7 +44,7 @@ export const editableCategories = {
 			},
 			'actions': [
 				{
-					'href': 'https://afe99802-9130-4320-a770-8d138b941e74.activities.api.proddev.d2l/6606/folders/13',
+					'href': 'https://afe99802-9130-4320-a770-8d138b941e74.assignments.api.proddev.d2l/6606/folders/13',
 					'name': 'select',
 					'method': 'PATCH',
 					'fields': [
@@ -70,7 +70,7 @@ export const editableCategories = {
 			},
 			'actions': [
 				{
-					'href': 'https://afe99802-9130-4320-a770-8d138b941e74.activities.api.proddev.d2l/6606/folders/13',
+					'href': 'https://afe99802-9130-4320-a770-8d138b941e74.assignments.api.proddev.d2l/6606/folders/13',
 					'name': 'select',
 					'method': 'PATCH',
 					'fields': [
@@ -89,12 +89,12 @@ export const editableCategories = {
 			'rel': [
 				'self'
 			],
-			'href': 'https://afe99802-9130-4320-a770-8d138b941e74.activities.api.proddev.d2l/6606/folders/13/categories'
+			'href': 'https://afe99802-9130-4320-a770-8d138b941e74.assignments.api.proddev.d2l/6606/folders/13/categories'
 		}
 	],
 	'actions': [
 		{
-			'href': 'https://afe99802-9130-4320-a770-8d138b941e74.activities.api.proddev.d2l/6606/folders/13/categories',
+			'href': 'https://afe99802-9130-4320-a770-8d138b941e74.assignments.api.proddev.d2l/6606/folders/13/categories',
 			'name': 'add',
 			'method': 'POST',
 			'fields': [

--- a/test/activities/data/EmptyCategories.js
+++ b/test/activities/data/EmptyCategories.js
@@ -8,7 +8,7 @@ export const emptyCategories = {
 			'rel': [
 				'self'
 			],
-			'href': 'https://afe99802-9130-4320-a770-8d138b941e74.activities.api.proddev.d2l/6606/folders/13/categories'
+			'href': 'https://afe99802-9130-4320-a770-8d138b941e74.assignments.api.proddev.d2l/6606/folders/13/categories'
 		}
 	]
 };

--- a/test/activities/data/NonEdtiableCategories.js
+++ b/test/activities/data/NonEdtiableCategories.js
@@ -46,7 +46,7 @@ export const nonEditableCategories = {
 			'rel': [
 				'self'
 			],
-			'href': 'https://afe99802-9130-4320-a770-8d138b941e74.activities.api.proddev.d2l/6606/folders/13/categories'
+			'href': 'https://afe99802-9130-4320-a770-8d138b941e74.assignments.api.proddev.d2l/6606/folders/13/categories'
 		}
 	]
 };

--- a/test/activities/data/NonSelectedCategories.js
+++ b/test/activities/data/NonSelectedCategories.js
@@ -34,7 +34,7 @@ export const nonSelectedCategories = {
 			'rel': [
 				'self'
 			],
-			'href': 'https://afe99802-9130-4320-a770-8d138b941e74.activities.api.proddev.d2l/6606/folders/13/categories'
+			'href': 'https://afe99802-9130-4320-a770-8d138b941e74.assignments.api.proddev.d2l/6606/folders/13/categories'
 		}
 	]
 };


### PR DESCRIPTION
I was thinking of changing this to `/activities` as categories is now used in multiple tools, however, as Margaret pointed out that doesn't represent a real URL in our system and the actual use of PATCHing categories will be done against a specific tools URL. 