### PR TITLE
Added tests and refactored assignments save to avoid depending on AF specific PUT action

### DIFF
--- a/test/activities/assignments/AssignmentEntity.js
+++ b/test/activities/assignments/AssignmentEntity.js
@@ -120,6 +120,170 @@ describe('AssignmentEntity', () => {
 			expect(fetchMock.called()).to.be.true;
 		});
 
+		it('saves allowable file type', async() => {
+			fetchMock.patchOnce('https://f5aa43d7-c082-485c-84f5-4808147fe98a.assignments.api.dev.brightspace.com/123065/folders/7', editableEntity);
+
+			var assignmentEntity = new AssignmentEntity(editableEntity);
+
+			await assignmentEntity.save({
+				allowableFileType: '2',
+			});
+
+			const form = await getFormData(fetchMock.lastCall().request);
+			if (!form.notSupported) {
+				expect(form.get('allowableFileType')).to.equal('2');
+			}
+			expect(fetchMock.called()).to.be.true;
+		});
+
+		it('saves custom allowable file type', async() => {
+			fetchMock.patchOnce('https://f5aa43d7-c082-485c-84f5-4808147fe98a.assignments.api.dev.brightspace.com/123065/folders/7', editableEntity);
+
+			var assignmentEntity = new AssignmentEntity(editableEntity);
+
+			await assignmentEntity.save({
+				allowableFileType: '5',
+				customAllowableFileTypes: '.pdf,.html'
+			});
+
+			const form = await getFormData(fetchMock.lastCall().request);
+			if (!form.notSupported) {
+				expect(form.get('allowableFileType')).to.equal('5');
+				expect(form.get('customAllowableFileTypes')).to.equal('.pdf,.html');
+			}
+			expect(fetchMock.called()).to.be.true;
+		});
+
+		it('saves anonymous marking', async() => {
+			fetchMock.patchOnce('https://f5aa43d7-c082-485c-84f5-4808147fe98a.assignments.api.dev.brightspace.com/123065/folders/7', editableEntity);
+
+			var assignmentEntity = new AssignmentEntity(editableEntity);
+
+			await assignmentEntity.save({
+				isAnonymous: true
+			});
+
+			const form = await getFormData(fetchMock.lastCall().request);
+			if (!form.notSupported) {
+				expect(form.get('isAnonymous')).to.equal('true');
+			}
+			expect(fetchMock.called()).to.be.true;
+		});
+
+		it('saves default scoring rubric', async() => {
+			fetchMock.patchOnce('https://f5aa43d7-c082-485c-84f5-4808147fe98a.assignments.api.dev.brightspace.com/123065/folders/7', editableEntity);
+
+			var assignmentEntity = new AssignmentEntity(editableEntity);
+
+			await assignmentEntity.save({
+				defaultScoringRubricId: 123
+			});
+
+			const form = await getFormData(fetchMock.lastCall().request);
+			if (!form.notSupported) {
+				expect(form.get('defaultScoringRubricId')).to.equal('123');
+			}
+			expect(fetchMock.called()).to.be.true;
+		});
+
+		it('saves notification email', async() => {
+			fetchMock.patchOnce('https://f5aa43d7-c082-485c-84f5-4808147fe98a.assignments.api.dev.brightspace.com/123065/folders/7', editableEntity);
+
+			var assignmentEntity = new AssignmentEntity(editableEntity);
+
+			await assignmentEntity.save({
+				notificationEmail: 'a@a.com'
+			});
+
+			const form = await getFormData(fetchMock.lastCall().request);
+			if (!form.notSupported) {
+				expect(form.get('notificationEmail')).to.equal('a@a.com');
+			}
+			expect(fetchMock.called()).to.be.true;
+		});
+
+		it('saves completion type', async() => {
+			fetchMock.patchOnce('https://f5aa43d7-c082-485c-84f5-4808147fe98a.assignments.api.dev.brightspace.com/123065/folders/7', editableEntity);
+
+			var assignmentEntity = new AssignmentEntity(editableEntity);
+
+			await assignmentEntity.save({
+				completionType: '2'
+			});
+
+			const form = await getFormData(fetchMock.lastCall().request);
+			if (!form.notSupported) {
+				expect(form.get('completionType')).to.equal('2');
+			}
+			expect(fetchMock.called()).to.be.true;
+		});
+
+		it('saves submissions rule', async() => {
+			fetchMock.patchOnce('https://f5aa43d7-c082-485c-84f5-4808147fe98a.assignments.api.dev.brightspace.com/123065/folders/7', editableEntity);
+
+			var assignmentEntity = new AssignmentEntity(editableEntity);
+
+			await assignmentEntity.save({
+				submissionsRule: 'onlyone'
+			});
+
+			const form = await getFormData(fetchMock.lastCall().request);
+			if (!form.notSupported) {
+				expect(form.get('submissionsRule')).to.equal('onlyone');
+			}
+			expect(fetchMock.called()).to.be.true;
+		});
+
+		it('saves file submissions limit', async() => {
+			fetchMock.patchOnce('https://f5aa43d7-c082-485c-84f5-4808147fe98a.assignments.api.dev.brightspace.com/123065/folders/7', editableEntity);
+
+			var assignmentEntity = new AssignmentEntity(editableEntity);
+
+			await assignmentEntity.save({
+				filesSubmissionLimit: 'onefilepersubmission'
+			});
+
+			const form = await getFormData(fetchMock.lastCall().request);
+			if (!form.notSupported) {
+				expect(form.get('filesSubmissionLimit')).to.equal('onefilepersubmission');
+			}
+			expect(fetchMock.called()).to.be.true;
+		});
+
+		it('saves annotations', async() => {
+			fetchMock.patchOnce('https://f5aa43d7-c082-485c-84f5-4808147fe98a.assignments.api.dev.brightspace.com/123065/folders/7', editableEntity);
+
+			var assignmentEntity = new AssignmentEntity(editableEntity);
+
+			await assignmentEntity.save({
+				annotationToolsAvailable: false
+			});
+
+			const form = await getFormData(fetchMock.lastCall().request);
+			if (!form.notSupported) {
+				expect(form.get('annotationToolsAvailability')).to.equal('false');
+			}
+			expect(fetchMock.called()).to.be.true;
+		});
+
+		it('saves custom allowable file type', async() => {
+			fetchMock.patchOnce('https://f5aa43d7-c082-485c-84f5-4808147fe98a.assignments.api.dev.brightspace.com/123065/folders/7', editableEntity);
+
+			var assignmentEntity = new AssignmentEntity(editableEntity);
+
+			await assignmentEntity.save({
+				allowableFileType: '5',
+				customAllowableFileTypes: '.pdf,.html'
+			});
+
+			const form = await getFormData(fetchMock.lastCall().request);
+			if (!form.notSupported) {
+				expect(form.get('allowableFileType')).to.equal('5');
+				expect(form.get('customAllowableFileTypes')).to.equal('.pdf,.html');
+			}
+			expect(fetchMock.called()).to.be.true;
+		});
+
 		it('skips save if not dirty', async() => {
 			var assignmentEntity = new AssignmentEntity(editableEntity);
 
@@ -136,10 +300,51 @@ describe('AssignmentEntity', () => {
 
 			await assignmentEntity.save({
 				name: 'New name',
-				instructions: 'New instructions'
+				instructions: 'New instructions',
+				allowableFileType: '5',
+				customAllowableFileTypes: '.pdf,.html',
+				annotationToolsAvailable: false,
+				filesSubmissionLimit: 'onefilepersubmission',
+				submissionsRule: 'onlyone',
+				notificationEmail: 'a@a.com',
+				defaultScoringRubricId: 123,
+				isAnonymous: true,
 			});
 
 			expect(fetchMock.done());
+		});
+
+		it('combines multiple actions into a single request', async() => {
+			fetchMock.patchOnce('https://f5aa43d7-c082-485c-84f5-4808147fe98a.assignments.api.dev.brightspace.com/123065/folders/7', editableEntity);
+
+			var assignmentEntity = new AssignmentEntity(editableEntity);
+
+			await assignmentEntity.save({
+				name: 'New name',
+				instructions: 'New instructions',
+				allowableFileType: '5',
+				customAllowableFileTypes: '.pdf,.html',
+				annotationToolsAvailable: false,
+				filesSubmissionLimit: 'onefilepersubmission',
+				submissionsRule: 'onlyone',
+				notificationEmail: 'a@a.com',
+				defaultScoringRubricId: 123,
+				isAnonymous: true,
+			});
+
+			const form = await getFormData(fetchMock.lastCall().request);
+			if (!form.notSupported) {
+				expect(form.get('name')).to.equal('New name');
+				expect(form.get('instructions')).to.equal('New instructions');
+				expect(form.get('allowableFileType')).to.equal('5');
+				expect(form.get('customAllowableFileTypes')).to.equal('.pdf,.html');
+				expect(form.get('filesSubmissionLimit')).to.equal('onefilepersubmission');
+				expect(form.get('submissionsRule')).to.equal('onlyone');
+				expect(form.get('notificationEmail')).to.equal('a@a.com');
+				expect(form.get('defaultScoringRubricId')).to.equal('123');
+				expect(form.get('isAnonymous')).to.equal('true');
+			}
+			expect(fetchMock.called()).to.be.true;
 		});
 	});
 
