### PR TITLE
DE51074 > Followup: remove extra toString that snuck in

### DIFF
--- a/src/activities/ActivityUsageEntity.js
+++ b/src/activities/ActivityUsageEntity.js
@@ -651,7 +651,7 @@ export class ActivityUsageEntity extends Entity {
 
 	equals(activity) {
 		const currentStartDateType = this.startDateType() ? String(this.startDateType()) : String(this.defaultStartDateType());
-		const currentEndDateType = this.endDateType() ? String(this.endDateType()) : String(this.defaultEndDateType()?.toString());
+		const currentEndDateType = this.endDateType() ? String(this.endDateType()) : String(this.defaultEndDateType());
 
 		const diffs = [
 			[this.dueDate(), activity.dates.dueDate],


### PR DESCRIPTION
## Description
Recently merged a PR for DE51074 and accidently kept an extra `toString()` while debugging tests. Removing that in this PR
## Related PRs
https://github.com/BrightspaceHypermediaComponents/siren-sdk/pull/557