### PR TITLE
US138199 LTI - Build new LTI Score editor that will handle multiple grades

### DIFF
--- a/src/activities/ActivityUsageEntity.js
+++ b/src/activities/ActivityUsageEntity.js
@@ -586,7 +586,7 @@ export class ActivityUsageEntity extends Entity {
 	/**
 	 * @returns {Number} Count of Scoring API URLs attached to this activity
 	 */
-	 scoringCount() {
+	scoringCount() {
 		const scoringHrefs = this.scoringHrefs();
 		return scoringHrefs ? scoringHrefs.length : 0;
 	}

--- a/src/activities/ActivityUsageEntity.js
+++ b/src/activities/ActivityUsageEntity.js
@@ -584,11 +584,27 @@ export class ActivityUsageEntity extends Entity {
 	}
 
 	/**
-	* @returns {string} URL of the scoring API, for managing activity's scoreOutOf
-	*/
+	 * @returns {Number} Count of Scoring API URLs attached to this activity
+	 */
+	 scoringCount() {
+		const scoringHrefs = this.scoringHrefs();
+		return scoringHrefs ? scoringHrefs.length : 0;
+	}
+
+	/**
+	 * @returns {string} URL of the scoring API, for managing activity's scoreOutOf
+	 */
 	scoringHref() {
 		const scoreOutOfSubEntity = this._entity && this._entity.getSubEntityByRel(Rels.Activities.scoreOutOf);
 		return scoreOutOfSubEntity && scoreOutOfSubEntity.href;
+	}
+
+	/**
+	 * @returns {Array} Scoring API URLs attached to this activity, for managing the activity's grades' scoreOutOf
+	 */
+	scoringHrefs() {
+		const scoreOutOfSubEntities = this._entity && this._entity.getSubEntitiesByRel(Rels.Activities.scoreOutOf);
+		return scoreOutOfSubEntities && scoreOutOfSubEntities.map(entity => (entity.href));
 	}
 
 	async validate(activity) {

--- a/src/activities/ScoringEntity.js
+++ b/src/activities/ScoringEntity.js
@@ -30,7 +30,7 @@ export class ScoringEntity extends Entity {
 	/**
 	 * @returns {Number} Activity's grade object ID, if there is a grade association
 	 */
-	 gradeObjectId() {
+	gradeObjectId() {
 		return this._entity && this._entity.properties && this._entity.properties.gradeObjectId;
 	}
 

--- a/src/activities/ScoringEntity.js
+++ b/src/activities/ScoringEntity.js
@@ -26,6 +26,14 @@ export class ScoringEntity extends Entity {
 	autoPoints() {
 		return this._entity && this._entity.properties && this._entity.properties.autoPoints;
 	}
+
+	/**
+	 * @returns {Number} Activity's grade object ID, if there is a grade association
+	 */
+	 gradeObjectId() {
+		return this._entity && this._entity.properties && this._entity.properties.gradeObjectId;
+	}
+
 	/**
 	 * @returns {bool} Whether or not the update score out of action is present
 	 */

--- a/src/activities/content/ContentLTILinkEntity.js
+++ b/src/activities/content/ContentLTILinkEntity.js
@@ -44,8 +44,7 @@ export class ContentLTILinkEntity extends Entity {
 	 * @returns {boolean} Whether or not LTI grades is enabled
 	 */
 	isLtiGradesFeatureEnabled() {
-		return this._entity && this._entity.properties
-		&& this._entity.properties.isLtiGradesFeatureEnabled;
+		return this._entity && this._entity.properties && this._entity.properties.isLtiGradesFeatureEnabled;
 	}
 
 	/**

--- a/src/activities/content/ContentLTILinkEntity.js
+++ b/src/activities/content/ContentLTILinkEntity.js
@@ -41,6 +41,14 @@ export class ContentLTILinkEntity extends Entity {
 	}
 
 	/**
+	 * @returns {boolean} Whether or not LTI grades is enabled
+	 */
+	 isLtiGradesFeatureEnabled() {
+		return this._entity && this._entity.properties
+		&& this._entity.properties.isLtiGradesFeatureEnabled;
+	}
+
+	/**
 	 * @returns {string|undefined} Name of the content-ltilink item according to the LTI tool
 	 */
 	ltiTitle() {

--- a/src/activities/content/ContentLTILinkEntity.js
+++ b/src/activities/content/ContentLTILinkEntity.js
@@ -43,7 +43,7 @@ export class ContentLTILinkEntity extends Entity {
 	/**
 	 * @returns {boolean} Whether or not LTI grades is enabled
 	 */
-	 isLtiGradesFeatureEnabled() {
+	isLtiGradesFeatureEnabled() {
 		return this._entity && this._entity.properties
 		&& this._entity.properties.isLtiGradesFeatureEnabled;
 	}


### PR DESCRIPTION
## Relevant Rally Links

- https://rally1.rallydev.com/#/289692574792d/custom/355050439968?detail=%2Fuserstory%2F631786620271


## Description

> Design Spec: https://xd.adobe.com/view/e86e9f24-03cb-405f-89dc-0bad4d31af8f-bd3d/
> 
> Build new Score editor as described [here](https://desire2learn.atlassian.net/wiki/spaces/PHOENIX/pages/3140157869/US137222+SPIKE+-+LTI+-+Determine+how+we+interact+with+LTI+grades#1.-Identify-how-we-want-to-handle-the-grade-component-differences-between-LTI-1.1-and-LTI-1.3-objects.-(ie-is-it-a-separate-FACE-page,-do-we-identify-it-on-load-of-the-page,-etc))
> 
> New component for on the FACE page, identifies number of associated grade items, and includes a button to the multi-grade dialog
> 
> This display needs to be wrapped in a feature flag to control whether grades at all are rendered (on for **20.22.07** release)
> 
> Acceptance Criteria:
> * Displays when more than 1 grade is associated
> * Shows the number of associated grades
> * Launches the multi-grade dialog (US138571)
> * Controlled by feature flag


## Goal/Solution

### LD Flag

The [`content-lti-grades`](https://github.com/Brightspace/lms-launch-darkly-flags/pull/4638/files#diff-b06593ac618d1db13248ab9817e949743bc9e3a41ec32d3432455bc11962fb67) feature flag enables grades for LTI in general (both single and multi-grades).

### LMS

(Dependency registration, route boilerplate, tests, and interfaces omitted for clarity!)

#### Activities

[ActivityUsageScoreOutOfSubEntityProvider.cs](https://github.com/Brightspace/lms/pull/22997/files#diff-0209e22502dc78287b4837f6c43fad5be6b5635ebacfae8b86a3e809c92abfd9):

This class is where `ILMSActivityUsageGradeAssociationProviders` are looped through to create either the scoring sub-entities on the main activity entity, or the scoring entities themselves (what you reach when you hit the scoring sub-entity links, i.e. what is used by the score-out-of elements on the FACE page).

Now, this class will also loop through `ILMSActivityUsageMultipleGradesAssociationProviders`, which are the multi-grade versions of the above.
The main difference is that these providers are used to first get all relevant grade IDs before doing the siren entity serialization.

Note that multi-grades providers are looped through first before non-multi-grades providers.

[ActivityMultipleScoreOutOfSerializer.cs](https://github.com/Brightspace/lms/pull/22997/files#diff-176c73f48a5fa9104cd2712d6e6c76510ec43e3a4aed47a00cf098edd35bb186):

This new class does the actual serialization for multi-grades described above.
It is the multi-grades version of `ActivityScoreOutOfSerializer`.

The main difference is that it needs grade IDs, and when serializing scoring entities, it also adds the grade ID as a property.

**This might be where it makes sense to add additional scoring-related info, such as grade name (US138200), etc.**

[ActivitiesController.cs](https://github.com/Brightspace/lms/pull/22997/files#diff-b08eb0636329b58d9e202b0ead924d6ab30990f77e5bbbfb691cec4944551b20):

The activities controller has one new route: */scoring/{gradeObjectId}*

This is almost the same as the existing scoring route, but takes in a grade ID in the route so that it can serialize score-out-of for a specific grade.
It does this using `ActivityUsageScoreOutOfSubEntityProvider`, like the original scoring route.

[LMSActivityLinkFormatter.cs](https://github.com/Brightspace/lms/pull/22997/files#diff-7933b1c3f02743bc35a754002337628d3b3788e84f8f67bbb732e3d420285028):

This class has added functionality for serializing a specific grade's score-out-of link (which points to the new activities controller route above).

It's not used in Activities, but in the content controller (similar to how SCORM grades uses a similar link formatter in Activities to decorate its score-out-of responses).

#### Content

[LtiLinksController.cs](https://github.com/Brightspace/lms/pull/22997/files#diff-ef4fd96dc3e157d7dc863a38680dec6a8ed01a58a7470b505f29c15e6580ec9d):

A score-out-of route similar to the ones for SCORM has been added to this controller, along with feature flag and security info as needed.

Like SCORM, it uses the `ContentGradeSyncManager` (**but without push to grades/score syncing**).

Like the activities controller route and unlike SCORM, this route also needs a grade ID.

[SirenLtiLinksSerializer.cs](https://github.com/Brightspace/lms/pull/22997/files#diff-3a32b3a96f5af333ed56674ae48ba9a38cb2bb4f14f1f26bc68451d05ba15321):

The LTI grades feature flag is now passed through this serializer.

[LtiLinksActivityUsageMultipleGradesAssociationProvider.cs](https://github.com/Brightspace/lms/pull/22997/files#diff-d19b00cb7ddda1c546dcccb237643b18f7eb2a41364264b04077adbb4b86571c):

This provider is currently the only `ILMSActivityUsageMultipleGradesAssociationProvider`.

Like its non-multi-grades siblings, it does the bulk of the heavy lifting:

* Grade association
* Retrieving score-related fields
* Serializing the score update action
* (New for multi-grades providers) Retrieves the list of grade IDs associated with the activity

**Note that the grade association functions are out of scope for this ticket and will be filled in by US138202 and US138572.**

[ContentLtiGradesFeature.cs](https://github.com/Brightspace/lms/pull/22997/files#diff-bb9ba5c3982917f0596f5428b7cec6d22e974024e782350eacf75b38b46af198):

Feature flag for enabling LTI grades.

[ContentGradeSyncManager.cs](https://github.com/Brightspace/lms/pull/22997/files#diff-8bc90f1018b52c40fa445c291648b790769fd86d5857846a0f9617140aa56fd4):

This is the class currently used by all SCORM topics to manage grades.
Although its functionality was not SCORM-specific, some of its parameter names were.
They have been renamed without loss or change of functionality.

A new function has been added to this class, which retrieves a grade sync item (the item that represents content topic to grade relationships) for a specific grade ID.

The *TryGetGradeManager* function has also been made public, so that the `LtiLinksActivityUsageMultipleGradesAssociationProvider` can use it to retrieve grade IDs (and so that we have a single place to hit the grade manager factory in Content, in case we have other grade-related things we need to do).

#### Tools

Certain interfaces for classes in Activities are modified and created here.

### Siren

LTI content activity entity [`ContentLTILinkEntity.js`](https://github.com/BrightspaceHypermediaComponents/siren-sdk/pull/478/files#diff-1115c11eb1af2bb5fa547afb6a400cee11858892df5bc9cfad6ba50a327e3c16):

* This is the entity where most of the FACE page info comes from.  It now has the new feature flag as a property.

Main activity entity [`ActivityUsageEntity.js`](https://github.com/BrightspaceHypermediaComponents/siren-sdk/pull/478/files#diff-b81c79c0e332ef29b7d3ef8ff523e2fe24ba38fa929791c2538a2a76c484a404):

* This is the high-level activities info entity that is first called when opening the FACE page.
* It now has multiple scoring sub-entities instead of zero (LTI activities initially sent no grades).
* There are functions on the siren entity to get all sub-entities or specific ones (by grade ID).

Scoring entity [`ScoringEntity.js`](https://github.com/BrightspaceHypermediaComponents/siren-sdk/pull/478/files#diff-63bda0917c73aa8a627c2db4a47fa14831cbd108071c55d191d2112bd39046ff):

* This contains the actual grade-specific score-out-of info.
* It now has a grade ID property as well, to help identify which entity is which.

### Activities

<Coming soon!>


## Screenshots/Video

<Coming soon!>


## Related PRs

- LD Flag: https://github.com/Brightspace/lms-launch-darkly-flags/pull/4638
- LMS: https://github.com/Brightspace/lms/pull/22997
- Activities: https://github.com/BrightspaceHypermediaComponents/activities/pull/2612


## Remaining Work

- [ ] Dev testing desired if possible
