### PR TITLE
fix: Fix sauce runner build name and cleanup dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,18 +20,15 @@
   "dependencies": {
     "@brightspace-ui/core": "^2",
     "@polymer/polymer": "^3.0.0",
+    "d2l-fetch": "Brightspace/d2l-fetch.git#semver:^2",
     "d2l-polymer-siren-behaviors": "Brightspace/polymer-siren-behaviors#semver:^1"
   },
   "devDependencies": {
     "@babel/polyfill": "^7.0.0",
     "@open-wc/testing": "^3",
-    "@polymer/iron-component-page": "^3.0.0-pre.18",
-    "@polymer/iron-demo-helpers": "^3.0.0-pre.18",
-    "@polymer/iron-test-helpers": "^3.0.0",
     "@polymer/polymer": "^3.0.0",
     "@polymer/test-fixture": "^4.0.2",
     "@web/test-runner": "^0.13",
-    "@webcomponents/webcomponentsjs": "^2.2.1",
     "babel-eslint": "^10.0.1",
     "chai": "^4.2.0",
     "eslint": "^4.15.0",
@@ -39,13 +36,10 @@
     "eslint-plugin-html": "^4.0.1",
     "fetch-mock": "^8.3.2",
     "jsdoc": "^3.5.5",
-    "lie": "^3.3.0",
     "lit-element": "^3",
     "mocha": "^7.0.1",
     "polymer-cli": "^1.9.1",
     "sinon": "^13",
-    "wct-mocha": "^1.0.1",
-    "whatwg-fetch": "^2.0.0",
-    "d2l-fetch": "Brightspace/d2l-fetch.git#semver:^2"
+    "wct-mocha": "^1.0.1"
   }
 }

--- a/test/AlertsEntity/AlertsEntity.html
+++ b/test/AlertsEntity/AlertsEntity.html
@@ -2,7 +2,6 @@
 	<head>
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script src="/node_modules/mocha/mocha.js"></script>
 		<script src="/node_modules/chai/chai.js"></script>
 		<script src="/node_modules/@polymer/test-fixture/test-fixture.js"></script>

--- a/test/EnrollmentEntity/EnrollmentEntity.html
+++ b/test/EnrollmentEntity/EnrollmentEntity.html
@@ -2,7 +2,6 @@
 	<head>
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script src="/node_modules/mocha/mocha.js"></script>
 		<script src="/node_modules/chai/chai.js"></script>
 		<script src="/node_modules/@polymer/test-fixture/test-fixture.js"></script>

--- a/test/PromotedSearchEntity/PromotedSearchEntity.html
+++ b/test/PromotedSearchEntity/PromotedSearchEntity.html
@@ -2,7 +2,6 @@
 	<head>
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script src="/node_modules/mocha/mocha.js"></script>
 		<script src="/node_modules/chai/chai.js"></script>
 		<script src="/node_modules/@polymer/test-fixture/test-fixture.js"></script>

--- a/test/SequenceEntity/SequenceEntity.html
+++ b/test/SequenceEntity/SequenceEntity.html
@@ -2,7 +2,6 @@
 	<head>
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script src="/node_modules/mocha/mocha.js"></script>
 		<script src="/node_modules/chai/chai.js"></script>
 		<script src="/node_modules/@polymer/test-fixture/test-fixture.js"></script>

--- a/test/UserActivityUsageEntity/UserActivityUsageEntity.html
+++ b/test/UserActivityUsageEntity/UserActivityUsageEntity.html
@@ -2,7 +2,6 @@
 	<head>
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script src="/node_modules/mocha/mocha.js"></script>
 		<script src="/node_modules/chai/chai.js"></script>
 		<script src="/node_modules/@polymer/test-fixture/test-fixture.js"></script>

--- a/test/UserSettingsEntity/UserSettingsEntity.html
+++ b/test/UserSettingsEntity/UserSettingsEntity.html
@@ -2,7 +2,6 @@
 	<head>
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script src="/node_modules/mocha/mocha.js"></script>
 		<script src="/node_modules/chai/chai.js"></script>
 		<script src="/node_modules/@polymer/test-fixture/test-fixture.js"></script>

