### PR TITLE
DE47484 Lessons > SCORM FACE > Hide push to grades checkbox

### DIFF
--- a/src/activities/content/ContentImportedScormActivityEntity.js
+++ b/src/activities/content/ContentImportedScormActivityEntity.js
@@ -34,7 +34,7 @@ export class ContentImportedScormActivityEntity extends ContentEntity {
 	/**
 	 * @returns {boolean} Whether or not the Push-Scores-to-Grades checkbox is enabled
 	 */
-	 isGradeSyncCheckboxFeatureEnabled() {
+	isGradeSyncCheckboxFeatureEnabled() {
 		return this._entity && this._entity.properties && this._entity.properties.isGradeSyncCheckboxFeatureEnabled;
 	}
 

--- a/src/activities/content/ContentImportedScormActivityEntity.js
+++ b/src/activities/content/ContentImportedScormActivityEntity.js
@@ -32,6 +32,13 @@ export class ContentImportedScormActivityEntity extends ContentEntity {
 	}
 
 	/**
+	 * @returns {boolean} Whether or not the Push-Scores-to-Grades checkbox is enabled
+	 */
+	 isGradeSyncCheckboxFeatureEnabled() {
+		return this._entity && this._entity.properties && this._entity.properties.isGradeSyncCheckboxFeatureEnabled;
+	}
+
+	/**
 	 * Updates the SCORM activty to have the given title
 	 * @param {string} title Title to set on the SCORM activity
 	 */


### PR DESCRIPTION
## Relevant Rally Links

* https://rally1.rallydev.com/#/289692574792ud/custom/355050439968?Iteration=u&Release=u&c_UXDevKanbanStates=Defined&cpoid=289692574792&detail=%2Fdefect%2F627957174891&rankScope=BACKLOG&typeDef=7362609627
* https://rally1.rallydev.com/#/289692574792ud/custom/355050439968?detail=%2Fuserstory%2F627958967051

## Description/Solution

Adding a new feature flag, `content-scorm-grade-sync-checkbox` to hide the push-scores-to-grades checkbox on the FACE page.  This affects imported SCORM and can be copied to LOR SCORM as well.

## Related Pull Reqests

* LD: https://github.com/Brightspace/lms-launch-darkly-flags/pull/3874
* LMS: https://github.com/Brightspace/lms/pull/19755
* Activities: https://github.com/BrightspaceHypermediaComponents/activities/pull/2422