### PR TITLE
US142491 Add POST body data to create forum with specified name

### DIFF
--- a/src/activities/discussions/DiscussionForumsEntity.js
+++ b/src/activities/discussions/DiscussionForumsEntity.js
@@ -22,6 +22,7 @@ export class DiscussionForumsEntity extends Entity {
 		if (!this.canCreateForum()) return;
 
 		const action = this._entity.getActionByName(Actions.discussions.forums.createForum);
-		await performSirenAction(this._token, action);
+		const fields = [{ name: 'name', value: name }];
+		await performSirenAction(this._token, action, fields);
 	}
 }


### PR DESCRIPTION
### Motivation/Context
Previously making POST request with empty forum name hence creating "Untitled" forums instead of specified forum name in the dialog

### Rally Story
[US142491](https://rally1.rallydev.com/#/?detail=/userstory/644998737805&fdp=true): [ui] Create change forum dialog