### PR TITLE
US136096 - adding ActivityEvaluationStatusEntity and tests

### DIFF
--- a/src/activities/ActivityEvaluationStatusEntity.js
+++ b/src/activities/ActivityEvaluationStatusEntity.js
@@ -1,0 +1,90 @@
+import { Entity } from '../es6/Entity.js';
+import { Rels } from '../hypermedia-constants';
+
+const supportedActivityTypes = [
+	'assignment',
+	'topic',
+	'quiz',
+];
+
+export class ActivityEvaluationStatusEntity extends Entity {
+	/**
+	 * @return {string|null} The activity type or null if the entity doesn't not have an expected class.
+	 */
+	getActivityType() {
+		if (this._entity) {
+			for (const hmClass of supportedActivityTypes) {
+				if (this._entity.hasClass(hmClass)) {
+					return hmClass;
+				}
+			}
+		}
+		return null;
+	}
+
+	/**
+	 * @returns {int|null} The number of assignments of this activity
+	 */
+	numAssigned() {
+		return this._entity ? Number(this._entity.properties.assigned) : null;
+	}
+
+	/**
+	 * @returns {int|null} The number of completions of this activity
+	 */
+	numCompleted() {
+		return this._entity ? Number(this._entity.properties.completed) : null;
+	}
+
+	/**
+	 * @returns {int|null} The number of evaluations of this activity
+	 */
+	numEvaluated() {
+		return this._entity ? Number(this._entity.properties.evaluated) : null;
+	}
+
+	/**
+	 * @returns {int|null} The number of published evaluations of this activity
+	 */
+	numPublished() {
+		return this._entity ? Number(this._entity.properties.published) : null;
+	}
+
+	/**
+	 * @returns {int|null} The number of new submissions of this activity
+	 */
+	numNewSubmissions() {
+		return this._entity ? Number(this._entity.properties.newsubmissions) : null;
+	}
+
+	/**
+	 * @returns {int|null} The number of resubmissions of this activity
+	 */
+	numResubmissions() {
+		return this._entity ? Number(this._entity.properties.resubmissions) : null;
+	}
+
+	/**
+	 * @returns {string|null} The path to the assessment application, for all assessments
+	 */
+	assesAllApplication() {
+		const entity = this._entity.getSubEntityByRel(Rels.Assessments.assessAllApplication);
+		return entity ? entity.properties.path : null;
+	}
+
+	/**
+	 * @returns {string|null} The path to the assessment application, for new assessments
+	 */
+	assessNewApplication() {
+		const entity = this._entity.getSubEntityByRel(Rels.Assessments.assessNewApplication);
+		return entity ? entity.properties.path : null;
+	}
+
+	/**
+	 * @returns {string|null} The path to the submission application
+	 */
+	submissionApplication() {
+		const entity = this._entity.getSubEntityByRel(Rels.Assessments.submissionApplication);
+		return entity ? entity.properties.path : null;
+	}
+}