--- a/test/activities/ActivityEvaluationStatusEntity.html
+++ b/test/activities/ActivityEvaluationStatusEntity.html
@@ -2,7 +2,6 @@
 	<head>
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script src="/node_modules/mocha/mocha.js"></script>
 		<script src="/node_modules/chai/chai.js"></script>
 		<script src="/node_modules/@polymer/test-fixture/test-fixture.js"></script>

--- a/test/activities/ActivityGradeEntity.html
+++ b/test/activities/ActivityGradeEntity.html
@@ -2,7 +2,6 @@
 	<head>
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script src="/node_modules/mocha/mocha.js"></script>
 		<script src="/node_modules/chai/chai.js"></script>
 		<script src="/node_modules/@polymer/test-fixture/test-fixture.js"></script>

--- a/test/activities/ActivitySpecialAccessEntity.html
+++ b/test/activities/ActivitySpecialAccessEntity.html
@@ -2,7 +2,6 @@
 	<head>
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script src="/node_modules/mocha/mocha.js"></script>
 		<script src="/node_modules/chai/chai.js"></script>
 		<script src="/node_modules/@polymer/test-fixture/test-fixture.js"></script>

--- a/test/activities/ActivityUsageCollectionEntity.html
+++ b/test/activities/ActivityUsageCollectionEntity.html
@@ -2,7 +2,6 @@
 	<head>
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes" />
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script src="/node_modules/mocha/mocha.js"></script>
 		<script src="/node_modules/chai/chai.js"></script>
 		<script src="/node_modules/@polymer/test-fixture/test-fixture.js"></script>

--- a/test/activities/ActivityUsageEntity.html
+++ b/test/activities/ActivityUsageEntity.html
@@ -2,7 +2,6 @@
 	<head>
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script src="/node_modules/mocha/mocha.js"></script>
 		<script src="/node_modules/chai/chai.js"></script>
 		<script src="/node_modules/@polymer/test-fixture/test-fixture.js"></script>

--- a/test/activities/CategoriesEntity.html
+++ b/test/activities/CategoriesEntity.html
@@ -2,7 +2,6 @@
 	<head>
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script src="/node_modules/mocha/mocha.js"></script>
 		<script src="/node_modules/chai/chai.js"></script>
 		<script src="/node_modules/@polymer/test-fixture/test-fixture.js"></script>

--- a/test/activities/GradeCandidateCollectionEntity.html
+++ b/test/activities/GradeCandidateCollectionEntity.html
@@ -2,7 +2,6 @@
 	<head>
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script src="/node_modules/mocha/mocha.js"></script>
 		<script src="/node_modules/chai/chai.js"></script>
 		<script src="/node_modules/@polymer/test-fixture/test-fixture.js"></script>

--- a/test/activities/GradeCandidateEntity.html
+++ b/test/activities/GradeCandidateEntity.html
@@ -2,7 +2,6 @@
 	<head>
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script src="/node_modules/mocha/mocha.js"></script>
 		<script src="/node_modules/chai/chai.js"></script>
 		<script src="/node_modules/@polymer/test-fixture/test-fixture.js"></script>

--- a/test/activities/GradeEntity.html
+++ b/test/activities/GradeEntity.html
@@ -2,7 +2,6 @@
 	<head>
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script src="/node_modules/mocha/mocha.js"></script>
 		<script src="/node_modules/chai/chai.js"></script>
 		<script src="/node_modules/@polymer/test-fixture/test-fixture.js"></script>

--- a/test/activities/ScoringEntity.html
+++ b/test/activities/ScoringEntity.html
@@ -2,7 +2,6 @@
 	<head>
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script src="/node_modules/mocha/mocha.js"></script>
 		<script src="/node_modules/chai/chai.js"></script>
 		<script src="/node_modules/@polymer/test-fixture/test-fixture.js"></script>

--- a/test/activities/assignments/AssignmentActivityUsageEntity.html
+++ b/test/activities/assignments/AssignmentActivityUsageEntity.html
@@ -2,7 +2,6 @@
 	<head>
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script src="/node_modules/mocha/mocha.js"></script>
 		<script src="/node_modules/chai/chai.js"></script>
 		<script src="/node_modules/@polymer/test-fixture/test-fixture.js"></script>

--- a/test/activities/assignments/AssignmentEntity.html
+++ b/test/activities/assignments/AssignmentEntity.html
@@ -2,7 +2,6 @@
 	<head>
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script src="/node_modules/mocha/mocha.js"></script>
 		<script src="/node_modules/chai/chai.js"></script>
 		<script src="/node_modules/@polymer/test-fixture/test-fixture.js"></script>

