### PR TITLE
US140433 Add discussion topic entity with name field related functions

### DIFF
--- a/src/activities/discussions/DiscussionTopicEntity.js
+++ b/src/activities/discussions/DiscussionTopicEntity.js
@@ -1,0 +1,9 @@
+import { Actions } from '../../hypermedia-constants.js';
+import { Entity } from '../../es6/Entity.js';
+import { performSirenAction } from '../../es6/SirenAction.js';
+
+/**
+ * DiscussionTopicEntity class representation of a D2L Discussion Topic.
+ */
+export class DiscussionTopicEntity extends Entity {
+}

--- a/src/activities/discussions/DiscussionTopicEntity.js
+++ b/src/activities/discussions/DiscussionTopicEntity.js
@@ -19,4 +19,26 @@ export class DiscussionTopicEntity extends Entity {
 	canEditName() {
 		return this._entity && this._entity.hasActionByName(Actions.discussions.topic.updateName);
 	}
+
+	/**
+	 * @summary Formats action and fields if topic name has changed and user has edit permission
+	 * @param {object} topic the topic that's being modified
+	 * @returns {object} the appropriate action/fields to update
+	 */
+	_formatUpdateNameAction(topic) {
+		const { name } = topic || {};
+
+		if (!name) return;
+		if (!this._hasFieldValueChanged(name, this.name())) return;
+		if (!this.canEditName()) return;
+
+		const action = this._entity.getActionByName(Actions.discussions.topic.updateName);
+		const fields = [{ name: 'name', value: name }];
+
+		return { action, fields };
+	}
+
+	_hasFieldValueChanged(currentValue, initialValue) {
+		return currentValue !== initialValue;
+	}
 }

--- a/src/activities/discussions/DiscussionTopicEntity.js
+++ b/src/activities/discussions/DiscussionTopicEntity.js
@@ -1,6 +1,6 @@
 import { Actions } from '../../hypermedia-constants.js';
 import { Entity } from '../../es6/Entity.js';
-import { performSirenAction } from '../../es6/SirenAction.js';
+import { performSirenActions } from '../../es6/SirenAction.js';
 
 /**
  * DiscussionTopicEntity class representation of a D2L Discussion Topic.
@@ -18,6 +18,22 @@ export class DiscussionTopicEntity extends Entity {
 	 */
 	canEditName() {
 		return this._entity && this._entity.hasActionByName(Actions.discussions.topic.updateName);
+	}
+
+	/**
+	 * @summary Fires all the formatted siren actions collectively
+	 * @param {object} topic the topic that's being modified
+	 */
+	async save(topic) {
+		if (!topic) return;
+
+		const updateNameAction = this._formatUpdateNameAction(topic);
+
+		const sirenActions = [
+			updateNameAction,
+		];
+
+		await performSirenActions(this._token, sirenActions);
 	}
 
 	/**

--- a/src/activities/discussions/DiscussionTopicEntity.js
+++ b/src/activities/discussions/DiscussionTopicEntity.js
@@ -21,6 +21,24 @@ export class DiscussionTopicEntity extends Entity {
 	}
 
 	/**
+	 * @summary Formats action and fields if topic name has changed and user has edit permission
+	 * @param {object} topic the topic that's being modified
+	 * @returns {object} the appropriate action/fields to update
+	 */
+	_formatUpdateNameAction(topic) {
+		const { name } = topic || {};
+
+		if (!name) return;
+		if (!this._hasFieldValueChanged(name, this.name())) return;
+		if (!this.canEditName()) return;
+
+		const action = this._entity.getActionByName(Actions.discussions.topic.updateName);
+		const fields = [{ name: 'name', value: name }];
+
+		return { action, fields };
+	}
+
+	/**
 	 * @summary Checks if topic entity has changed, primarily used for dirty check
 	 * @param {object} topic the topic that's being modified
 	 */
@@ -52,24 +70,6 @@ export class DiscussionTopicEntity extends Entity {
 		];
 
 		await performSirenActions(this._token, sirenActions);
