### PR TITLE
Create new end of sequence entity

### DIFF
--- a/src/sequences/EndOfSequenceEntity.js
+++ b/src/sequences/EndOfSequenceEntity.js
@@ -1,0 +1,12 @@
+import { Entity } from '../es6/Entity';
+
+export class EndOfSequenceActivityEntity extends Entity {
+	endOfSequenceSummaryProperties() {
+		if (!this._entity) {
+			return {};
+		}
+
+		const summaryEntity = this._entity.getSubEntityByRel('end-of-sequence-summary');
+		return summaryEntity.properties || {};
+	}
+}

--- a/src/sequences/EndOfSequenceEntity.js
+++ b/src/sequences/EndOfSequenceEntity.js
@@ -1,6 +1,9 @@
 import { Entity } from '../es6/Entity';
 
 export class EndOfSequenceActivityEntity extends Entity {
+	/**
+	 * @return An object with numeric values: optional, required
+	 */
 	endOfSequenceSummaryProperties() {
 		if (!this._entity) {
 			return {};


### PR DESCRIPTION
Creates a new representation for the Sequence's End of Sequence Entity. Right now the only thing we need to get from it is the properties from the summary subentity. More stuff can be added to it as it is needed.

https://rally1.rallydev.com/#/289692574792d/custom/355050439968?detail=%2Fuserstory%2F622544965323&fdp=true

related sequences pr: https://github.com/BrightspaceHypermediaComponents/sequences/pull/382