--- a/test/activities/associateGrade/AssociateGradeEntity.html
+++ b/test/activities/associateGrade/AssociateGradeEntity.html
@@ -2,7 +2,6 @@
 	<head>
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script src="/node_modules/mocha/mocha.js"></script>
 		<script src="/node_modules/chai/chai.js"></script>
 		<script src="/node_modules/@polymer/test-fixture/test-fixture.js"></script>

--- a/test/activities/associateGrade/GradeCategoryCollectionEntity.html
+++ b/test/activities/associateGrade/GradeCategoryCollectionEntity.html
@@ -2,7 +2,6 @@
 	<head>
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script src="/node_modules/mocha/mocha.js"></script>
 		<script src="/node_modules/chai/chai.js"></script>
 		<script src="/node_modules/@polymer/test-fixture/test-fixture.js"></script>

--- a/test/activities/associateGrade/GradeCategoryEntity.html
+++ b/test/activities/associateGrade/GradeCategoryEntity.html
@@ -2,7 +2,6 @@
 	<head>
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script src="/node_modules/mocha/mocha.js"></script>
 		<script src="/node_modules/chai/chai.js"></script>
 		<script src="/node_modules/@polymer/test-fixture/test-fixture.js"></script>

--- a/test/activities/associateGrade/GradeCategoryLinkedEntity.html
+++ b/test/activities/associateGrade/GradeCategoryLinkedEntity.html
@@ -2,7 +2,6 @@
 	<head>
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script src="/node_modules/mocha/mocha.js"></script>
 		<script src="/node_modules/chai/chai.js"></script>
 		<script src="/node_modules/@polymer/test-fixture/test-fixture.js"></script>

--- a/test/activities/associateGrade/GradeSchemeCollectionEntity.html
+++ b/test/activities/associateGrade/GradeSchemeCollectionEntity.html
@@ -2,7 +2,6 @@
 	<head>
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script src="/node_modules/mocha/mocha.js"></script>
 		<script src="/node_modules/chai/chai.js"></script>
 		<script src="/node_modules/@polymer/test-fixture/test-fixture.js"></script>

--- a/test/activities/associateGrade/GradeSchemeEntity.html
+++ b/test/activities/associateGrade/GradeSchemeEntity.html
@@ -2,7 +2,6 @@
 	<head>
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script src="/node_modules/mocha/mocha.js"></script>
 		<script src="/node_modules/chai/chai.js"></script>
 		<script src="/node_modules/@polymer/test-fixture/test-fixture.js"></script>

--- a/test/activities/associateGrade/GradeSchemeLinkedEntity.html
+++ b/test/activities/associateGrade/GradeSchemeLinkedEntity.html
@@ -2,7 +2,6 @@
 	<head>
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script src="/node_modules/mocha/mocha.js"></script>
 		<script src="/node_modules/chai/chai.js"></script>
 		<script src="/node_modules/@polymer/test-fixture/test-fixture.js"></script>

--- a/test/activities/content/ContentEntity.html
+++ b/test/activities/content/ContentEntity.html
@@ -2,7 +2,6 @@
 	<head>
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script src="/node_modules/mocha/mocha.js"></script>
 		<script src="/node_modules/chai/chai.js"></script>
 		<script src="/node_modules/@polymer/test-fixture/test-fixture.js"></script>

--- a/test/activities/content/ContentFileEntity.html
+++ b/test/activities/content/ContentFileEntity.html
@@ -2,7 +2,6 @@
 	<head>
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script src="/node_modules/mocha/mocha.js"></script>
 		<script src="/node_modules/chai/chai.js"></script>
 		<script src="/node_modules/@polymer/test-fixture/test-fixture.js"></script>

--- a/test/activities/content/ContentHtmlFileEntity.html
+++ b/test/activities/content/ContentHtmlFileEntity.html
@@ -2,7 +2,6 @@
 	<head>
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script src="/node_modules/mocha/mocha.js"></script>
 		<script src="/node_modules/chai/chai.js"></script>
 		<script src="/node_modules/@polymer/test-fixture/test-fixture.js"></script>