-	}
-
-	/**
-	 * @summary Formats action and fields if topic name has changed and user has edit permission
-	 * @param {object} topic the topic that's being modified
-	 * @returns {object} the appropriate action/fields to update
-	 */
-	_formatUpdateNameAction(topic) {
-		const { name } = topic || {};
-
-		if (!name) return;
-		if (!this._hasFieldValueChanged(name, this.name())) return;
-		if (!this.canEditName()) return;
-
-		const action = this._entity.getActionByName(Actions.discussions.topic.updateName);
-		const fields = [{ name: 'name', value: name }];
-
-		return { action, fields };
 	}
 
 	_hasFieldValueChanged(currentValue, initialValue) {

--- a/src/activities/discussions/DiscussionTopicEntity.js
+++ b/src/activities/discussions/DiscussionTopicEntity.js
@@ -21,6 +21,24 @@ export class DiscussionTopicEntity extends Entity {
 	}
 
 	/**
+	 * @summary Checks if topic entity has changed, primarily used for dirty check
+	 * @param {object} topic the topic that's being modified
+	 */
+	equals(topic) {
+		const diffs = [
+			[topic.name, this.name()],
+		];
+
+		for (const [current, initial] of diffs) {
+			if (current !== initial) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	/**
 	 * @summary Fires all the formatted siren actions collectively
 	 * @param {object} topic the topic that's being modified
 	 */

--- a/src/activities/discussions/DiscussionTopicEntity.js
+++ b/src/activities/discussions/DiscussionTopicEntity.js
@@ -6,4 +6,31 @@ import { performSirenAction } from '../../es6/SirenAction.js';
  * DiscussionTopicEntity class representation of a D2L Discussion Topic.
  */
 export class DiscussionTopicEntity extends Entity {
+	/**
+	 * @returns {string} Name of the discussion topic
+	 */
+	name() {
+		return this._entity && this._entity.properties && this._entity.properties.name;
+	}
+
+	/**
+	 * @returns {bool} Whether or not the edit name action is present on the discussion topic entity
+	 */
+	canEditName() {
+		return this._entity && this._entity.hasActionByName(Actions.discussions.topic.updateName);
+	}
+
+	/**
+	 * Updates the discussion topic to have the given name
+	 * @param {string} name Name to set on the discussion topic
+	 */
+	async setName(name) {
+		const action = this.canEditName() && this._entity.getActionByName(Actions.discussions.topic.updateName);
+		if (!action) {
+			return;
+		}
+
+		const fields = [{ name: 'name', value: name }];
+		await performSirenAction(this._token, action, fields);
+	}
 }

--- a/src/activities/discussions/DiscussionTopicEntity.js
+++ b/src/activities/discussions/DiscussionTopicEntity.js
@@ -19,18 +19,4 @@ export class DiscussionTopicEntity extends Entity {
 	canEditName() {
 		return this._entity && this._entity.hasActionByName(Actions.discussions.topic.updateName);
 	}
-
-	/**
-	 * Updates the discussion topic to have the given name
-	 * @param {string} name Name to set on the discussion topic
-	 */
-	async setName(name) {
-		const action = this.canEditName() && this._entity.getActionByName(Actions.discussions.topic.updateName);
-		if (!action) {
-			return;
-		}
-
-		const fields = [{ name: 'name', value: name }];
-		await performSirenAction(this._token, action, fields);
-	}
 }

--- a/src/hypermedia-constants.js
+++ b/src/hypermedia-constants.js
@@ -783,6 +783,7 @@ export const Actions = {
 	},
 	discussions: {
 		topic: {
+			updateName: 'update-name',
 		},
 	},
 };

--- a/src/hypermedia-constants.js
+++ b/src/hypermedia-constants.js
@@ -780,5 +780,9 @@ export const Actions = {
 		checkout: 'checkout',
 		checkin: 'checkin',
 		commit: 'commit'
-	}
+	},
+	discussions: {
+		topic: {
+		},
+	},
 };

--- a/test/activities/discussions/DiscussionTopicEntity.test.js
+++ b/test/activities/discussions/DiscussionTopicEntity.test.js
@@ -1,0 +1,35 @@
+import { DiscussionTopicEntity } from '../../../src/activities/discussions/DiscussionTopicEntity.js';
+import { editableDiscussionTopic } from './data/EditableDiscussionTopic.js';
+import { expect } from '@open-wc/testing';
+import { nonEditableDiscussionTopic } from './data/NoneditableDiscussionTopic.js';
+import SirenParse from 'siren-parser';
+
+describe('DiscussionTopicEntity', () => {
+	let editableEntity, nonEditableEntity;
+
+	beforeEach(() => {
+		nonEditableEntity = SirenParse(nonEditableDiscussionTopic);
+		editableEntity = SirenParse(editableDiscussionTopic);
+	});
+
+	describe('Basic loading', () => {
+		it('reads name', () => {
+			const discussionTopic = new DiscussionTopicEntity(nonEditableEntity);
+			expect(discussionTopic.name()).to.equal('What a great topic');
+		});
+	});
+
+	describe('Editable', () => {
+		it('sets canEditName to true', () => {
+			const discussionTopic = new DiscussionTopicEntity(editableEntity);
+			expect(discussionTopic.canEditName()).to.be.true;
+		});
+	});
+
+	describe('Non Editable', () => {
+		it('sets canEditName to false', () => {
+			const discussionTopic = new DiscussionTopicEntity(nonEditableEntity);
+			expect(discussionTopic.canEditName()).to.be.false;
+		});
+	});
+});

