### PR TITLE
US137224 LTI - Add Banner with LTI Name

### DIFF
--- a/src/activities/content/ContentLTILinkEntity.js
+++ b/src/activities/content/ContentLTILinkEntity.js
@@ -41,6 +41,13 @@ export class ContentLTILinkEntity extends Entity {
 	}
 
 	/**
+	 * @returns {string|undefined} Name of the content-ltilink item according to the LTI tool
+	 */
+	 ltiTitle() {
+		return this._entity && this._entity.properties && this._entity.properties.ltiTitle;
+	}
+
+	/**
 	 * @returns {string|undefined} Title of the content-ltilink item
 	 */
 	title() {

--- a/src/activities/content/ContentLTILinkEntity.js
+++ b/src/activities/content/ContentLTILinkEntity.js
@@ -43,7 +43,7 @@ export class ContentLTILinkEntity extends Entity {
 	/**
 	 * @returns {string|undefined} Name of the content-ltilink item according to the LTI tool
 	 */
-	 ltiTitle() {
+	ltiTitle() {
 		return this._entity && this._entity.properties && this._entity.properties.ltiTitle;
 	}
 


### PR DESCRIPTION
## Relevant Rally Links

- https://rally1.rallydev.com/#/289692574792d/custom/355050439968?detail=%2Fuserstory%2F629905635169


## Description

> Design Spec:
> https://xd.adobe.com/view/9848dbf0-ec9e-4831-a276-4ff4f2ec2608-cd1b/screen/97d34b0d-9f0a-4cdc-9563-ad3e8ae53149
> (Note, this design includes a few other items beyond just the banner, this US is only for adding the grey Banner)
> 
> 
> Acceptance Criteria:
> 1) The Grey banner is displayed on the FACE page for LTI Links
> 2) The existing 'Open in New Window' button should be included on the banner (note it's missing in the design but needs to remain on the page)
> 3) If possible, display the name of the LTI is displayed on the banner. If we can't, then continue using 'External Activity'
>     * LTI name isn't the name of the topic, but rather the name of the External Learning Tool link that was used to create the topic. If it's not possible, or is quite complicated to pull that information and make it available then continue using 'External Activity' as it says currently.


## Goal/Solution

The LTI links controller will attempt to obtain a name from the `[dev_lsone_main].[dbo].[LTI_LINKS]` table using the [`LinkService`](https://search.d2l.dev/xref/lms/le/lti/D2L.LE.Lti/Advantage/Service/Default/LinkService.cs?r=1448e5b7#157).

If it succeeds, the property is serialized, otherwise it is not added.  Lack of an LTI name does not cause the request to fail.

If an `ltiTitle` property is found on the siren entity, it is used in the LTI banner.  Otherwise, "LTI File" is shown.


## Screenshots/Video

Open in new window button still works:

![image](https://user-images.githubusercontent.com/89945180/165635475-6984f06a-d5ff-4137-8e3c-3e50a580c628.png)

Note that in the latest version of this PR, the "LTI File" default langterm has been changed to "External Activity".

If the controller can find a name from the LTI table, it shows up instead:

![image](https://user-images.githubusercontent.com/89945180/165970256-c6ae379a-8747-415d-9dbe-d7f184507667.png)

When tested using the steps outlined in [this SPIKE](https://desire2learn.atlassian.net/wiki/spaces/PHOENIX/pages/3140157869/US137222+SPIKE+-+LTI+-+Determine+how+we+interact+with+LTI+grades#LTI-1.3-Testing-Tool), the table correctly contains names:

![image](https://user-images.githubusercontent.com/89945180/165977002-a69f4e6c-9cce-408f-b263-beaae265a9eb.png)



## Related PRs

- LMS: https://github.com/Brightspace/lms/pull/22608
- Activities: https://github.com/BrightspaceHypermediaComponents/activities/pull/2599


## Remaining Work

- [X] Retrieve actual name from LTI tool
- [ ] Dev testing desired if possible
