### PR TITLE
US135988 Read from and fire set-collection-paging action

### DIFF
--- a/src/activities/ActivityUsageCollectionEntity.js
+++ b/src/activities/ActivityUsageCollectionEntity.js
@@ -1,5 +1,6 @@
 import { Entity } from '../es6/Entity.js';
 import { Rels } from '../hypermedia-constants';
+import { Actions } from '../hypermedia-constants';
 import { ActivityUsageEntity } from './ActivityUsageEntity.js';
 import { performSirenAction } from '../es6/SirenAction.js';
 
@@ -49,6 +50,48 @@ export class ActivityUsageCollectionEntity extends Entity {
 		});
 		this._entity.entities = newEntityList;
 		this.update(this._entity);
+	}
+
+	/*
+	 * @returns {String} Gets selected paging type's string id
+	*/
+	getSelectedPagingType() {
+		const pagingTypeOptions = this.getPagingTypeOptions();
+
+		if (!pagingTypeOptions) return;
+
+		const selectedOption = pagingTypeOptions.find(option => option.selected);
+
+		return selectedOption && selectedOption.value;
+	}
+
+	/*
+	 * @returns {Array} Gets all available paging type objects
+	*/
+	getPagingTypeOptions() {
+		const entity = this._entity;
+
+		if (!entity) return;
+
+		const action = this._getSetCollectionPagingAction();
+		const fields = action && action.getFieldByName('pagingType');
+
+		return fields && fields.value;
+	}
+
+	/*
+	 * @returns {Boolean} Whether or not a user can edit paging type
+	*/
+	canUpdatePagingType() {
+		if (!this._entity) {
+			return;
+		}
+
+		return this._entity.hasActionByName(Actions.activities.activityUsageCollection.setCollectionPaging);
+	}
+
+	_getSetCollectionPagingAction() {
+		return this.canUpdatePagingType() && this._entity.getActionByName(Actions.activities.activityUsageCollection.setCollectionPaging);
 	}
 }
 

--- a/src/activities/ActivityUsageCollectionEntity.js
+++ b/src/activities/ActivityUsageCollectionEntity.js
@@ -90,8 +90,32 @@ export class ActivityUsageCollectionEntity extends Entity {
 		return this._entity.hasActionByName(Actions.activities.activityUsageCollection.setCollectionPaging);
 	}
 
+	equals(activityUsageCollection) {
+		const initialSelectedPagingType = this.getSelectedPagingType();
+		const { selectedPagingType : currentSelectedPagingType } = activityUsageCollection;
+		return currentSelectedPagingType === initialSelectedPagingType;
+	}
+
 	_getSetCollectionPagingAction() {
 		return this.canUpdatePagingType() && this._entity.getActionByName(Actions.activities.activityUsageCollection.setCollectionPaging);
+	}
+
+	async save(activityUsageCollection) {
+		if (!this.canUpdatePagingType() || !activityUsageCollection) return;
+
+		const initialSelectedPagingType = this.getSelectedPagingType();
+		const { selectedPagingType : currentSelectedPagingType } = activityUsageCollection;
+		if (currentSelectedPagingType !== initialSelectedPagingType) {
+			const setCollectionPagingAction = this._getSetCollectionPagingAction();
+
+			if (!setCollectionPagingAction) return;
+
+			const fields = [
+				{ name: 'pagingType', value: currentSelectedPagingType }
+			];
+
+			return await performSirenAction(this._token, setCollectionPagingAction, fields);
+		}
 	}
 }
 

--- a/src/hypermedia-constants.js
+++ b/src/hypermedia-constants.js
@@ -583,6 +583,9 @@ export const Actions = {
 			getSchemes: 'get-schemes',
 			chooseScheme: 'choose-scheme'
 		},
+		activityUsageCollection: {
+			setCollectionPaging: 'set-collection-paging',
+		},
 		save: 'save',
 		filterWorkToDo: 'filter-work-to-do'
 	},

--- a/test/activities/ActivityUsageCollectionEntity.html
+++ b/test/activities/ActivityUsageCollectionEntity.html
@@ -8,6 +8,7 @@
 		<script src="/node_modules/wct-mocha/wct-mocha.js"></script>
 		<script src="/node_modules/sinon/pkg/sinon.js"></script>
 