--- a/test/activities/content/ContentLTILinkEntity.html
+++ b/test/activities/content/ContentLTILinkEntity.html
@@ -2,7 +2,6 @@
 	<head>
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script src="/node_modules/mocha/mocha.js"></script>
 		<script src="/node_modules/chai/chai.js"></script>
 		<script src="/node_modules/@polymer/test-fixture/test-fixture.js"></script>

--- a/test/activities/content/ContentLTILinkFrameOptionsEntity.html
+++ b/test/activities/content/ContentLTILinkFrameOptionsEntity.html
@@ -2,7 +2,6 @@
 	<head>
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script src="/node_modules/mocha/mocha.js"></script>
 		<script src="/node_modules/chai/chai.js"></script>
 		<script src="/node_modules/@polymer/test-fixture/test-fixture.js"></script>

--- a/test/activities/content/ContentMediaFileEntity.html
+++ b/test/activities/content/ContentMediaFileEntity.html
@@ -2,7 +2,6 @@
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
-	<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 	<script src="/node_modules/mocha/mocha.js"></script>
 	<script src="/node_modules/chai/chai.js"></script>
 	<script src="/node_modules/@polymer/test-fixture/test-fixture.js"></script>

--- a/test/activities/content/ContentModuleEntity.html
+++ b/test/activities/content/ContentModuleEntity.html
@@ -2,7 +2,6 @@
 	<head>
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script src="/node_modules/mocha/mocha.js"></script>
 		<script src="/node_modules/chai/chai.js"></script>
 		<script src="/node_modules/@polymer/test-fixture/test-fixture.js"></script>

--- a/test/activities/content/ContentWebLinkEntity.html
+++ b/test/activities/content/ContentWebLinkEntity.html
@@ -2,7 +2,6 @@
 	<head>
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script src="/node_modules/mocha/mocha.js"></script>
 		<script src="/node_modules/chai/chai.js"></script>
 		<script src="/node_modules/@polymer/test-fixture/test-fixture.js"></script>

--- a/test/activities/quizzes/QuizEntity.html
+++ b/test/activities/quizzes/QuizEntity.html
@@ -2,7 +2,6 @@
 	<head>
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script src="/node_modules/mocha/mocha.js"></script>
 		<script src="/node_modules/chai/chai.js"></script>
 		<script src="/node_modules/@polymer/test-fixture/test-fixture.js"></script>

--- a/test/activities/quizzes/attempts/QuizAttemptsEntity.html
+++ b/test/activities/quizzes/attempts/QuizAttemptsEntity.html
@@ -2,7 +2,6 @@
 	<head>
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script src="/node_modules/mocha/mocha.js"></script>
 		<script src="/node_modules/chai/chai.js"></script>
 		<script src="/node_modules/@polymer/test-fixture/test-fixture.js"></script>

--- a/test/activities/quizzes/ipRestrictions/QuizIpRestrictionsEntity.html
+++ b/test/activities/quizzes/ipRestrictions/QuizIpRestrictionsEntity.html
@@ -2,7 +2,6 @@
 	<head>
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script src="/node_modules/mocha/mocha.js"></script>
 		<script src="/node_modules/chai/chai.js"></script>
 		<script src="/node_modules/@polymer/test-fixture/test-fixture.js"></script>

--- a/test/activities/quizzes/submissionViews/QuizSubmissionViewEntity.html
+++ b/test/activities/quizzes/submissionViews/QuizSubmissionViewEntity.html
@@ -2,7 +2,6 @@
 	<head>
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script src="/node_modules/mocha/mocha.js"></script>
 		<script src="/node_modules/chai/chai.js"></script>
 		<script src="/node_modules/@polymer/test-fixture/test-fixture.js"></script>

--- a/test/activities/quizzes/submissionViews/QuizSubmissionViewsEntity.html
+++ b/test/activities/quizzes/submissionViews/QuizSubmissionViewsEntity.html
@@ -2,7 +2,6 @@
 	<head>
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script src="/node_modules/mocha/mocha.js"></script>
 		<script src="/node_modules/chai/chai.js"></script>
 		<script src="/node_modules/@polymer/test-fixture/test-fixture.js"></script>

