### PR TITLE
DE46589: Get LOR embedUrl from link instead of property

### DIFF
--- a/src/activities/content/ContentLorActivityEntity.js
+++ b/src/activities/content/ContentLorActivityEntity.js
@@ -1,7 +1,6 @@
 import { Actions, Classes } from '../../hypermedia-constants';
 import { performSirenAction } from '../../es6/SirenAction';
 import { ContentEntity } from './ContentEntity';
-
 /**
  * ContentlorActivityEntity class representation of a d2l content-lor-package entity.
  */

--- a/src/activities/content/ContentLorActivityEntity.js
+++ b/src/activities/content/ContentLorActivityEntity.js
@@ -1,6 +1,7 @@
 import { Actions, Classes } from '../../hypermedia-constants';
 import { performSirenAction } from '../../es6/SirenAction';
 import { ContentEntity } from './ContentEntity';
+
 /**
  * ContentlorActivityEntity class representation of a d2l content-lor-package entity.
  */
@@ -24,7 +25,7 @@ export class ContentLorActivityEntity extends ContentEntity {
 	 * @returns {string|undefined} The url to embed the LOR object
 	 */
 	embedUrl() {
-		return this._entity && this._entity.properties && this._entity.properties.embedUrl;
+		return this._entity.hasLinkByRel('alternate') && this._entity.getLinkByRel('alternate').href;
 	}
 
 	/**


### PR DESCRIPTION
## Relevant Rally
- [DE46589](https://rally1.rallydev.com/#/?detail=/defect/620905741399&fdp=true): US131809 Follow-up: LMS & SIren-SDK - Change properties to be links

## Description
To better follow the Siren spec, the LOR embedUrl was moved the an `alternate` link instead of a property.

## Related PRs
1. LMS: https://github.com/Brightspace/lms/pull/17670