### PR TITLE
US131809: FACE LOR Links - Display embedded view of object on FACE page

### DIFF
--- a/src/activities/content/ContentLorActivityEntity.js
+++ b/src/activities/content/ContentLorActivityEntity.js
@@ -31,6 +31,13 @@ export class ContentLorActivityEntity extends ContentEntity {
 	}
 
 	/**
+	 * @returns {boolean} Whether or not the LOR object can be embedded or not (in iframe for previewing)
+	 */
+	canEmbed() {
+		return this._entity && this._entity.properties && this._entity.properties.canEmbed;
+	}
+
+	/**
 	 * @returns {string|undefined} The name of the LOR document
 	 */
 	documentName() {

--- a/src/activities/content/ContentLorActivityEntity.js
+++ b/src/activities/content/ContentLorActivityEntity.js
@@ -21,6 +21,13 @@ export class ContentLorActivityEntity extends ContentEntity {
 	}
 
 	/**
+	 * @returns {string|undefined} The url to embed the LOR object
+	 */
+	embedUrl() {
+		return this._entity && this._entity.properties && this._entity.properties.embedUrl;
+	}
+
+	/**
 	 * @returns {boolean} external resource value (i.e. open in new tab or not)
 	 */
 	isExternalResource() {


### PR DESCRIPTION
## Relevant Rally Links

https://rally1.rallydev.com/#/289692574792d/custom/355050439968?detail=%2Fuserstory%2F609370119907

## Description

This PR adds the `canEmbed` and `embedUrl` properties that the B/E adds (see below PR)

## Related PRs

- LMS: https://github.com/Brightspace/lms/pull/17413
- Activities: https://github.com/BrightspaceHypermediaComponents/activities/pull/2268
