### PR TITLE
US142491 Create new forum and associate current topic with the new forum logic

### DIFF
--- a/src/activities/discussions/DiscussionTopicEntity.js
+++ b/src/activities/discussions/DiscussionTopicEntity.js
@@ -230,6 +230,30 @@ export class DiscussionTopicEntity extends Entity {
 		return this._entity && this._entity.properties && this._entity.properties.forumName;
 	}
 
+	/**
+	 * @returns {bool} Whether or not the create and associate with forum action is present on the discussion topic entity
+	 */
+	canCreateAndAssociateWithForum() {
+		return this._entity && this._entity.hasActionByName(Actions.discussions.topic.createAndAssociateWithForum);
+	}
+
+	/**
+	 * @summary Formats action and fields if topic name has changed and user has edit permission
+	 * @param {object} topic the topic that's being modified
+	 * @returns {object} the appropriate action/fields to update
+	 */
+	_formatCreateAndAssociateWithForumAction(topic) {
+		const { forumName } = topic || {};
+
+		if (!forumName) return;
+		if (!this._hasFieldValueChanged(forumName, this.forumName())) return;
+		if (!this.canCreateAndAssociateWithForum()) return;
+
+		const action = this._entity.getActionByName(Actions.discussions.topic.createAndAssociateWithForum);
+		const fields = [
+			{ name: 'forumName', value: forumName },
+		];
+
 		return { action, fields };
 	}
 

--- a/src/activities/discussions/DiscussionTopicEntity.js
+++ b/src/activities/discussions/DiscussionTopicEntity.js
@@ -220,6 +220,15 @@ export class DiscussionTopicEntity extends Entity {
 
 		const action = this._entity.getActionByName(Actions.discussions.topic.updateRatingType);
 		const fields = [{ name: 'ratingType', value: postRatingSelection }];
+		return { action, fields };
+	}
+
+	/**
+	 * @returns {string} name of the parent forum associated with the discussion topic
+	 */
+	forumName() {
+		return this._entity && this._entity.properties && this._entity.properties.forumName;
+	}
 
 		return { action, fields };
 	}

--- a/src/activities/discussions/DiscussionTopicEntity.js
+++ b/src/activities/discussions/DiscussionTopicEntity.js
@@ -290,12 +290,14 @@ export class DiscussionTopicEntity extends Entity {
 		const updateDescriptionAction = this._formatUpdateDescriptionAction(topic);
 		const syncDraftWithForum = this._formatSyncDraftStatusAction(topic, shouldSyncDraftWithForum);
 		const updateRatePostType = this._formatUpdateRatePostAction(topic);
+		const createAndAssociateWithForumAction = this._formatCreateAndAssociateWithForumAction(topic);
 
 		const sirenActions = [
 			updateNameAction,
 			updateDescriptionAction,
 			syncDraftWithForum,
-			updateRatePostType
+			updateRatePostType,
+			createAndAssociateWithForumAction,
 		];
 
 		await performSirenActions(this._token, sirenActions);

--- a/src/hypermedia-constants.js
+++ b/src/hypermedia-constants.js
@@ -699,6 +699,7 @@ export const Actions = {
 			updateDescription: 'update-description',
 			delete: 'delete-topic',
 			updateRatingType: 'update-ratingtype',
+			createAndAssociateWithForum: 'create-and-associate-with-forum',
 		},
 	},
 	rubrics: {


### PR DESCRIPTION
### Summary of Changes
* Added `forumName` getter for read-only view and potentially dirty check
* Added the create and associate with forum action
* Called the action in `save()` when applicable (i.e. when the user has permission and the action field value has changed)

### Rally Story
[US142491](https://rally1.rallydev.com/#/?detail=/userstory/644998737805&fdp=true): [ui] Create change forum dialog
