### PR TITLE
fix: DE38401 add isNewGradeItem to scoring

### DIFF
--- a/src/activities/ScoringEntity.js
+++ b/src/activities/ScoringEntity.js
@@ -14,6 +14,13 @@ export class ScoringEntity extends Entity {
 	}
 
 	/**
+	 * @returns {bool} Activitiy's isNewGradeItem (associated to new grade item and pending save)
+	 */
+	isNewGradeItem() {
+		return this._entity && this._entity.properties && this._entity.properties.isNewGradeItem;
+	}
+
+	/**
 	 * @returns {string} Activity's grade maxPoints, if there is a grade association
 	 */
 	gradeMaxPoints() {


### PR DESCRIPTION
[DE38401](https://rally1.rallydev.com/#/?detail=/defect/378337436428&fdp=true): New Assignment and Quiz Creation > Associated grade item names created with invalid special chars