### PR TITLE
DE44379: Add prop hasLorInfo to ContentLorActivityEntity

### DIFF
--- a/src/activities/content/ContentLorActivityEntity.js
+++ b/src/activities/content/ContentLorActivityEntity.js
@@ -94,6 +94,16 @@ export class ContentLorActivityEntity extends ContentEntity {
 	}
 
 	/**
+	 * This was added to address LOR objects that are in a course but belong to a LOR on another instance.
+	 * This means the LOR info will not be able to be found by the serializer, and the page needs to handle
+	 * all the missing info.
+	 * @returns {boolean} Whether or not the LOR object was found
+	 */
+	hasLorInfo() {
+		return this._entity && this._entity.properties && this._entity.properties.hasLorInfo;
+	}
+
+	/**
 	 * Updates the LOR activty to have the given title
 	 * @param {string} title Title to set on the LOR activity
 	 */


### PR DESCRIPTION
## Relevant Rally
- [DE44379](https://rally1.rallydev.com/#/?detail=/defect/603904583187&fdp=true): Lessons > 20.21.7.30945 > Modified title to a weblink ends on a content link broken

## Related PRs
- LMS: https://github.com/Brightspace/lms/pull/19945
- Activities: https://github.com/BrightspaceHypermediaComponents/activities/pull/2431