### PR TITLE
DE51074: Lessons > discard changes dialog appears after FACE page is saved

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@brightspace-hmc/siren-sdk",
-  "version": "2.48.1",
+  "version": "2.49.0",
   "type": "module",
   "description": "",
   "main": "index.js",

--- a/src/activities/ActivityUsageEntity.js
+++ b/src/activities/ActivityUsageEntity.js
@@ -650,8 +650,8 @@ export class ActivityUsageEntity extends Entity {
 	}
 
 	equals(activity) {
-		const currentStartDateType = this.startDateType() ? this.startDateType().toString() : this.defaultStartDateType()?.toString();
-		const currentEndDateType = this.endDateType() ? this.endDateType().toString() : this.defaultEndDateType()?.toString();
+		const currentStartDateType = this.startDateType() ? String(this.startDateType()) : String(this.defaultStartDateType());
+		const currentEndDateType = this.endDateType() ? String(this.endDateType()) : String(this.defaultEndDateType());
 
 		const diffs = [
 			[this.dueDate(), activity.dates.dueDate],

--- a/src/activities/ActivityUsageEntity.js
+++ b/src/activities/ActivityUsageEntity.js
@@ -651,7 +651,7 @@ export class ActivityUsageEntity extends Entity {
 
 	equals(activity) {
 		const currentStartDateType = this.startDateType() ? String(this.startDateType()) : String(this.defaultStartDateType());
-		const currentEndDateType = this.endDateType() ? String(this.endDateType()) : String(this.defaultEndDateType());
+		const currentEndDateType = this.endDateType() ? String(this.endDateType()) : String(this.defaultEndDateType()?.toString());
 
 		const diffs = [
 			[this.dueDate(), activity.dates.dueDate],

--- a/test/activities/ActivityUsageEntity.test.js
+++ b/test/activities/ActivityUsageEntity.test.js
@@ -325,11 +325,11 @@ describe('ActivityUsageEntity', () => {
 			expect(entity.equals({
 				dates: {
 					dueDate: '2019-12-26T04:59:00.000Z',
-					startDate: undefined,
-					startDateType: undefined,
-					endDate: undefined,
-					endDateType: undefined,
-					displayInCalendar: undefined
+					startDate: 'undefined',
+					startDateType: 'undefined',
+					endDate: 'undefined',
+					endDateType: 'undefined',
+					displayInCalendar: 'undefined'
 				},
 				isDraft: true
 			})).to.be.true;
@@ -339,11 +339,11 @@ describe('ActivityUsageEntity', () => {
 			expect(entity.equals({
 				dates: {
 					dueDate: '2019-12-26T04:59:00.000Z',
-					startDate: undefined,
-					startDateType: undefined,
-					endDate: undefined,
-					endDateType: undefined,
-					displayInCalendar: undefined
+					startDate: 'undefined',
+					startDateType: 'undefined',
+					endDate: 'undefined',
+					endDateType: 'undefined',
+					displayInCalendar: 'undefined'
 				},
 				isDraft: false
 			})).to.be.false;

--- a/test/activities/ActivityUsageEntity.test.js
+++ b/test/activities/ActivityUsageEntity.test.js
@@ -325,11 +325,11 @@ describe('ActivityUsageEntity', () => {
 			expect(entity.equals({
 				dates: {
 					dueDate: '2019-12-26T04:59:00.000Z',
-					startDate: 'undefined',
+					startDate: undefined,
 					startDateType: 'undefined',
-					endDate: 'undefined',
+					endDate: undefined,
 					endDateType: 'undefined',
-					displayInCalendar: 'undefined'
+					displayInCalendar: undefined
 				},
 				isDraft: true
 			})).to.be.true;
@@ -339,11 +339,11 @@ describe('ActivityUsageEntity', () => {
 			expect(entity.equals({
 				dates: {
 					dueDate: '2019-12-26T04:59:00.000Z',
-					startDate: 'undefined',
+					startDate: undefined,
 					startDateType: 'undefined',
-					endDate: 'undefined',
+					endDate: undefined,
 					endDateType: 'undefined',
-					displayInCalendar: 'undefined'
+					displayInCalendar: undefined
 				},
 				isDraft: false
 			})).to.be.false;


### PR DESCRIPTION
## Relevant Rally Link
https://rally1.rallydev.com/#/289692574792d/custom/355050439968?detail=%2Fdefect%2F671995940833
## Description
**Note**: The defect mentions having to save first but it also occurs without saving

A recent addition of the ability to set the availability type (access restricted until available, submission restricted until available etc.) on some FACE pages was introduced and needed to be added to the dirty check as a result.

In the case where the value of `this.defaultStartDateType()` is undefined (i.e most of lessons FACE pages) `this.defaultStartDateType()?.toString()` would return `undefined` as type undefined, not as type string. So left (type undefined) would not actually equal right (type string) in the comparison causing the check to resolve as dirty and trigger the discard changes dialog.

Using `String()` will cover the case of having an undefined value.