### PR TITLE
feat:US146310 add basics for group restrictions

### DIFF
--- a/src/activities/discussions/DiscussionTopicEntity.js
+++ b/src/activities/discussions/DiscussionTopicEntity.js
@@ -369,6 +369,17 @@ export class DiscussionTopicEntity extends Entity {
 		return subEntity.hasClass(Classes.discussions.noGroupsOrSections);
 	}
 
+	groupSectionRestrictionsHref() {
+		if (!this._entity) {
+			return false;
+		}
+		const subEntity = this._entity.getSubEntityByRel(Rels.Discussions.groupSectionRestrictions);
+		if (!subEntity) {
+			return false;
+		}
+		return subEntity.href;
+	}
+
 	/**
 	 * @summary Checks if topic entity has changed, primarily used for dirty check
 	 * @param {object} topic the topic that's being modified

--- a/src/activities/discussions/TopicGroupSectionRestrictionsEntity.js
+++ b/src/activities/discussions/TopicGroupSectionRestrictionsEntity.js
@@ -1,0 +1,8 @@
+import { Entity } from '../../es6/Entity.js';
+
+/**
+ * TopicGroupSectionRestrictionsEntity class representation of a D2L Discussion Topic Group Section Restrictions entity.
+ */
+export class TopicGroupSectionRestrictionsEntity extends Entity {
+	// TODO: implement
+}


### PR DESCRIPTION
[US146310](https://rally1.rallydev.com/#/?detail=/userstory/672757938285&fdp=true): [api] set up initial working-copy for discussion-topic

Just very basic stuff required for us to be able to call the section-restrictions endpoint from the UI