### PR TITLE
US138621 - Add support for OneDrive LTI picker - release

### DIFF
--- a/src/activities/AttachmentCollectionEntity.js
+++ b/src/activities/AttachmentCollectionEntity.js
@@ -193,8 +193,8 @@ export class AttachmentCollectionEntity extends Entity {
 	}
 
 	/**
-* @returns {string} Returns URL of the files home API
-*/
+	 * @returns {string} Returns URL of the files home API
+	 */
 	getFilesHref() {
 		if (!this._entity || !this._entity.hasLinkByRel(Rels.Files.files)) {
 			return;


### PR DESCRIPTION
[US138621](https://rally1.rallydev.com/#/520974201756d/iterationstatus?detail=%2Fuserstory%2F633260836465&fdp=true&view=3265e82f-7ab0-4a61-abd2-b40776bb4cb3)

Missed semantic release keyword in [last PR](https://github.com/BrightspaceHypermediaComponents/siren-sdk/pull/480), this is to generate a release (and a minor spacing fix)