### PR TITLE
US140926 Refactor and add tests for discussion topic

### DIFF
--- a/test/activities/discussions/DiscussionTopicEntity.test.js
+++ b/test/activities/discussions/DiscussionTopicEntity.test.js
@@ -21,19 +21,30 @@ describe('DiscussionTopicEntity', () => {
 		});
 	});
 
-	describe('Editable', () => {
-		it('sets canEditName to true', () => {
-			const discussionTopic = new DiscussionTopicEntity(editableEntity);
-			expect(discussionTopic.canEditName()).to.be.true;
-			expect(discussionTopic.canEditDescription()).to.be.true;
+	describe('name', () => {
+		describe('canEditName', () => {
+			it('returns true when name is editable', () => {
+				const discussionTopic = new DiscussionTopicEntity(editableEntity);
+				expect(discussionTopic.canEditName()).to.be.true;
+			});
+
+			it('returns false when name is not editable', () => {
+				const discussionTopic = new DiscussionTopicEntity(nonEditableEntity);
+				expect(discussionTopic.canEditName()).to.be.false;
+			});
 		});
 	});
 
-	describe('Non Editable', () => {
-		it('sets canEditName to false', () => {
-			const discussionTopic = new DiscussionTopicEntity(nonEditableEntity);
-			expect(discussionTopic.canEditName()).to.be.false;
-			expect(discussionTopic.canEditDescription()).to.be.false;
+	describe('description', () => {
+		describe('canEditDescription', () => {
+			it('returns true when description is editable', () => {
+				const discussionTopic = new DiscussionTopicEntity(editableEntity);
+				expect(discussionTopic.canEditDescription()).to.be.true;
+			});
+
+			it('returns false when description are not editable', () => {
+				const discussionTopic = new DiscussionTopicEntity(nonEditableEntity);
+				expect(discussionTopic.canEditDescription()).to.be.false;
+			});
 		});
 	});
-});

--- a/test/activities/discussions/DiscussionTopicEntity.test.js
+++ b/test/activities/discussions/DiscussionTopicEntity.test.js
@@ -131,6 +131,49 @@ describe('DiscussionTopicEntity', () => {
 			expect(fetchMock.calls().length).to.equal(1);
 		});
 
+		describe('sync with forum feature', () => {
+			let discussionTopic;
+
+			beforeEach(() => {
+				discussionTopic = new DiscussionTopicEntity(editableEntity);
+			});
+
+			it('syncs when topic name is changed and topic is flagged to sync with forum name by the topic mobx entity', async() => {
+				await discussionTopic.save(
+					{ name: 'New name' },
+					true,
+				);
+
+				const form = await getFormData(fetchMock.lastCall().request);
+				if (!form.notSupported) {
+					expect(form.get('name')).to.equal('New name');
+					expect(form.get('shouldSyncNameWithForum')).to.equal('true');
+				}
+			});
+
+			it('does not fire patch topic action nor sync with forum name when topic name is unchanged', async() => {
+				await discussionTopic.save(
+					{ name: 'What a great topic' },
+					true,
+				);
+
+				expect(fetchMock.called()).to.be.false;
+			});
+
+			it('does not sync when topic is flagged to not sync with forum name by the topic mobx entity', async() => {
+				await discussionTopic.save(
+					{ name: 'New name' },
+					false,
+				);
+
+				const form = await getFormData(fetchMock.lastCall().request);
+				if (!form.notSupported) {
+					expect(form.get('name')).to.equal('New name');
+					expect(form.get('shouldSyncNameWithForum')).to.equal('false');
+				}
+			});
+		});
+
 		it('skips save if not dirty', async() => {
 			const discussionTopic = new DiscussionTopicEntity(editableEntity);
 

--- a/test/activities/discussions/DiscussionTopicEntity.test.js
+++ b/test/activities/discussions/DiscussionTopicEntity.test.js
@@ -16,8 +16,6 @@ describe('DiscussionTopicEntity', () => {
 		it('reads name', () => {
 			const discussionTopic = new DiscussionTopicEntity(nonEditableEntity);
 			expect(discussionTopic.name()).to.equal('What a great topic');
-			expect(discussionTopic.descriptionPlaintext()).to.equal('Example description for test case');
-			expect(discussionTopic.descriptionHtml()).to.equal('<p> Example description for test case </p>');
 		});
 	});
 
@@ -70,9 +68,36 @@ describe('DiscussionTopicEntity', () => {
 				expect(discussionTopic.canEditDescription()).to.be.true;
 			});
 
-			it('returns false when description are not editable', () => {
+			it('returns false when description are is editable', () => {
 				const discussionTopic = new DiscussionTopicEntity(nonEditableEntity);
 				expect(discussionTopic.canEditDescription()).to.be.false;
 			});
 		});
+
+		describe('properties', () => {
+			describe('descriptionPlaintext', () => {
+				it('returns description in plain text when description is editable', () => {
+					const discussionTopic = new DiscussionTopicEntity(editableEntity);
+					expect(discussionTopic.descriptionPlaintext()).to.equal('A great topic description');
+				});
+
+				it('returns description in plain text when description is not editable', () => {
+					const discussionTopic = new DiscussionTopicEntity(nonEditableEntity);
+					expect(discussionTopic.descriptionPlaintext()).to.equal('A great topic description');
+				});
+			});
+
+			describe('descriptionHtml', () => {
+				it('returns description in html format when description is editable', () => {
+					const discussionTopic = new DiscussionTopicEntity(editableEntity);
+					expect(discussionTopic.descriptionHtml()).to.equal('<p>A great topic description</p>');
+				});
+
+				it('returns description in html format when description is not editable', () => {
+					const discussionTopic = new DiscussionTopicEntity(nonEditableEntity);
+					expect(discussionTopic.descriptionHtml()).to.equal('<p>A great topic description</p>');
+				});
+			});
+		});
 	});
+});

--- a/test/activities/discussions/DiscussionTopicEntity.test.js
+++ b/test/activities/discussions/DiscussionTopicEntity.test.js
@@ -21,6 +21,34 @@ describe('DiscussionTopicEntity', () => {
 		});
 	});
 
+	describe('Equals', () => {
+		let modifiedEntity;
+
+		beforeEach(() => {
+			modifiedEntity = {
+				name: 'What a great topic',
+				description: '<p>A great topic description</p>',
+			};
+		});
+
+		it('returns true when equal', () => {
+			const discussionTopic = new DiscussionTopicEntity(editableEntity);
+			expect(discussionTopic.equals(modifiedEntity)).to.be.true;
+		});
+
+		it('returns false when name not equal', () => {
+			const discussionTopic = new DiscussionTopicEntity(editableEntity);
+			modifiedEntity.name = 'New name for discussion topic';
+			expect(discussionTopic.equals(modifiedEntity)).to.be.false;
+		});
+
+		it('returns false when description not equal', () => {
+			const discussionTopic = new DiscussionTopicEntity(editableEntity);
+			modifiedEntity.description = 'New description for discussion topic';
+			expect(discussionTopic.equals(modifiedEntity)).to.be.false;
+		});
+	});
+
 	describe('name', () => {
 		describe('canEditName', () => {
 			it('returns true when name is editable', () => {

--- a/test/activities/discussions/data/EditableDiscussionTopic.js
+++ b/test/activities/discussions/data/EditableDiscussionTopic.js
@@ -8,7 +8,7 @@ export const editableDiscussionTopic = {
 	],
 	'properties': {
 		'name': 'What a great topic',
-		'description': '<p> Example description for test case </p>',
+		'description': '<p>A great topic description</p>',
 	},
 	'actions': [
 		{
@@ -38,8 +38,8 @@ export const editableDiscussionTopic = {
 				'https://discussions.api.brightspace.com/rels/description'
 			],
 			'properties': {
-				'text': 'Example description for test case',
-				'html': '<p> Example description for test case </p>'
+				'text': 'A great topic description',
+				'html': '<p>A great topic description</p>'
 			},
 			'actions': [
 				{
@@ -50,7 +50,7 @@ export const editableDiscussionTopic = {
 						{
 							'type': 'text',
 							'name': 'description',
-							'value': '<p> Example description for test case </p>'
+							'value': '<p>A great topic description</p>'
 						}
 					]
 				}

--- a/test/activities/discussions/data/NonEditableDiscussionTopic.js
+++ b/test/activities/discussions/data/NonEditableDiscussionTopic.js
@@ -7,7 +7,7 @@ export const nonEditableDiscussionTopic = {
 	],
 	'properties': {
 		'name': 'What a great topic',
-		'description': '<p> Example description for test case </p>',
+		'description': '<p>A great topic description</p>',
 	},
 	'entities': [
 		{
@@ -21,8 +21,8 @@ export const nonEditableDiscussionTopic = {
 				'https://discussions.api.brightspace.com/rels/description'
 			],
 			'properties': {
-				'text': 'Example description for test case',
-				'html': '<p> Example description for test case </p>'
+				'text': 'A great topic description',
+				'html': '<p>A great topic description</p>'
 			},
 			'actions': []
 		}


### PR DESCRIPTION
### Motivation/Context
Originally only wanted to add tests for the sync topic and forum name feature but decided to do an overhaul for the existing discussion topic tests. Previously I only added load and permission check for name tests because equals and save functions weren't up yet.

### Summary of Changes
* Added tests for the `equals()` method
* Added tests for the `save()` method
* Added tests for sync topic and forum names (3 different scenarios - happy path, when topic name is unchanged, and when the UI component/mobx flags it as do not sync)
* Refactored description tests as they were added in the wrong place
* Added extra coverage for description entity's read-only properties

### Rally Story
[US140926](https://rally1.rallydev.com/#/?detail=/userstory/642120419367&fdp=true): Sync title between new topic + new forum