### PR TITLE
DE47321: Add embedUrl to imported SCORM entity

### DIFF
--- a/src/activities/content/ContentImportedScormActivityEntity.js
+++ b/src/activities/content/ContentImportedScormActivityEntity.js
@@ -32,6 +32,13 @@ export class ContentImportedScormActivityEntity extends ContentEntity {
 	}
 
 	/**
+	 * @returns {string|undefined} The url to embed the scorm activity
+	 */
+	embedUrl() {
+		return this._entity && this._entity.hasLinkByRel('alternate') && this._entity.getLinkByRel('alternate').href;
+	}
+
+	/**
 	 * Updates the SCORM activty to have the given title
 	 * @param {string} title Title to set on the SCORM activity
 	 */


### PR DESCRIPTION
## Relevant Rally Links

- [DE47321](https://rally1.rallydev.com/#/289692574792/custom/355050439968?detail=%2Fdefect%2F627185737859&fdp=true): Imported SCORM > Embedded preview does not show package on some objects

## Description

This PR adds a method for retrieving the alternate link from the imported SCORM siren response to be used in the embedded previews . 

## Goal/Solution

Successfully preview embedded imported SCORM topics on our FACE pages.

## Related PRs

- https://github.com/Brightspace/lms/pull/19646
- https://github.com/BrightspaceHypermediaComponents/activities/pull/2412