### PR TITLE
BREAKING CHANGE: bump dependencies to lit 2 versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "devDependencies": {
     "@babel/polyfill": "^7.0.0",
-    "@open-wc/testing": "^2.3.4",
+    "@open-wc/testing": "^3",
     "@polymer/iron-component-page": "^3.0.0-pre.18",
     "@polymer/iron-demo-helpers": "^3.0.0-pre.18",
     "@polymer/iron-test-helpers": "^3.0.0",
@@ -36,7 +36,7 @@
     "fetch-mock": "^8.3.2",
     "jsdoc": "^3.5.5",
     "lie": "^3.3.0",
-    "lit-element": "^2",
+    "lit-element": "^3",
     "mocha": "^7.0.1",
     "polymer-cli": "^1.9.1",
     "sinon": "^7.5.0",


### PR DESCRIPTION
Since Lit is just a devdependency and only used in tests, this should have no effect on the code. 
The Lit 2 upgrade will be a coordinated effort, so **this PR should not merge at this time**.