### PR TITLE
US146290 add no group or sections class check

### DIFF
--- a/src/activities/discussions/DiscussionTopicEntity.js
+++ b/src/activities/discussions/DiscussionTopicEntity.js
@@ -356,6 +356,20 @@ export class DiscussionTopicEntity extends Entity {
 	}
 
 	/**
+	 * @returns {bool} If the topic's course has no groups or sections
+	 */
+	hasNoGroupsOrSections() {
+		if (!this._entity) {
+			return false;
+		}
+		const subEntity = this._entity.getSubEntityByRel(Rels.Discussions.groupSectionRestrictions);
+		if (!subEntity) {
+			return false;
+		}
+		return subEntity.hasClass(Classes.discussions.noGroupsOrSections);
+	}
+
+	/**
 	 * @summary Checks if topic entity has changed, primarily used for dirty check
 	 * @param {object} topic the topic that's being modified
 	 */

--- a/src/hypermedia-constants.js
+++ b/src/hypermedia-constants.js
@@ -141,6 +141,7 @@ export const Rels = {
 		forum: 'https://discussions.api.brightspace.com/rels/forum',
 		topicCategories: 'https://discussions.api.brightspace.com/rels/topic-categories',
 		topic: 'https://discussions.api.brightspace.com/rels/topic',
+		groupSectionRestrictions: 'https://discussions.api.brightspace.com/rels/group-section-restrictions'
 	},
 	// Files API sub-domain rels
 	Files: {
@@ -379,7 +380,8 @@ export const Classes = {
 		topic: 'topic',
 		description: 'description',
 		unlocked: 'unlocked',
-		hasPosts: 'has-posts'
+		hasPosts: 'has-posts',
+		noGroupsOrSections: 'no-groups-or-sections',
 	},
 	enrollments: {
 		enrollment: 'enrollment',


### PR DESCRIPTION
[US146290](https://rally1.rallydev.com/#/?detail=/userstory/672645516489&fdp=true): [api + ui] No groups or sections state

Add check for `no-groups-or-sections` class when a course has no sections or groups. 

[LMS PR](https://github.com/Brightspace/lms/pull/31062)