### PR TITLE
US134138: SCORM - Push Existing Scores to new Grade Checkbox Displays if New Grade is selected

### DIFF
--- a/src/activities/associateGrade/AssociateGradeEntity.js
+++ b/src/activities/associateGrade/AssociateGradeEntity.js
@@ -12,6 +12,7 @@ const GRADEBOOK_STATUS = 'gradebookStatus';
 const GRADE_NAME = 'gradeName';
 const MAX_POINTS = 'maxPoints';
 const GRADE_TYPE = 'gradeType';
+const PUSH_SCORE = 'pushScoresToGrade';
 
 export const GradebookStatus = Object.freeze({
 	NotInGradebook: 'not-in-gradebook',
@@ -199,6 +200,10 @@ export class AssociateGradeEntity extends Entity {
 
 	setGradeType(gradeType) {
 		return this._setNewGradeProperty(GRADE_TYPE, gradeType);
+	}
+
+	setPushScoreToGrade(pushScore) {
+		return this._setNewGradeProperty(PUSH_SCORE, pushScore);
 	}
 
 	_getNewGradeEntity() {


### PR DESCRIPTION
### Relevant Rally

[US134138: SCORM - Push Existing Scores to new Grade Checkbox Displays if New Grade is selected](https://rally1.rallydev.com/#/289692574792d/custom/355050439968?detail=%2Fuserstory%2F618459351439&fdp=true)

[US134750: SCORM - Push Existing Scores to new Grade Item does the action](https://rally1.rallydev.com/#/289692574792d/custom/355050439968?detail=%2Fuserstory%2F620808787711&fdp=true)


### Video/Screenshots

#### Score Out Of

See various scenarios tested below:

![Imported SCORM Score Out Of](https://user-images.githubusercontent.com/89945180/150857568-1c8c05ad-1f13-46ef-a389-34b106737bc7.gif)

Note that the missing embedded preview is a separate defect and out of scope for this PR.

#### Push Scores to Grades

Diligent user **Studi McStudentface** scored 100% on an imported SCORM topic while it was associated with grade item NC2:

![Before Pushing](https://user-images.githubusercontent.com/89945180/150857619-d109c3f4-4186-455d-ba7e-487a004857f5.PNG)

After said topic had its grade association switched to grade item NC1 with the "Push All Existing Scores to Grades" checkbox ticked, Studi's completion was correctly moved from NC2 to NC1:

![After Pushing](https://user-images.githubusercontent.com/89945180/150857632-a3fe3a82-d16a-4e58-a37f-4ab9620650e7.PNG)


### Description

Updated the AssociateGradeEntity to include an update on the `pushScoresToGrade` member