### PR TITLE
fix: DE48783 Set siren action for validateDates to immediate 

### DIFF
--- a/src/activities/ActivityUsageEntity.js
+++ b/src/activities/ActivityUsageEntity.js
@@ -397,7 +397,7 @@ export class ActivityUsageEntity extends Entity {
 			dates.displayInCalendar
 		);
 		if (datesActionAndFields) {
-			await performSirenAction(this._token, datesActionAndFields.action, datesActionAndFields.fields);
+			await performSirenAction(this._token, datesActionAndFields.action, datesActionAndFields.fields, true);
 		}
 	}
 


### PR DESCRIPTION
[DE48783](https://rally1.rallydev.com/#/?detail=/defect/638947673943&fdp=true): [FACE Quiz] > Console errors for PATCH request when start/end/due dates are in invalid states upon saving

Set immediate siren action for validate dates as the caller is awaiting the response anyway and queuing up the action results in an extra unhandled promise error.