### PR TITLE
US144752: Participation Options

### DIFF
--- a/src/activities/discussions/DiscussionTopicEntity.js
+++ b/src/activities/discussions/DiscussionTopicEntity.js
@@ -91,6 +91,31 @@ export class DiscussionTopicEntity extends Entity {
 	}
 
 	/**
+	 * @returns {bool} whether the update participation type action is present in the topic entity
+	 */
+	 canUpdateParticipationOption() {
+		const entity = this._entity;
+		return entity && entity.hasActionByName(Actions.discussions.topic.updateParticipationOption);
+	}
+
+	/**
+	 * Updates the topic's participation option selection
+	 * @param {object} topic the topic that's being modified
+	 */
+	 _formatUpdateParticipationOptionAction(topic) {
+		const { participationSelection } = topic || {};
+
+		if (!participationSelection || !this.canUpdateParticipationOption()) {
+			return;
+		}
+		if (!this._hasFieldValueChanged(participationSelection, this.participationSelection())) return;
+
+		const action = this._entity.getActionByName(Actions.discussions.topic.updateParticipationOption);
+		const fields = [{ name: 'participationType', value: participationSelection }];
+		return { action, fields };
+	}
+
+	/**
 	 * @summary Formats action and fields if topic name has changed and user has edit permission
 	 * @param {object} topic the topic that's being modified
 	 * @param {bool} shouldSyncNameWithForum determines whether topic and forum names should sync
@@ -127,14 +152,6 @@ export class DiscussionTopicEntity extends Entity {
 	canUpdateRatingType() {
 		const entity = this._entity;
 		return entity && entity.hasActionByName(Actions.discussions.topic.updateRatingType);
-	}
-
-	/**
-	 * @returns {bool} whether the update participation type action is present in the topic entity
-	 */
-	canUpdateParticipationOption() {
-		const entity = this._entity;
-		return entity && entity.hasActionByName(Actions.discussions.topic.updateParticipationOption);
 	}
 
 	/**
@@ -249,23 +266,6 @@ export class DiscussionTopicEntity extends Entity {
 
 		const action = this._entity.getActionByName(Actions.discussions.topic.updateRatingType);
 		const fields = [{ name: 'ratingType', value: postRatingSelection }];
-		return { action, fields };
-	}
-
-	/**
-	 * Updates the topic's participation option selection
-	 * @param {object} topic the topic that's being modified
-	 */
-	_formatUpdateParticipationOptionAction(topic) {
-		const { participationSelection } = topic || {};
-
-		if (!participationSelection || !this.canUpdateParticipationOption()) {
-			return;
-		}
-		if (!this._hasFieldValueChanged(participationSelection, this.participationSelection())) return;
-
-		const action = this._entity.getActionByName(Actions.discussions.topic.updateParticipationOption);
-		const fields = [{ name: 'participationType', value: participationSelection }];
 		return { action, fields };
 	}
 