--- a/test/activities/discussions/data/EditableDiscussionTopic.js
+++ b/test/activities/discussions/data/EditableDiscussionTopic.js
@@ -1,0 +1,65 @@
+const tenantId = 'f5aa43d7-c082-485c-84f5-4808147fe98a';
+
+export const editableDiscussionTopic = {
+	'class': [
+		'named-entity',
+		'topic',
+	],
+	'properties': {
+		'name': 'What a great topic',
+	},
+	'actions': [
+		{
+			'class': [
+				'required'
+			],
+			'href': `https://${tenantId}.discussions.api.dev.brightspace.com/6613/forums/10003/topics/10004`,
+			'name': 'update-name',
+			'method': 'PATCH',
+			'fields': [
+				{
+					'type': 'text',
+					'name': 'name',
+				}
+			]
+		},
+	],
+	'links': [
+		{
+			'rel': [
+				'self'
+			],
+			'href': `https://${tenantId}.discussions.api.dev.brightspace.com/6613/forums/10003/topics/10004`
+		},
+		{
+			'rel': [
+				'alternate'
+			],
+			'type': 'text/html',
+			'href': 'https://cd2022812192.devlms.brightspace.com/d2l/le/6613/discussions/topics/10004/View'
+		},
+		{
+			'rel': [
+				'https://activities.api.brightspace.com/rels/activity-usage'
+			],
+			'href': `https://${tenantId}.activities.api.dev.brightspace.com/activities/6606_3000_10004/usages/6613`
+		},
+		{
+			'rel': [
+				'organization',
+				'https://api.brightspace.com/rels/organization'
+			],
+			'href': `https://${tenantId}.organizations.api.dev.brightspace.com/6613`
+		},
+		{
+			'rel': [
+				'up',
+				'https://discussions.api.brightspace.com/rels/forum'
+			],
+			'href': `https://${tenantId}.discussions.api.dev.brightspace.com/6613/forums/10003`
+		},
+	],
+	'rel': [
+		'https://discussions.api.brightspace.com/rels/topic'
+	]
+};

--- a/test/activities/discussions/data/NonEditableDiscussionTopic.js
+++ b/test/activities/discussions/data/NonEditableDiscussionTopic.js
@@ -1,0 +1,49 @@
+const tenantId = 'f5aa43d7-c082-485c-84f5-4808147fe98a';
+
+export const nonEditableDiscussionTopic = {
+	'class': [
+		'named-entity',
+		'topic',
+	],
+	'properties': {
+		'name': 'What a great topic',
+	},
+	'links': [
+		{
+			'rel': [
+				'self'
+			],
+			'href': `https://${tenantId}.discussions.api.dev.brightspace.com/6613/forums/10003/topics/10004`
+		},
+		{
+			'rel': [
+				'alternate'
+			],
+			'type': 'text/html',
+			'href': 'https://cd2022812192.devlms.brightspace.com/d2l/le/6613/discussions/topics/10004/View'
+		},
+		{
+			'rel': [
+				'https://activities.api.brightspace.com/rels/activity-usage'
+			],
+			'href': `https://${tenantId}.activities.api.dev.brightspace.com/activities/6606_3000_10004/usages/6613`
+		},
+		{
+			'rel': [
+				'organization',
+				'https://api.brightspace.com/rels/organization'
+			],
+			'href': `https://${tenantId}.organizations.api.dev.brightspace.com/6613`
+		},
+		{
+			'rel': [
+				'up',
+				'https://discussions.api.brightspace.com/rels/forum'
+			],
+			'href': `https://${tenantId}.discussions.api.dev.brightspace.com/6613/forums/10003`
+		},
+	],
+	'rel': [
+		'https://discussions.api.brightspace.com/rels/topic'
+	]
+};


### PR DESCRIPTION
### Summary of Changes
* Added Discussion Topic Entity
* Added functions for fetching and setting name of topic, as well as permission check
* Added tests for the name/title field (Note that the only difference between the two test data files is the presence of `actions`)

### Rally Story
[US140433](https://rally1.rallydev.com/#/?detail=/userstory/640968148381&fdp=true): [ui] Edit topic title field