--- a/test/activities/quizzes/timing/QuizTimingEntity.html
+++ b/test/activities/quizzes/timing/QuizTimingEntity.html
@@ -2,7 +2,6 @@
 	<head>
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script src="/node_modules/mocha/mocha.js"></script>
 		<script src="/node_modules/chai/chai.js"></script>
 		<script src="/node_modules/@polymer/test-fixture/test-fixture.js"></script>

--- a/test/alignments/AlignmentsCollectionEntity.html
+++ b/test/alignments/AlignmentsCollectionEntity.html
@@ -2,7 +2,6 @@
 	<head>
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script src="/node_modules/mocha/mocha.js"></script>
 		<script src="/node_modules/chai/chai.js"></script>
 		<script src="/node_modules/@polymer/test-fixture/test-fixture.js"></script>

--- a/test/competencies/CompetenciesEntity.html
+++ b/test/competencies/CompetenciesEntity.html
@@ -2,7 +2,6 @@
 	<head>
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script src="/node_modules/mocha/mocha.js"></script>
 		<script src="/node_modules/chai/chai.js"></script>
 		<script src="/node_modules/@polymer/test-fixture/test-fixture.js"></script>

--- a/test/consortium/ConsortiumRootEntity.html
+++ b/test/consortium/ConsortiumRootEntity.html
@@ -2,18 +2,12 @@
 	<head>
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1, user-scalable=yes">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script src="/node_modules/mocha/mocha.js"></script>
 		<script src="/node_modules/chai/chai.js"></script>
 		<script src="/node_modules/@polymer/test-fixture/test-fixture.js"></script>
 		<script src="/node_modules/wct-mocha/wct-mocha.js"></script>
 		<script src="/node_modules/sinon/pkg/sinon.js"></script>
 		<script type="module" src="../../../siren-parser/global.js"></script>
-
-		<!-- For IE11 -->
-		<script src="../../../lie/dist/lie.polyfill.min.js"></script>
-		<script src="../../../whatwg-fetch/fetch.js"></script>
-
 
 		<script type="module" src="../../src/consortium/ConsortiumRootEntity.js"></script>
 	</head>

--- a/test/consortium/ConsortiumTokenCollection.html
+++ b/test/consortium/ConsortiumTokenCollection.html
@@ -2,7 +2,6 @@
 	<head>
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1, user-scalable=yes">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script src="/node_modules/mocha/mocha.js"></script>
 		<script src="/node_modules/chai/chai.js"></script>
 		<script src="/node_modules/@polymer/test-fixture/test-fixture.js"></script>
@@ -10,11 +9,6 @@
 		<script src="/node_modules/sinon/pkg/sinon.js"></script>
 
 		<script type="module" src="../../../siren-parser/global.js"></script>
-
-		<!-- For IE11 -->
-		<script src="../../../lie/dist/lie.polyfill.min.js"></script>
-		<script src="../../../whatwg-fetch/fetch.js"></script>
-
 
 		<script type="module" src="../../src/consortium/ConsortiumTokenCollectionEntity.js"></script>
 	</head>

--- a/test/entity.html
+++ b/test/entity.html
@@ -4,16 +4,11 @@
 	<head>
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1, user-scalable=yes">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script src="/node_modules/mocha/mocha.js"></script>
 		<script src="/node_modules/chai/chai.js"></script>
 		<script src="/node_modules/@polymer/test-fixture/test-fixture.js"></script>
 		<script src="/node_modules/wct-mocha/wct-mocha.js"></script>
 		<script src="/node_modules/sinon/pkg/sinon.js"></script>
-
-		<!-- For IE11 -->
-		<script src="../../lie/dist/lie.polyfill.min.js"></script>
-		<script src="../../whatwg-fetch/fetch.js"></script>
 	</head>
 	<body>
 

--- a/test/es6/EntityFactory.html
+++ b/test/es6/EntityFactory.html
@@ -2,7 +2,6 @@
 	<head>
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1, user-scalable=yes">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script src="/node_modules/mocha/mocha.js"></script>
 		<script src="/node_modules/chai/chai.js"></script>
 		<script src="/node_modules/@polymer/test-fixture/test-fixture.js"></script>
@@ -10,13 +9,6 @@
 		<script src="/node_modules/sinon/pkg/sinon.js"></script>
 
 		<script type="module" src="../../../siren-parser/global.js"></script>
