### PR TITLE
DE50119: LTI multigrades > +Grade Item > 2 grade items associated

### DIFF
--- a/src/activities/associateGrade/AssociateGradeEntity.js
+++ b/src/activities/associateGrade/AssociateGradeEntity.js
@@ -66,7 +66,7 @@ export class AssociateGradeEntity extends Entity {
 
 	isGradeItemAssociatedToActivity() {
 		return this._entity && this._entity.properties && this._entity.properties.isAssociatedToActivity;
-	} 
+	}
 
 	hasSelectboxType() {
 		const newGradeEntity = this._getNewGradeEntity();

--- a/src/activities/associateGrade/AssociateGradeEntity.js
+++ b/src/activities/associateGrade/AssociateGradeEntity.js
@@ -64,6 +64,10 @@ export class AssociateGradeEntity extends Entity {
 		}
 	}
 
+	isGradeItemAssociatedToActivity() {
+		return this._entity && this._entity.properties && this._entity.properties.isAssociatedToActivity;
+	}
+
 	hasSelectboxType() {
 		const newGradeEntity = this._getNewGradeEntity();
 		return newGradeEntity && newGradeEntity.hasSubEntityByClass(Classes.activities.associateGrade.selectbox);

--- a/src/activities/associateGrade/AssociateGradeEntity.js
+++ b/src/activities/associateGrade/AssociateGradeEntity.js
@@ -66,7 +66,7 @@ export class AssociateGradeEntity extends Entity {
 
 	isGradeItemAssociatedToActivity() {
 		return this._entity && this._entity.properties && this._entity.properties.isAssociatedToActivity;
-	}
+	} 
 
 	hasSelectboxType() {
 		const newGradeEntity = this._getNewGradeEntity();


### PR DESCRIPTION
### Relevant Rally Links
https://rally1.rallydev.com/#/289692574792d/custom/355050439968?detail=%2Fdefect%2F650301242827

### Description
When adding a new grade item with the +Grade Item button, it is possible to add another grade item in the background using the Edit or Link to Existing option and selecting Create and Link to a new grade item. This will add a newly created grade item to the workingcopy but not display in the dialog, allowing it to be saved without knowing. See attached GIF for this behavior.
![newGradeItem](https://user-images.githubusercontent.com/91631476/194123313-18f78d4c-8750-4490-a302-abd75a2e6f1c.gif)

### Goal
The goal is to add a new property on the siren entity to allow for activities to determine if an associated grade is associated to an activity

### Related PRs
lms: https://github.com/Brightspace/lms/pull/28472
activities: https://github.com/BrightspaceHypermediaComponents/activities/pull/3012