### PR TITLE
DE46154 Add Grade Category `maxPoints` and `autoPoints` properties & Grade Candidate `autoPoints` property

### DIFF
--- a/src/activities/GradeCandidateEntity.js
+++ b/src/activities/GradeCandidateEntity.js
@@ -25,6 +25,15 @@ export class GradeCandidateEntity extends Entity {
 			return entity.getLinkByRel(Rels.Grades.grade).href;
 		}
 	}
+	/**
+	 * @returns {bool} True if grade-candidate is `autoPoints` i.e. maxPoints are set automatically
+	 */
+	isAutoPoints() {
+		const associateGradeAction = this._entity && this._entity.getActionByName(Actions.activities.associateGrade.associateGrade);
+		if (!associateGradeAction) return false;
+		const autoPoints = associateGradeAction.getFieldByName('autoPoints');
+		return autoPoints.value;
+	}
 
 	/**
 	 * @returns {Array} Returns all grade-candidate sub-entities

--- a/src/activities/GradeCandidateEntity.js
+++ b/src/activities/GradeCandidateEntity.js
@@ -25,15 +25,6 @@ export class GradeCandidateEntity extends Entity {
 			return entity.getLinkByRel(Rels.Grades.grade).href;
 		}
 	}
-	/**
-	 * @returns {bool} True if grade-candidate is `autoPoints` i.e. maxPoints are set automatically
-	 */
-	isAutoPoints() {
-		const associateGradeAction = this._entity && this._entity.getActionByName(Actions.activities.associateGrade.associateGrade);
-		if (!associateGradeAction) return false;
-		const autoPoints = associateGradeAction.getFieldByName('autoPoints');
-		return autoPoints.value;
-	}
 
 	/**
 	 * @returns {Array} Returns all grade-candidate sub-entities

--- a/src/activities/GradeEntity.js
+++ b/src/activities/GradeEntity.js
@@ -19,6 +19,13 @@ export class GradeEntity extends Entity {
 	}
 
 	/**
+	 * @returns {bool} If Grade has auto points set by it's Grade Category
+	 */
+	autoPoints() {
+		return this._entity && this._entity.properties && this._entity.properties.autoPoints;
+	}
+
+	/**
 	 * @returns {string} Grade's max points value
 	 */
 	maxPoints() {

--- a/src/activities/ScoringEntity.js
+++ b/src/activities/ScoringEntity.js
@@ -21,6 +21,12 @@ export class ScoringEntity extends Entity {
 	}
 
 	/**
+	 * @returns {bool} Activity's grade maxPoints is set by an autoPoints (distributed points) grade category
+	 */
+	autoPoints() {
+		return this._entity && this._entity.properties && this._entity.properties.autoPoints;
+	}
+	/**
 	 * @returns {bool} Whether or not the update score out of action is present
 	 */
 	canUpdateScoring() {

--- a/src/activities/associateGrade/GradeCategoryEntity.js
+++ b/src/activities/associateGrade/GradeCategoryEntity.js
@@ -17,7 +17,7 @@ export class GradeCategoryEntity extends Entity {
 		return this._entity && this._entity.properties && this._entity.properties.autoPoints;
 	}
 	/**
-	 * @returns {number} Grade Cateogry's Max Points
+	 * @returns {number} Grade Category's Max Points
 	 * This value will be used for Grade Items that belong to the Grade Category when Auto Points is `true`
 	 */
 	maxPoints() {

--- a/src/activities/associateGrade/GradeCategoryEntity.js
+++ b/src/activities/associateGrade/GradeCategoryEntity.js
@@ -5,7 +5,7 @@ import { Entity } from '../../es6/Entity';
  */
 export class GradeCategoryEntity extends Entity {
 	/**
-	 * @returns {string} Grade Cateogry's name
+	 * @returns {string} Grade Category's name
 	 */
 	name() {
 		return this._entity && this._entity.properties && this._entity.properties.name;

--- a/src/activities/associateGrade/GradeCategoryEntity.js
+++ b/src/activities/associateGrade/GradeCategoryEntity.js
@@ -5,9 +5,22 @@ import { Entity } from '../../es6/Entity';
  */
 export class GradeCategoryEntity extends Entity {
 	/**
-	 * @returns {string} Grade cateogry's name
+	 * @returns {string} Grade Cateogry's name
 	 */
 	name() {
 		return this._entity && this._entity.properties && this._entity.properties.name;
+	}
+	/**
+	 * @returns {boolean} Is Auto Points set on the Grade Category (auto set max points for Grade items within the category)
+	 */
+	autoPoints() {
+		return this._entity && this._entity.properties && this._entity.properties.autoPoints;
+	}
+	/**
+	 * @returns {number} Grade Cateogry's Max Points
+	 * This value will be used for Grade Items that belong to the Grade Category when Auto Points is `true`
+	 */
+	maxPoints() {
+		return this._entity && this._entity.properties && this._entity.properties.maxPoints;
 	}
 }


### PR DESCRIPTION
[DE46153](https://rally1.rallydev.com/#/?detail=/defect/616899740963&fdp=true): FACE Assignment > When choose to link to existing grade item as part of grade category with distributed points, grade out of should not be editable
[DE46154](https://rally1.rallydev.com/#/?detail=/defect/616901920397&fdp=true): FACE Assignment > Updating Grade Out Of value on an assignment linked to a Grade item under grade category with distributed points, doesn't respect the distribution

https://github.com/BrightspaceHypermediaComponents/activities/pull/2248