-
-		<!-- For IE11 -->
-		<script src="../../../lie/dist/lie.polyfill.min.js"></script>
-		<script src="../../../whatwg-fetch/fetch.js"></script>
-
-
-
 	</head>
 	<body>
 		<script type="module" src="./EntityFactory.js"></script>

--- a/test/es6/SirenActionTest.html
+++ b/test/es6/SirenActionTest.html
@@ -3,20 +3,14 @@
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1, user-scalable=yes">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script src="/node_modules/mocha/mocha.js"></script>
 		<script src="/node_modules/chai/chai.js"></script>
 		<script src="/node_modules/@polymer/test-fixture/test-fixture.js"></script>
 		<script src="/node_modules/wct-mocha/wct-mocha.js"></script>
 		<script src="/node_modules/sinon/pkg/sinon.js"></script>
-		<script src="/node_modules/sinon-chai/lib/sinon-chai.js"></script>
 		<script type="module" src="/node_modules/fetch-mock/es5/client-bundle.js"></script>
 
 	<script type="module" src="../../../siren-parser/global.js"></script>
-
-	<!-- For IE11 -->
-	<script src="../../../lie/dist/lie.polyfill.min.js"></script>
-	<script src="../../../whatwg-fetch/fetch.js"></script>
 </head>
 
 <body>

--- a/test/files/FilesHomeEntity.html
+++ b/test/files/FilesHomeEntity.html
@@ -2,7 +2,6 @@
 	<head>
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script src="/node_modules/mocha/mocha.js"></script>
 		<script src="/node_modules/chai/chai.js"></script>
 		<script src="/node_modules/@polymer/test-fixture/test-fixture.js"></script>

--- a/test/helpers/StateTree.html
+++ b/test/helpers/StateTree.html
@@ -3,13 +3,11 @@
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script src="/node_modules/mocha/mocha.js"></script>
 		<script src="/node_modules/chai/chai.js"></script>
 		<script src="/node_modules/@polymer/test-fixture/test-fixture.js"></script>
 		<script src="/node_modules/wct-mocha/wct-mocha.js"></script>
 		<script src="/node_modules/sinon/pkg/sinon.js"></script>
-		<script src="/node_modules/sinon-chai/lib/sinon-chai.js"></script>
 
 	<script type="module" src="../../../siren-parser/global.js"></script>
 	<script type="module" src="../../src/helpers/StateTree.js"></script>

--- a/test/index.html
+++ b/test/index.html
@@ -4,7 +4,6 @@
 <head>
 	<meta charset="utf-8">
 	<meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
-	<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 	<script src="/node_modules/mocha/mocha.js"></script>
 	<script src="/node_modules/wct-mocha/wct-mocha.js"></script>
 </head>

--- a/test/mixin/entity-mixin-test.html
+++ b/test/mixin/entity-mixin-test.html
@@ -2,19 +2,13 @@
 	<head>
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1, user-scalable=yes">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script src="/node_modules/mocha/mocha.js"></script>
 		<script src="/node_modules/chai/chai.js"></script>
 		<script src="/node_modules/@polymer/test-fixture/test-fixture.js"></script>
 		<script src="/node_modules/wct-mocha/wct-mocha.js"></script>
 		<script src="/node_modules/sinon/pkg/sinon.js"></script>
-		<script src="/node_modules/sinon-chai/lib/sinon-chai.js"></script>
 
 		<script type="module" src="../../../siren-parser/global.js"></script>
-
-		<!-- For IE11 -->
-		<script src="../../../lie/dist/lie.polyfill.min.js"></script>
-		<script src="../../../whatwg-fetch/fetch.js"></script>
 
 		<script type="module" src="../utility/siren-sdk-organization-info.js"></script>
 		<script type="module" src="../utility/siren-sdk-organization-info-lit.js"></script>

--- a/test/mixin/simple-entity-mixin-test.html
+++ b/test/mixin/simple-entity-mixin-test.html
@@ -2,7 +2,6 @@
 	<head>
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1, user-scalable=yes">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script src="/node_modules/mocha/mocha.js"></script>
 		<script src="/node_modules/chai/chai.js"></script>
 		<script src="/node_modules/@polymer/test-fixture/test-fixture.js"></script>
@@ -10,10 +9,6 @@
 		<script src="/node_modules/sinon/pkg/sinon.js"></script>
 
 		<script type="module" src="../../../siren-parser/global.js"></script>
