### PR TITLE
DE47339: Add Grade Scheme ID to Linked Entity

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "siren-sdk",
-  "version": "1.119.1",
+  "version": "1.120.0",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/activities/associateGrade/GradeSchemeLinkedEntity.js
+++ b/src/activities/associateGrade/GradeSchemeLinkedEntity.js
@@ -14,6 +14,12 @@ export class GradeSchemeLinkedEntity extends Entity {
 		}
 		return this._entity.getLinkByRel(Rels.Grades.scheme).href;
 	}
+	/**
+	 * @returns {number} Grade scheme's id, will be -1 when default scheme is chosen
+	 */
+	schemeId() {
+		return this._entity && this._entity.properties && this._entity.properties.gradeSchemeId;
+	}
 
 	canChooseScheme() {
 		if (!this._entity) {

--- a/test/activities/associateGrade/GradeSchemeLinkedEntity.js
+++ b/test/activities/associateGrade/GradeSchemeLinkedEntity.js
@@ -22,6 +22,10 @@ describe('GradeSchemeLinkedEntity', () => {
 			expect(entity.href()).to.equal('https://5096e993-e418-4681-81c5-cae06b019fbb.grades.api.dev.brightspace.com/organizations/6613/grade-schemes/1');
 		});
 
+		it('gets schemeId', () => {
+			expect(entity.schemeId()).to.equal(1);
+		});
+
 		it('can choose scheme', () => {
 			expect(entity.canChooseScheme()).to.be.true;
 		});
@@ -58,6 +62,10 @@ describe('GradeSchemeLinkedEntity', () => {
 
 		it('gets href', () => {
 			expect(entity.href()).to.equal('https://5096e993-e418-4681-81c5-cae06b019fbb.grades.api.dev.brightspace.com/organizations/6613/grade-schemes/2');
+		});
+
+		it('schemeId is not serialized', () => {
+			expect(entity.schemeId()).to.be.undefined;
 		});
 
 		it('can not choose scheme', () => {

--- a/test/activities/associateGrade/data/GradeSchemeLinked.js
+++ b/test/activities/associateGrade/data/GradeSchemeLinked.js
@@ -22,6 +22,9 @@ export const gradeSchemeLinked = {
 				]
 			}
 		],
+		'properties': {
+			'gradeSchemeId': 1
+		},
 		'links': [
 			{
 				'rel': [


### PR DESCRIPTION
[DE47339](https://rally1.rallydev.com/#/?detail=/defect/627263379249&fdp=true): Grades > 20.22.1.34790 > Grade Item created in Assignments tool explicitly sets gradeScheme, rather than using the default


#### Todo
- [ ] Update tests