--- a/src/hypermedia-constants.js
+++ b/src/hypermedia-constants.js
@@ -84,7 +84,10 @@ export const Rels = {
 	},
 	// Assessments
 	Assessments: {
-		assessmentApplication: 'https://assessments.api.brightspace.com/rels/assessment-application'
+		assessmentApplication: 'https://assessments.api.brightspace.com/rels/assessment-application',
+		assessAllApplication: 'https://assessments.api.brightspace.com/rels/assess-all-application',
+		assessNewApplication: 'https://assessments.api.brightspace.com/rels/assess-new-application',
+		submissionApplication: 'https://assessments.api.brightspace.com/rels/submission-application'
 	},
 	// Assignments
 	Assignments: {

--- a/test/activities/ActivityEvaluationStatusEntity.html
+++ b/test/activities/ActivityEvaluationStatusEntity.html
@@ -1,0 +1,19 @@
+<html>
+	<head>
+		<meta charset="utf-8">
+		<meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
+		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
+		<script src="/node_modules/mocha/mocha.js"></script>
+		<script src="/node_modules/chai/chai.js"></script>
+		<script src="/node_modules/@polymer/test-fixture/test-fixture.js"></script>
+		<script src="/node_modules/wct-mocha/wct-mocha.js"></script>
+		<script src="/node_modules/sinon/pkg/sinon.js"></script>
+
+		<script type="module" src="../../../siren-parser/global.js"></script>
+		<script type="module" src="../../src/activities/ActivityEvaluationStatusEntity.js"></script>
+	</head>
+
+	<body>
+		<script type="module" src="./ActivtiyEvaluationStatusEntity.js"></script>
+	</body>
+</html>

--- a/test/activities/ActivityEvaluationStatusEntity.js
+++ b/test/activities/ActivityEvaluationStatusEntity.js
@@ -1,0 +1,81 @@
+import { ActivityEvaluationStatusEntity } from '../../src/activities/ActivityEvaluationStatusEntity.js';
+import { testData } from './data/ActivityEvaluationentity.js';
+
+describe('ActivityEvaluationStatusEntity', () => {
+	let entity;
+
+	beforeEach(() => {
+		const entityJson = window.D2L.Hypermedia.Siren.Parse(testData.assignmentStatusEntity);
+		entity = new ActivityEvaluationStatusEntity(entityJson);
+	});
+
+	describe('Loads all properties', () => {
+		it('can get num assigned', () => {
+			expect(entity.numAssigned()).to.equal(30);
+		});
+
+		it('can get num completed', () => {
+			expect(entity.numCompleted()).to.equal(15);
+		});
+
+		it('can get num evaluated', () => {
+			expect(entity.numEvaluated()).to.equal(10);
+		});
+
+		it('can get num published', () => {
+			expect(entity.numPublished()).to.equal(5);
+		});
+
+		it('can get num newSubmissions', () => {
+			expect(entity.numNewSubmissions()).to.equal(1);
+		});
+
+		it('can get num resubmissions', () => {
+			expect(entity.numResubmissions()).to.equal(2);
+		});
+	});
+
+	describe('Loads all sub entities', () => {
+		it('can get assess all application href', () => {
+			expect(entity.assessAllApplication()).to.equal('assess-all');
+		});
+
+		it('can get assess new application href', () => {
+			expect(entity.assessNewApplication()).to.equal('assess-new');
+		});
+
+		it('can get assess all application href', () => {
+			expect(entity.submissionApplication()).to.equal('submission');
+		});
+	});
+
+	describe('Loads the correct activity types', () => {
+		it('can get assignment activity type', () => {
+			const entityJson = window.D2L.Hypermedia.Siren.Parse(testData.assignmentStatusEntity);
+			entity = new ActivityEvaluationStatusEntity(entityJson);
+
+			expect(entity.getActivityType()).to.equal('assignment');
+		});
+
+		it('can get quiz activity type', () => {
+			const entityJson = window.D2L.Hypermedia.Siren.Parse(testData.quizStatusEntity);
+			entity = new ActivityEvaluationStatusEntity(entityJson);
+
+			expect(entity.getActivityType()).to.equal('quiz');
+		});
+
+		it('can get discussion topic activity type', () => {
+			const entityJson = window.D2L.Hypermedia.Siren.Parse(testData.discussionTopicEntity);
+			entity = new ActivityEvaluationStatusEntity(entityJson);
+
+			expect(entity.getActivityType()).to.equal('topic');
+		});
+
+		it('returns null when unable to find activity type', () => {
+			const entityJson = window.D2L.Hypermedia.Siren.Parse(testData.unexpectedStatusEntity);
+			entity = new ActivityEvaluationStatusEntity(entityJson);
+
+			expect(entity.getActivityType()).to.be.null;
+		});
+	});
+});

--- a/test/activities/data/ActivityEvaluationEntity.js
+++ b/test/activities/data/ActivityEvaluationEntity.js
@@ -1,0 +1,89 @@
+export const testData = {
+	assignmentStatusEntity: {
+		'class': [
+			'assignment',
+			'evaluation-status'
+		],
+		'properties': {
+			'assigned': 30,
+			'completed': 15,
+			'evaluated': 10,
+			'published': 5,
+			'newsubmissions': 1,
+			'resubmissions': 2
+		},
+		'entities': [
+			{
+				'class': [
+					'relative-uri'
+				],
+				'rel': [
+					'item',
+					'https://assessments.api.brightspace.com/rels/submission-application'
+				],
+				'properties': {
+					'path': 'submission'
+				}
+			},
+			{
+				'class': [
+					'relative-uri'
+				],
+				'rel': [
+					'item',
+					'https://assessments.api.brightspace.com/rels/assess-all-application'
+				],
+				'properties': {
+					'path': 'assess-all'
+				}
+			},
+			{
+				'class': [
+					'relative-uri'
+				],
+				'rel': [
+					'item',
+					'https://assessments.api.brightspace.com/rels/assess-new-application'
+				],
+				'properties': {
+					'path': 'asses-new'
+				}
+			}
+		],
+		'links': [
+			{
+				'rel': [
+					'https://activities.api.brightspace.com/rels/evaluation-status'
+				],
+				'href': 'https://2864b37c-fb9f-4b5b-ae27-897885ef47ce.activities.api.proddev.d2l/activities/6606_2000_3/usages/6613/evaluation-status'
+			},
+			{
+				'rel': [
+					'https://activities.api.brightspace.com/rels/activity-usage'
+				],
+				'href': 'https://2864b37c-fb9f-4b5b-ae27-897885ef47ce.activities.api.proddev.d2l/activities/6606_2000_3/usages/6613'
+			},
+			{
+				'rel': [
+					'assignment'
+				],
+				'href': 'https://2864b37c-fb9f-4b5b-ae27-897885ef47ce.assignments.api.proddev.d2l/6613/folders/3'
+			}
+		],
+		'rel': [
+			'https://assignments.api.brightspace.com/rels/evaluation-status'
+		]
+	},
+	quizStatusEntity: {
+		class: [ 'quiz', 'evaluation-status' ],
+		...testData.assignmentStatusEntity
+	},
+	discussionTopicStatusEntity: {
+		class: [ 'topic', 'evaluation-status' ],
+		...testData.assignmentStatusEntity
+	},
+	unexpectedStatusEntity: {
+		class: [ 'unexpectedActivityTypeClass', 'evaluation-status' ],
+		...testData.assignmentStatusEntity
+	}
+};


### PR DESCRIPTION
[US136096](https://rally1.rallydev.com/#/?detail=/userstory/626871691749&fdp=true): [UCE] existing completion summary api data source

Adding the `ActivityEvaluationStatusEntity` to be used in the activities repo for the new completion summary component.