### PR TITLE
feat: Added canEditAvailabilityDates method

### DIFF
--- a/src/activities/ActivityUsageEntity.js
+++ b/src/activities/ActivityUsageEntity.js
@@ -269,6 +269,22 @@ export class ActivityUsageEntity extends Entity {
 	}
 
 	/**
+	 * @returns {bool} Whether or not the ActivityAvailabilityDates create action is present
+	 */
+	canEditAvailabilityDates() {
+		const dateEntity = this._getSubEntityByClass(Classes.availabilityDates.availabilityDates);
+		if (!dateEntity) {
+			return false;
+		}
+
+		const action = dateEntity.getActionByName(Actions.activities.availabilityDates.create);
+		if (action) {
+			return true;
+		}
+
+		return false;
+	}
+	/**
 	   * Updates the start date of the activity usage entity to the date specified
 	 * @param {string} dateValue Date string to set as the start date, or empty string to clear the start date
 	 */


### PR DESCRIPTION
This PR adds a check for the create action on the ActivityAvailabilityDates. We will use this to determine if a user can edit dates in the UI.

## Previous PR
1. https://github.com/BrightspaceHypermediaComponents/siren-sdk/pull/453

## Rally Story
https://rally1.rallydev.com/#/?detail=/userstory/623042532951&fdp=true