### PR TITLE
Fix shouldUpdate in entity-mixin-lit

### DIFF
--- a/src/mixin/entity-mixin-lit.js
+++ b/src/mixin/entity-mixin-lit.js
@@ -35,7 +35,7 @@ export const EntityMixinLit = superclass => class extends superclass {
 			this.href && this.token) {
 			this._getEntity();
 		}
-		return this.href && this.token;
+		return this.href && this.token ? super.shouldUpdate(changedProperties) : false;
 	}
 
 	_entityHasChanged(newValue, oldValue) {


### PR DESCRIPTION
I'm a bit worried about this change, but in theory it should only be a good thing.  Basically, anything using both the `EntityMixinLit` and `core`'s `LocalizeDynamicMixin` isn't actually waiting until the langterms are loaded before rendering.  This is probably only actually noticeable in the OSLO case, where langterms take a while to return.

I think the fix below is the correct way to do this - `EntityMixinLit` gets the chance to say "no, don't update, we don't have an `href`/`token`" but will then default to other mixin's requirements if its good to go with the update.

Thoughts?