### PR TITLE
US142491 Enable individual save actions for discussion forums dialog

### DIFF
--- a/src/activities/discussions/DiscussionForumEntity.js
+++ b/src/activities/discussions/DiscussionForumEntity.js
@@ -1,6 +1,6 @@
 import { Actions, Rels } from '../../hypermedia-constants.js';
 import { Entity } from '../../es6/Entity.js';
-import { performSirenActions } from '../../es6/SirenAction.js';
+import { performSirenAction } from '../../es6/SirenAction.js';
 
 /**
  * DiscussionForumEntity class representation of a D2L Discussion Forum.
@@ -32,12 +32,10 @@ export class DiscussionForumEntity extends Entity {
 
 	/**
 	 * @summary Formats action and fields if forum name has changed and user has edit permission
-	 * @param {object} forum the forum that's being modified
+	 * @param {object} name the forum's new name
 	 * @returns {object} the appropriate action/fields to update
 	 */
-	_formatUpdateNameAction(forum) {
-		const { name } = forum || {};
-
+	_formatUpdateNameAction(name) {
 		if (!name) return;
 		if (!this._hasFieldValueChanged(name, this.name())) return;
 		if (!this.canEditName()) return;
@@ -51,37 +49,16 @@ export class DiscussionForumEntity extends Entity {
 	}
 
 	/**
-	 * @summary Checks if forum entity has changed, primarily used for dirty check
-	 * @param {object} forum the forum that's being modified
+	 * @summary Calls the update name action if name is provided and user has edit permission
+	 * @param {object} name the forum's new name
 	 */
-	equals(forum) {
-		const diffs = [
-			[forum.name, this.name()],
-		];
+	async updateName(name) {
+		if (!name) return;
+		if (!this.canEditName()) return;
 
-		for (const [current, initial] of diffs) {
-			if (current !== initial) {
-				return false;
-			}
-		}
-
-		return true;
-	}
-
-	/**
-	 * @summary Fires all the formatted siren actions collectively
-	 * @param {object} forum the forum that's being modified
-	 */
-	async save(forum) {
-		if (!forum) return;
-
-		const updateNameAction = this._formatUpdateNameAction(forum);
-
-		const sirenActions = [
-			updateNameAction,
-		];
-
-		await performSirenActions(this._token, sirenActions);
+		const sirenAction = this._formatUpdateNameAction(name);
+		const { action, fields } = sirenAction;
+		await performSirenAction(this._token, action, fields);
 	}
 
 	_hasFieldValueChanged(currentValue, initialValue) {

--- a/src/activities/discussions/DiscussionForumEntity.js
+++ b/src/activities/discussions/DiscussionForumEntity.js
@@ -32,7 +32,7 @@ export class DiscussionForumEntity extends Entity {
 
 	/**
 	 * @summary Formats action and fields if forum name has changed and user has edit permission
-	 * @param {object} name the forum's new name
+	 * @param {string} name the forum's new name
 	 * @returns {object} the appropriate action/fields to update
 	 */
 	_formatUpdateNameAction(name) {
@@ -50,7 +50,7 @@ export class DiscussionForumEntity extends Entity {
 
 	/**
 	 * @summary Calls the update name action if name is provided and user has edit permission
-	 * @param {object} name the forum's new name
+	 * @param {string} name the forum's new name
 	 */
 	async updateName(name) {
 		if (!name) return;

--- a/src/activities/discussions/DiscussionForumEntity.js
+++ b/src/activities/discussions/DiscussionForumEntity.js
@@ -57,6 +57,8 @@ export class DiscussionForumEntity extends Entity {
 		if (!this.canEditName()) return;
 
 		const sirenAction = this._formatUpdateNameAction(name);
+		if (!sirenAction) return;
+
 		const { action, fields } = sirenAction;
 		await performSirenAction(this._token, action, fields);
 	}

--- a/src/activities/discussions/DiscussionTopicEntity.js
+++ b/src/activities/discussions/DiscussionTopicEntity.js
@@ -239,7 +239,7 @@ export class DiscussionTopicEntity extends Entity {
 
 	/**
 	 * @summary Formats action and fields if topic name has changed and user has edit permission
-	 * @param {object} forumName the new forum's name
+	 * @param {string} forumName the new forum's name
 	 * @returns {object} the appropriate action/fields to update
 	 */
 	_formatCreateAndAssociateWithForumAction(forumName) {
@@ -257,7 +257,7 @@ export class DiscussionTopicEntity extends Entity {
 
 	/**
 	 * @summary Calls the create and associate with forum action if name is provided and user has create permission
-	 * @param {object} name the new forum's name
+	 * @param {string} name the new forum's name
 	 */
 	async createAndAssociateWithForum(name) {
 		if (!name) return;

--- a/src/activities/discussions/DiscussionTopicEntity.js
+++ b/src/activities/discussions/DiscussionTopicEntity.js
@@ -239,12 +239,10 @@ export class DiscussionTopicEntity extends Entity {
 
 	/**
 	 * @summary Formats action and fields if topic name has changed and user has edit permission
-	 * @param {object} topic the topic that's being modified
+	 * @param {object} forumName the new forum's name
 	 * @returns {object} the appropriate action/fields to update
 	 */
-	_formatCreateAndAssociateWithForumAction(topic) {
-		const { forumName } = topic || {};
-
+	_formatCreateAndAssociateWithForumAction(forumName) {
 		if (!forumName) return;
 		if (!this._hasFieldValueChanged(forumName, this.forumName())) return;
 		if (!this.canCreateAndAssociateWithForum()) return;
@@ -255,6 +253,19 @@ export class DiscussionTopicEntity extends Entity {
 		];
 
 		return { action, fields };
+	}
+
+	/**
+	 * @summary Calls the create and associate with forum action if name is provided and user has create permission
+	 * @param {object} name the new forum's name
+	 */
+	async createAndAssociateWithForum(name) {
+		if (!name) return;
+		if (!this.canCreateAndAssociateWithForum()) return;
+
+		const sirenAction = this._formatCreateAndAssociateWithForumAction(name);
+		const { action, fields } = sirenAction;
+		await performSirenAction(this._token, action, fields);
 	}
 
 	/**
@@ -290,14 +301,12 @@ export class DiscussionTopicEntity extends Entity {
 		const updateDescriptionAction = this._formatUpdateDescriptionAction(topic);
 		const syncDraftWithForum = this._formatSyncDraftStatusAction(topic, shouldSyncDraftWithForum);
 		const updateRatePostType = this._formatUpdateRatePostAction(topic);
-		const createAndAssociateWithForumAction = this._formatCreateAndAssociateWithForumAction(topic);
 
 		const sirenActions = [
 			updateNameAction,
 			updateDescriptionAction,
 			syncDraftWithForum,
 			updateRatePostType,
-			createAndAssociateWithForumAction,
 		];
 
 		await performSirenActions(this._token, sirenActions);

--- a/src/activities/discussions/DiscussionTopicEntity.js
+++ b/src/activities/discussions/DiscussionTopicEntity.js
@@ -264,6 +264,8 @@ export class DiscussionTopicEntity extends Entity {
 		if (!this.canCreateAndAssociateWithForum()) return;
 
 		const sirenAction = this._formatCreateAndAssociateWithForumAction(name);
+		if (!sirenAction) return;
+
 		const { action, fields } = sirenAction;
 		await performSirenAction(this._token, action, fields);
 	}


### PR DESCRIPTION
Used wrong Rally story number in commit messages sorry! It should be US142491

### Motivation/Context
The dirty check and save need to be handled centrally within the component because:
1. The topic (`isNew`) and forum (`isParentActivityNew`) states are only available in the front end, so there isn't really a way to preserve the dialog's default selected radio option because it relies on the aforementioned info.
2. The information needed by each of the radio option (input text field and select) are spread across different states (i.e. forum, topic, and categories). Note that when the "create a new forum" option is selected, changes made in the "choose a forum" option's select box should be disregarded for dirty check.


Depending on `isNew`, `isParentActivityNew`, whether save in place has been called before, and whether the user has made any changes in the dialog yet, the topic and forum may
1. Sync names (i.e. change the current forum's name) - this should only happen when 
   * `isNew = true` and `isParentActivityNew = true` AND
   * Either this is first time the user clicks save in place OR the user has never made any changes in the dialog
2. Otherwise, a new forum must be created with the specified name AND the topic needs to be associated with this newly created forum


Hence, I think it's better to add their own dirty check and save logic instead of lumping them with the group dirty check and save logic.

### Rally Story
[US142491](https://rally1.rallydev.com/#/?detail=/userstory/644998737805&fdp=true): [ui] Create change forum dialog