@@ -173,13 +378,6 @@ describe('AssignmentEntity', () => {
 			var assignmentEntity = new AssignmentEntity(editableEntity);
 			expect(assignmentEntity.filesSubmissionLimit()).to.equal('unlimited');
 		});
-		it('set files per submission', async() => {
-			fetchMock.patchOnce('https://f5aa43d7-c082-485c-84f5-4808147fe98a.assignments.api.dev.brightspace.com/123065/folders/7', editableEntity);
-			var assignmentEntity = new AssignmentEntity(editableEntity);
-			await assignmentEntity.setFilesSubmissionLimit('onefilepersubmission');
-			expect(fetchMock.called()).to.be.true;
-		});
-
 	});
 
 	describe('SubmissionsRule', () => {
@@ -191,13 +389,6 @@ describe('AssignmentEntity', () => {
 			var assignmentEntity = new AssignmentEntity(editableEntity);
 			expect(assignmentEntity.submissionsRule()).to.equal('keepall');
 		});
-		it('set files per submission', async() => {
-			fetchMock.patchOnce('https://f5aa43d7-c082-485c-84f5-4808147fe98a.assignments.api.dev.brightspace.com/123065/folders/7', editableEntity);
-			var assignmentEntity = new AssignmentEntity(editableEntity);
-			await assignmentEntity.setSubmissionsRule('onlyone');
-			expect(fetchMock.called()).to.be.true;
-		});
-
 	});
 	describe('NotificationEmail', () => {
 		it('Can Edit notificaiton email', () => {
@@ -208,12 +399,5 @@ describe('AssignmentEntity', () => {
 			var assignmentEntity = new AssignmentEntity(editableEntity);
 			expect(assignmentEntity.notificationEmail()).to.equal('test@d2l.com');
 		});
-		it('set notificaiton email', async() => {
-			fetchMock.patchOnce('https://f5aa43d7-c082-485c-84f5-4808147fe98a.assignments.api.dev.brightspace.com/123065/folders/7', editableEntity);
-			var assignmentEntity = new AssignmentEntity(editableEntity);
-			await assignmentEntity.setNotificationEmail('test1@d2l.com');
-			expect(fetchMock.called()).to.be.true;
-		});
-
 	});
 });