+		<script type="module" src="/node_modules/fetch-mock/es5/client-bundle.js"></script>
 		<script type="module" src="../../../siren-parser/global.js"></script>
 		<script type="module" src="../../src/activities/ActivityUsageCollectionEntity.js"></script>
 	</head>

--- a/test/activities/ActivityUsageCollectionEntity.js
+++ b/test/activities/ActivityUsageCollectionEntity.js
@@ -1,10 +1,12 @@
+/* global fetchMock */
 import { ActivityUsageCollectionEntity } from '../../src/activities/ActivityUsageCollectionEntity.js';
-import { collection } from './data/collection.js';
+import { getFormData } from '../utility/test-helpers.js';
+import { testData } from './data/collection.js';
 
 describe('ActivityUsageCollectionEntity', () => {
 	describe('Basic loading', () => {
 		it('Loads collected items', done => {
-			const entity = window.D2L.Hypermedia.Siren.Parse(collection);
+			const entity = window.D2L.Hypermedia.Siren.Parse(testData.collection);
 			const collectionEntity = new ActivityUsageCollectionEntity(entity);
 
 			const itemEntities = [];
@@ -18,7 +20,7 @@ describe('ActivityUsageCollectionEntity', () => {
 		});
 
 		it('has activity-usage href for collected items', done => {
-			const entity = window.D2L.Hypermedia.Siren.Parse(collection);
+			const entity = window.D2L.Hypermedia.Siren.Parse(testData.collection);
 			const collectionEntity = new ActivityUsageCollectionEntity(entity);
 
 			const itemEntities = [];
@@ -31,6 +33,74 @@ describe('ActivityUsageCollectionEntity', () => {
 					'https://activities.api.testdomain.d2l/activities/6606_3000_6/usages/6606'
 				);
 				done();
+			});
+		});
+	});
+
+	describe('Set Collection Paging', () => {
+		describe('Editable', () => {
+			let entity;
+			let entityJson;
+
+			beforeEach(() => {
+				entityJson = window.D2L.Hypermedia.Siren.Parse(testData.setCollectionPagingEditable);
+				entity = new ActivityUsageCollectionEntity(entityJson);
+			});
+
+			afterEach(() => {
+				fetchMock.reset();
+			});
+
+			it('sets canUpdatePagingType to true', () => {
+				expect(entity.canUpdatePagingType()).to.be.true;
+			});
+
+			it('saves pagingType', async() => {
+				fetchMock.patchOnce('https://305d9474-d93a-4205-9d27-101205376fcf.activities.api.dev.brightspace.com/old/activities/6606_51000_1759/usages/123171/collection/paging', entityJson);
+
+				await entity.save({
+					selectedPagingType: 'none'
+				});
+
+				const form = await getFormData(fetchMock.lastCall().request);
+				if (!form.notSupported) {
+					expect(form.get('pagingType')).to.equal('none');
+				}
+				expect(fetchMock.called()).to.be.true;
+			});
+
+			it('skips save if not dirty', async() => {
+				await entity.save({
+					selectedPagingType: 'oneactivityperpage'
+				});
+
+				expect(fetchMock.done());
+			});
+		});
+
+		describe('Non Editable', () => {
+			let entity;
+			let entityJson;
+
+			beforeEach(() => {
+				entityJson = window.D2L.Hypermedia.Siren.Parse(testData.setCollectionPagingNonEditable);
+				entity = new ActivityUsageCollectionEntity(entityJson);
+			});
+
+			afterEach(() => {
+				fetchMock.reset();
+			});
+
+			it('sets canUpdatePagingType to false', () => {
+				expect(entity.canUpdatePagingType()).to.be.false;
+			});
+
+			it('skips save if not editable', async() => {
+				await entity.save({
+					selectedPagingType: 'none'
+				});
+
+				expect(fetchMock.done());
 			});
 		});
 	});

--- a/test/activities/data/collection.js
+++ b/test/activities/data/collection.js
@@ -1,4 +1,4 @@
-export const collection = {
+const collection = {
 	entities: [
 		{
 			rel: ['item'],
@@ -73,4 +73,124 @@ export const collection = {
 			href: 'https://activities.api.testdomain.d2l/activities/6606_706000_6606/usages/6606'
 		}
 	]
+};
+
+export const testData = {
+	collection,
+	setCollectionPagingEditable: {
+		'actions': [
+			{
+				href: 'https://305d9474-d93a-4205-9d27-101205376fcf.activities.api.dev.brightspace.com/old/activities/6606_51000_1759/usages/123171/collection',
+				name: 'move-activity',
+				method: 'PATCH',
+				fields: [
+					{
+						type: 'text',
+						name: 'itemToMoveId'
+					},
+					{
+						type: 'text',
+						name: 'targetId'
+					},
+					{
+						type: 'number',
+						name: 'moveAfter'
+					}
+				],
+			},
+			{
+				href: 'https://305d9474-d93a-4205-9d27-101205376fcf.activities.api.dev.brightspace.com/old/activities/6606_51000_1759/usages/123171/collection/paging',
+				name: 'set-collection-paging',
+				method: 'PATCH',
+				fields: [
+					{
+						type: 'radio',
+						name: 'pagingType',
+						value: [
+							{
+								title: 'All activities displayed together',
+								value: 'none',
+								selected: false
+							},
+							{
+								title: '1 activity per page',
+								value: 'oneactivityperpage',
+								selected: true
+							},
+							{
+								title: 'Add page break after each sub-collection',
+								value: 'pagebreakaftereachsubcollection',
+								selected: false
+							}
+						]
+					}
+				]
+			},
+		],
+		'links': [
+			{
+				rel: [
+					'self'
+				],
+				href: 'https://305d9474-d93a-4205-9d27-101205376fcf.activities.api.dev.brightspace.com/activities/6606_51000_1759/usages/123171/collection'
+			},
+			{
+				rel: [
+					'https://activities.api.brightspace.com/rels/activity-usage',
+					'up'
+				],
+				href: 'https://305d9474-d93a-4205-9d27-101205376fcf.activities.api.dev.brightspace.com/old/activities/6606_51000_1759/usages/123171'
+			},
+			{
+				rel: [
+					'https://activities.api.brightspace.com/rels/collection-numbering'
+				],
+				href: 'https://305d9474-d93a-4205-9d27-101205376fcf.activities.api.dev.brightspace.com/old/activities/6606_51000_1759/usages/123171/collection/numbering'
+			}
+		],
+	},
+	setCollectionPagingNonEditable: {
+		'actions': [
+			{
+				href: 'http://9fxdl33.desire2learn.d2l:44444/d2l/api/hm/activities/activities/6606_51000_25/usages/6613/collection',
+				name: 'move-activity',
+				method: 'PATCH',
+				fields: [
+					{
+						type: 'text',
+						name: 'itemToMoveId'
+					},
+					{
+						type: 'text',
+						name: 'targetId'
+					},
+					{
+						type: 'number',
+						name: 'moveAfter'
+					}
+				],
+			},
+		],
+		'links': [
+			{
+				rel: [
+					'self'
+				],
+				href: 'https://305d9474-d93a-4205-9d27-101205376fcf.activities.api.dev.brightspace.com/activities/6606_51000_1759/usages/123171/collection'
+			},
+			{
+				rel: [
+					'https://activities.api.brightspace.com/rels/activity-usage',
+					'up'
+				],
+				href: 'https://305d9474-d93a-4205-9d27-101205376fcf.activities.api.dev.brightspace.com/old/activities/6606_51000_1759/usages/123171'
+			},
+			{
+				rel: [
+					'https://activities.api.brightspace.com/rels/collection-numbering'
+				],
+				href: 'https://305d9474-d93a-4205-9d27-101205376fcf.activities.api.dev.brightspace.com/old/activities/6606_51000_1759/usages/123171/collection/numbering'
+			}
+		],
+	}
 };


### PR DESCRIPTION
### Summary of Changes
* Added method for fetching selected paging type
* Added method for fetching all the available paging type options
* Added equals method to compare entities for dirty check
* Added save method to fire the actual `set-collection-paging` action
* Added unit tests

### Rally Story
[US135988](https://rally1.rallydev.com/#/?detail=/userstory/626561954629&fdp=true): [ui] page break options