### PR TITLE
feat: US145707: [Continued] UCE -> Move the Manual Completion component to Activities

### DIFF
--- a/src/activities/content/ContentCompletionEntity.js
+++ b/src/activities/content/ContentCompletionEntity.js
@@ -7,12 +7,12 @@ import { performSirenAction } from '../../es6/SirenAction.js';
 export class ContentCompletionEntity extends Entity {
 
 	/** @returns {bool} Whether or not the the content completion type is manual*/
-	async isContentCompletionManual() {
+	isContentCompletionManual() {
 		return this._entity && this._entity.hasClass('manual');
 	}
 
 	/** @returns {bool} Whether or not the the content has been marked as completed*/
-	async isContentCompleted() {
+	isContentCompleted() {
 		return this._entity && this._entity.hasClass('completed');
 	}
 

--- a/src/activities/content/ContentCompletionEntity.js
+++ b/src/activities/content/ContentCompletionEntity.js
@@ -1,0 +1,34 @@
+import { Entity } from '../../es6/Entity.js';
+import { performSirenAction } from '../../es6/SirenAction.js';
+
+/**
+ * ContentCompletionEntity class representation of a d2l content completion entity.
+ */
+export class ContentCompletionEntity extends Entity {
+
+	/** @returns {bool} Whether or not the the content completion type is manual*/
+	async isContentCompletionManual() {
+		return this._entity && this._entity.hasClass('manual');
+	}
+
+	/** @returns {bool} Whether or not the the content has been marked as completed*/
+	async isContentCompleted() {
+		return this._entity && this._entity.hasClass('completed');
+	}
+
+	/**
+	 * Updates the completion status to completed
+	 */
+	async markAsComplete() {
+		if (!this._entity) {
+			return;
+		}
+		const action = this._entity.getActionByName('mark-as-complete');
+		if (!action) {
+			return;
+		}
+
+		const res = await performSirenAction(this._token, action);
+		return res;
+	}
+}


### PR DESCRIPTION
Rally Link: https://rally1.rallydev.com/#/289692574792d/custom/355050439968?detail=%2Fuserstory%2F671674197365

This PR defines the ContentCompletionEntity class to be used by the activities repo for the refactor.

Related PR:
- Activities: https://github.com/BrightspaceHypermediaComponents/activities/pull/3325
- UCE: https://github.com/Brightspace/unified-content-experience/pull/331