--- a/test/activities/assignments/data/EditableAssignment.js
+++ b/test/activities/assignments/data/EditableAssignment.js
@@ -8,6 +8,69 @@ export const editableAssignment = {
 	'entities': [
 		{
 			'class': [
+				'submissions-rule'
+			],
+			'rel': [
+				'https://assignments.api.brightspace.com/rels/submissions-rule'
+			],
+			'properties': {
+				'rule': {
+					'title': 'All submissions are kept',
+					'value': 'keepall'
+				}
+			},
+			'actions': [
+				{
+					'href': 'https://f5aa43d7-c082-485c-84f5-4808147fe98a.assignments.api.dev.brightspace.com/123065/folders/7',
+					'name': 'update-submissions-rule',
+					'method': 'PATCH',
+					'fields': [
+						{
+							'type': 'radio',
+							'name': 'submissionsRule',
+							'value': [
+								{
+									'title': 'All submissions are kept',
+									'value': 'keepall',
+									'selected': true
+								},
+								{
+									'title': 'Only one submission allowed',
+									'value': 'onlyone',
+									'selected': false
+								},
+								{
+									'title': 'Only the most recent submission is kept',
+									'value': 'overwritesubmissions',
+									'selected': false
+								}
+							]
+						}
+					]
+				}
+			]
+		},
+		{
+			'rel': [
+				'https://assignments.api.brightspace.com/rels/anonymous-marking'
+			],
+			'actions': [
+				{
+					'href': 'https://f5aa43d7-c082-485c-84f5-4808147fe98a.assignments.api.dev.brightspace.com/123065/folders/7',
+					'name': 'update-anonymous-marking',
+					'method': 'PATCH',
+					'fields': [
+						{
+							'type': 'checkbox',
+							'name': 'isAnonymous',
+							'value': false
+						}
+					]
+				}
+			]
+		},
+		{
+			'class': [
 				'date',
 				'due-date'
 			],
@@ -277,6 +340,107 @@ export const editableAssignment = {
 		},
 	],
 	'actions': [
+		{
+			'href': 'https://f5aa43d7-c082-485c-84f5-4808147fe98a.assignments.api.dev.brightspace.com/123065/folders/7',
+			'name': 'update-completion-type',
+			'method': 'PATCH',
+			'fields': [
+				{
+					'type': 'radio',
+					'title': 'Completion Type',
+					'name': 'completionType',
+					'value': [
+						{
+							'title': 'Automatically on submission',
+							'value': 0,
+							'selected': true
+						},
+						{
+							'title': 'Manually by learners',
+							'value': 2,
+							'selected': false
+						},
+						{
+							'title': 'Automatically on evaluation',
+							'value': 3,
+							'selected': false
+						},
+						{
+							'title': 'Automatically on due date',
+							'value': 1,
+							'selected': false
+						}
+					]
+				}
+			]
+		},
+		{
+			'href': 'https://f5aa43d7-c082-485c-84f5-4808147fe98a.assignments.api.dev.brightspace.com/123065/folders/7',
+			'name': 'update-default-scoring-rubric',
+			'method': 'PATCH',
+			'fields': [
+				{
+					'type': 'text',
+					'name': 'defaultScoringRubricId',
+					'value': '-1'
+				}
+			]
+		},
+		{
+			'href': 'https://f5aa43d7-c082-485c-84f5-4808147fe98a.assignments.api.dev.brightspace.com/123065/folders/7',
+			'name': 'update-allowable-file-type',
+			'method': 'PATCH',
+			'fields': [
+				{
+					'type': 'radio',
+					'title': 'Allowable File Types',
+					'name': 'allowableFileType',
+					'value': [
+						{
+							'title': 'No Restrictions',
+							'value': 0,
+							'selected': true
+						},
+						{
+							'title': 'PDF Only',
+							'value': 1,
+							'selected': false
+						},
+						{
+							'title': 'Annotatable Files',
+							'value': 2,
+							'selected': false
+						},
+						{
+							'title': 'Files that can be previewed without conversion',
+							'value': 3,
+							'selected': false
+						},
+						{
+							'title': 'Images and Videos',
+							'value': 4,
+							'selected': false
+						},
+						{
+							'title': 'Custom File Types',
+							'value': 5,
+							'selected': false
+						}
+					]
+				}
+			]
+		},
+		{
+			'href': 'https://f5aa43d7-c082-485c-84f5-4808147fe98a.assignments.api.dev.brightspace.com/123065/folders/7',
+			'name': 'update-custom-allowable-file-type',
+			'method': 'PATCH',
+			'fields': [
+				{
+					'type': 'text',
+					'name': 'customAllowableFileTypes'
+				}
+			]
+		},
 		{
 			'class': [
 				'required'


### PR DESCRIPTION
https://rally1.rallydev.com/#/29180338367d/custom/486232622040?detail=%2Fdefect%2F618752964661

Apologies for the oversized PR. The root cause of this permissions check is that Assignments was implicitly depending on the `PUT` action which was designed for AF.

[We were overriding the action's method](https://github.com/BrightspaceHypermediaComponents/siren-sdk/blob/master/src/activities/assignments/AssignmentEntity.js#L896) inside `save()` which worked provided the `PUT` action was present on the assignment entity itself. 

If the `PUT` action wasn't present then [this check](https://github.com/BrightspaceHypermediaComponents/siren-sdk/blob/d9b3c85d7549997b3475fe2f6f84b1d5e6440e31/src/activities/assignments/AssignmentEntity.js#L885) failed and the save became a no-op.

The `PUT` action gets included provided a user has the `ManageDelivery` permission: 

https://github.com/Brightspace/lms/blob/master/le/dropbox/D2L.LE.Dropbox.Extensibility/HM/Folders/Serializers/Siren/SirenFoldersSerializer.cs#L530

https://github.com/Brightspace/lms/blob/master/le/dropbox/D2L.LE.Dropbox/Utilities/Access/DropboxAccessChecker.cs#L103

This fix ensures that the `save` method instead checks each update action individually and formats them into a single request. 