### PR TITLE
DE46505 & DE46506 [cert] Add grade category max points and auto points properties

### DIFF
--- a/src/activities/GradeEntity.js
+++ b/src/activities/GradeEntity.js
@@ -19,6 +19,13 @@ export class GradeEntity extends Entity {
 	}
 
 	/**
+	 * @returns {bool} If Grade has auto points set by it's Grade Category
+	 */
+	autoPoints() {
+		return this._entity && this._entity.properties && this._entity.properties.autoPoints;
+	}
+
+	/**
 	 * @returns {string} Grade's max points value
 	 */
 	maxPoints() {

--- a/src/activities/ScoringEntity.js
+++ b/src/activities/ScoringEntity.js
@@ -21,6 +21,12 @@ export class ScoringEntity extends Entity {
 	}
 
 	/**
+	 * @returns {bool} Activity's grade maxPoints is set by an autoPoints (distributed points) grade category
+	 */
+	autoPoints() {
+		return this._entity && this._entity.properties && this._entity.properties.autoPoints;
+	}
+	/**
 	 * @returns {bool} Whether or not the update score out of action is present
 	 */
 	canUpdateScoring() {

--- a/src/activities/associateGrade/GradeCategoryEntity.js
+++ b/src/activities/associateGrade/GradeCategoryEntity.js
@@ -5,7 +5,7 @@ import { Entity } from '../../es6/Entity';
  */
 export class GradeCategoryEntity extends Entity {
 	/**
-	 * @returns {string} Grade Cateogry's name
+	 * @returns {string} Grade Category's name
 	 */
 	name() {
 		return this._entity && this._entity.properties && this._entity.properties.name;
@@ -17,7 +17,7 @@ export class GradeCategoryEntity extends Entity {
 		return this._entity && this._entity.properties && this._entity.properties.autoPoints;
 	}
 	/**
-	 * @returns {number} Grade Cateogry's Max Points
+	 * @returns {number} Grade Category's Max Points
 	 * This value will be used for Grade Items that belong to the Grade Category when Auto Points is `true`
 	 */
 	maxPoints() {

--- a/src/activities/associateGrade/GradeCategoryEntity.js
+++ b/src/activities/associateGrade/GradeCategoryEntity.js
@@ -5,9 +5,22 @@ import { Entity } from '../../es6/Entity';
  */
 export class GradeCategoryEntity extends Entity {
 	/**
-	 * @returns {string} Grade cateogry's name
+	 * @returns {string} Grade Cateogry's name
 	 */
 	name() {
 		return this._entity && this._entity.properties && this._entity.properties.name;
+	}
+	/**
+	 * @returns {boolean} Is Auto Points set on the Grade Category (auto set max points for Grade items within the category)
+	 */
+	autoPoints() {
+		return this._entity && this._entity.properties && this._entity.properties.autoPoints;
+	}
+	/**
+	 * @returns {number} Grade Cateogry's Max Points
+	 * This value will be used for Grade Items that belong to the Grade Category when Auto Points is `true`
+	 */
+	maxPoints() {
+		return this._entity && this._entity.properties && this._entity.properties.maxPoints;
 	}
 }


### PR DESCRIPTION
[DE46505](https://rally1.rallydev.com/#/?detail=/defect/620536749613&fdp=true): [cert] FACE Assignment > Updating Grade Out Of value on an assignment linked to a Grade item under grade category with distributed points, doesn't respect the distribution

[DE46506](https://rally1.rallydev.com/#/?detail=/defect/620536751567&fdp=true): [cert] Assignment > When choose to link to existing grade item as part of grade category with distributed points, grade out of should not be editable

Backport of:
https://github.com/BrightspaceHypermediaComponents/siren-sdk/pull/438