### PR TITLE
US142491 Add getter method to obtain selected category href

### DIFF
--- a/src/activities/CategoriesEntity.js
+++ b/src/activities/CategoriesEntity.js
@@ -80,6 +80,29 @@ export class CategoriesEntity extends Entity {
 		return this._entity.properties.selectedCategory;
 	}
 
+	getSelectedCategoryHref(categoryId) {
+		if (!this._entity) {
+			return;
+		}
+
+		const subEntities = this._entity.getSubEntitiesByClass(Classes.activities.category);
+
+		let selectedCategory;
+		if (subEntities) {
+			selectedCategory = subEntities.find(category => Number(category.properties.categoryId) === categoryId);
+		}
+
+		if (!selectedCategory) return;
+
+		// TODO: if user selects a category and this isn't saved yet, the action might be called Actions.activities.categories.select?
+		const action = selectedCategory.getActionByName(Actions.activities.categories.deselect);
+		if (!action) return;
+
+		const { href } = action;
+
+		return href;
+	}
+
 	equals(category) {
 		const selectedCategory = this.getSelectedCategory();
 		if (!selectedCategory) {


### PR DESCRIPTION
### Motivation/Context
Update: no need to consider deselect case because categories store is always saved and refreshed based on backend state, so we would always have the most up-to-date selected category href (which contains the deselect action)

### Rally Story
[US142491](https://rally1.rallydev.com/#/?detail=/userstory/644998737805&fdp=true): [ui] Create change forum dialog