-
-		<!-- For IE11 -->
-		<script src="../../../lie/dist/lie.polyfill.min.js"></script>
-		<script src="../../../whatwg-fetch/fetch.js"></script>
 
 		<script type="module" src="../utility/siren-sdk-simple-organization.js"></script>
 

--- a/test/organizations/CompletionTracking.html
+++ b/test/organizations/CompletionTracking.html
@@ -2,7 +2,6 @@
 	<head>
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script src="/node_modules/mocha/mocha.js"></script>
 		<script src="/node_modules/chai/chai.js"></script>
 		<script src="/node_modules/@polymer/test-fixture/test-fixture.js"></script>

--- a/test/organizations/OrganizationAvailabilityEntity.html
+++ b/test/organizations/OrganizationAvailabilityEntity.html
@@ -2,7 +2,6 @@
 	<head>
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script src="/node_modules/mocha/mocha.js"></script>
 		<script src="/node_modules/chai/chai.js"></script>
 		<script src="/node_modules/@polymer/test-fixture/test-fixture.js"></script>

--- a/test/organizations/OrganizationAvailabilitySetEntity.html
+++ b/test/organizations/OrganizationAvailabilitySetEntity.html
@@ -2,7 +2,6 @@
 	<head>
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script src="/node_modules/mocha/mocha.js"></script>
 		<script src="/node_modules/chai/chai.js"></script>
 		<script src="/node_modules/@polymer/test-fixture/test-fixture.js"></script>

--- a/test/root/root.html
+++ b/test/root/root.html
@@ -2,7 +2,6 @@
 	<head>
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1, user-scalable=yes">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script src="/node_modules/mocha/mocha.js"></script>
 		<script src="/node_modules/chai/chai.js"></script>
 		<script src="/node_modules/@polymer/test-fixture/test-fixture.js"></script>
@@ -10,11 +9,6 @@
 		<script src="/node_modules/sinon/pkg/sinon.js"></script>
 
 		<script type="module" src="../../../siren-parser/global.js"></script>
-
-		<!-- For IE11 -->
-		<script src="../../../lie/dist/lie.polyfill.min.js"></script>
-		<script src="../../../whatwg-fetch/fetch.js"></script>
-
 
 		<script type="module" src="../../src/root/root.js"></script>
 	</head>

--- a/test/skeleton-test.html
+++ b/test/skeleton-test.html
@@ -4,17 +4,11 @@
 	<head>
 		<meta charset="utf-8">
 		<meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1, user-scalable=yes">
-		<script src="/node_modules/@webcomponents/webcomponentsjs/webcomponents-loader.js"></script>
 		<script src="/node_modules/mocha/mocha.js"></script>
 		<script src="/node_modules/chai/chai.js"></script>
 		<script src="/node_modules/@polymer/test-fixture/test-fixture.js"></script>
 		<script src="/node_modules/wct-mocha/wct-mocha.js"></script>
 		<script src="/node_modules/sinon/pkg/sinon.js"></script>
-
-		<!-- For IE11 -->
-		<script src="../../lie/dist/lie.polyfill.min.js"></script>
-		<script src="../../whatwg-fetch/fetch.js"></script>
-
 	</head>
 	<body>
 		<script>

--- a/web-test-runner.sauce.config.js
+++ b/web-test-runner.sauce.config.js
@@ -12,7 +12,7 @@ const sauceLabsCapabilities = {
 	name: 'siren-sdk unit tests',
 
 	// eslint-disable-next-line no-undef
-	build: `d2l-image-selector ${process.env.GITHUB_REF ?? 'local'} build ${process.env.GITHUB_RUN_NUMBER ?? ''}`
+	build: `siren-sdk ${process.env.GITHUB_REF ?? 'local'} build ${process.env.GITHUB_RUN_NUMBER ?? ''}`
 };
 
 const sauceLabsLauncher = createSauceLabsLauncher(


### PR DESCRIPTION
Noticed in the last PR that the name of the sauce runner was fixed, but not the build:
![image](https://user-images.githubusercontent.com/13419300/159086152-f84de1fb-bee9-4e9f-837b-50afda2fa752.png)

Figured I'd cleanup some easy dependencies while I was here, but that spiraled a bit because this repo has 50 test files 🙈 