--- a/src/activities/discussions/DiscussionTopicEntity.js
+++ b/src/activities/discussions/DiscussionTopicEntity.js
@@ -93,7 +93,7 @@ export class DiscussionTopicEntity extends Entity {
 	/**
 	 * @returns {bool} whether the update participation type action is present in the topic entity
 	 */
-	 canUpdateParticipationOption() {
+	canUpdateParticipationOption() {
 		const entity = this._entity;
 		return entity && entity.hasActionByName(Actions.discussions.topic.updateParticipationOption);
 	}
@@ -102,7 +102,7 @@ export class DiscussionTopicEntity extends Entity {
 	 * Updates the topic's participation option selection
 	 * @param {object} topic the topic that's being modified
 	 */
-	 _formatUpdateParticipationOptionAction(topic) {
+	_formatUpdateParticipationOptionAction(topic) {
 		const { participationSelection } = topic || {};
 
 		if (!participationSelection || !this.canUpdateParticipationOption()) {

--- a/src/activities/discussions/DiscussionTopicEntity.js
+++ b/src/activities/discussions/DiscussionTopicEntity.js
@@ -69,6 +69,9 @@ export class DiscussionTopicEntity extends Entity {
 		return fields && fields.value;
 	}
 
+	/**
+	 * @returns {number} participation option of discussion topic.
+	 */
 	participationSelection() {
 		const options = this.participationOptions();
 		const selected = options?.find(option => option?.selected);
@@ -76,7 +79,7 @@ export class DiscussionTopicEntity extends Entity {
 	}
 
 	/**
-	 * @returns {object[]} Post rating options of discussion topic.
+	 * @returns {object[]} participation options of discussion topic.
 	 */
 	participationOptions() {
 		if (!this.canUpdateRatingType()) return;
@@ -126,11 +129,13 @@ export class DiscussionTopicEntity extends Entity {
 		return entity && entity.hasActionByName(Actions.discussions.topic.updateRatingType);
 	}
 
+	/**
+	 * @returns {bool} whether the update participation type action is present in the topic entity
+	 */
 	canUpdateParticipationOption() {
 		const entity = this._entity;
 		return entity && entity.hasActionByName(Actions.discussions.topic.updateParticipationOption);
 	}
-
 
 	/**
 	 * @returns {object} a helper function to get topic description entity
@@ -247,6 +252,10 @@ export class DiscussionTopicEntity extends Entity {
 		return { action, fields };
 	}
 
+	/**
+	 * Updates the topic's participation option selection
+	 * @param {object} topic the topic that's being modified
+	 */
 	_formatUpdateParticipationOptionAction(topic) {
 		const { participationSelection } = topic || {};
 
@@ -316,7 +325,7 @@ export class DiscussionTopicEntity extends Entity {
 			[topic.name, this.name()],
 			[topic.description, this.descriptionEditorHtml()],
 			[topic.postRatingSelection, this.postRatingSelection()],
-			[topic.participationSelection,this.participationSelection()],
+			[topic.participationSelection, this.participationSelection()],
 		];
 
 		for (const [current, initial] of diffs) {

--- a/src/activities/discussions/DiscussionTopicEntity.js
+++ b/src/activities/discussions/DiscussionTopicEntity.js
@@ -82,7 +82,7 @@ export class DiscussionTopicEntity extends Entity {
 	 * @returns {object[]} participation options of discussion topic.
 	 */
 	participationOptions() {
-		if (!this.canUpdateRatingType()) return;
+		if (!this.canUpdateParticipationOption()) return;
 
 		const action = this._entity.getActionByName(Actions.discussions.topic.updateParticipationOption);
 		const fields = action && action.getFieldByName('participationType');

--- a/src/hypermedia-constants.js
+++ b/src/hypermedia-constants.js
@@ -701,6 +701,7 @@ export const Actions = {
 			updateDescription: 'update-description',
 			delete: 'delete-topic',
 			updateRatingType: 'update-ratingtype',
+			updateParticipationOption: 'update-participationtype',
 			createAndAssociateWithForum: 'create-and-associate-with-forum',
 		},
 	},

--- a/test/activities/discussions/DiscussionTopicEntity.test.js
+++ b/test/activities/discussions/DiscussionTopicEntity.test.js
@@ -58,7 +58,7 @@ describe('DiscussionTopicEntity', () => {
 
 		it('returns false when participation option not equal', () => {
 			const discussionTopic = new DiscussionTopicEntity(editableEntity);
-			modifiedEntity.postRatingSelection = 'anonymous';
+			modifiedEntity.participationSelection = 'anonymous';
 			expect(discussionTopic.equals(modifiedEntity)).to.be.false;
 		});
 	});

--- a/test/activities/discussions/DiscussionTopicEntity.test.js
+++ b/test/activities/discussions/DiscussionTopicEntity.test.js
@@ -29,6 +29,7 @@ describe('DiscussionTopicEntity', () => {
 				name: 'What a great topic',
 				description: '<p>A great topic description</p>',
 				postRatingSelection: 'None',
+				participationSelection: 'defaultParticipation',
 			};
 		});
 
@@ -54,6 +55,12 @@ describe('DiscussionTopicEntity', () => {
 			modifiedEntity.postRatingSelection = 'FiveStar';
 			expect(discussionTopic.equals(modifiedEntity)).to.be.false;
 		});
+
+		it('returns false when participation option not equal', () => {
+			const discussionTopic = new DiscussionTopicEntity(editableEntity);
+			modifiedEntity.postRatingSelection = 'anonymous';
+			expect(discussionTopic.equals(modifiedEntity)).to.be.false;
+		});
 	});
 
 	describe('name', () => {
@@ -75,6 +82,15 @@ describe('DiscussionTopicEntity', () => {
 			it('returns true when action present', () => {
 				const discussionTopic = new DiscussionTopicEntity(editableEntity);
 				expect(discussionTopic.canUpdateRatingType()).to.be.true;
+			});
+		});
+	});
+
+	describe('participationSelection', () => {
+		describe('canEditParticipationSelection', () => {
+			it('returns true when action present', () => {
+				const discussionTopic = new DiscussionTopicEntity(editableEntity);
+				expect(discussionTopic.canUpdateParticipationOption()).to.be.true;
 			});
 		});
 	});
@@ -169,6 +185,7 @@ describe('DiscussionTopicEntity', () => {
 				name: 'New name',
 				description: '<p>New description</p>',
 				postRatingSelection: 'None',
+				participationSelection: 'defadefaultParticipationult',
 			});
 
 			const form = await getFormData(fetchMock.lastCall().request);
@@ -231,6 +248,7 @@ describe('DiscussionTopicEntity', () => {
 				name: 'What a great topic',
 				description: '<p>A great topic description</p>',
 				postRatingSelection: 'None',
+				participationSelection: 'defaultParticipation',
 			});
 
 			expect(fetchMock.called()).to.be.false;
@@ -243,6 +261,7 @@ describe('DiscussionTopicEntity', () => {
 				name: 'New name',
 				description: '<p>New description</p>',
 				postRatingSelection: 'None',
+				participationSelection: 'defaultParticipation',
 			});
 
 			expect(fetchMock.called()).to.be.false;

--- a/test/activities/discussions/DiscussionTopicEntity.test.js
+++ b/test/activities/discussions/DiscussionTopicEntity.test.js
@@ -185,7 +185,7 @@ describe('DiscussionTopicEntity', () => {
 				name: 'New name',
 				description: '<p>New description</p>',
 				postRatingSelection: 'None',
-				participationSelection: 'defadefaultParticipationult',
+				participationSelection: 'defaultParticipation',
 			});
 
 			const form = await getFormData(fetchMock.lastCall().request);

--- a/test/activities/discussions/data/EditableDiscussionTopic.js
+++ b/test/activities/discussions/data/EditableDiscussionTopic.js
@@ -73,6 +73,33 @@ export const editableDiscussionTopic = {
 					]
 				}
 			]
+		},
+		{
+			'title' : 'Update participation type',
+			'href': `https://${tenantId}.api.dev.brightspace.com/d2l/api/hm/discussions/6609/forums/10025/topics/10026`,
+			'name': 'update-participationtype',
+			'method': 'PATCH',
+			'type': 'application/x-www-form-urlencoded',
+			'fields': [
+				{
+					'name': 'participationType',
+					'type': 'radio',
+					'value': [
+						{
+							'value': 'defaultParticipation',
+							'selected': true
+						},
+						{
+							'value': 'anonymous',
+							'selected': false
+						},
+						{
+							'value': 'startThreadToView',
+							'selected': false
+						},
+					]
+				}
+			]
 		}
 	],
 	'entities': [


### PR DESCRIPTION
https://rally1.rallydev.com/#/29180338367d/custom/486232622040?detail=%2Fuserstory%2F665853120201

SirenSDK support for participation options. 

Radio options, with three choices: 
- defaultParticipation 
- anonymous
- startThreadToView