### PR TITLE
feat: US144988: [Continued] Add the Manual Completion component to LX

### DIFF
--- a/src/activities/content/ContentCompletionEntity.js
+++ b/src/activities/content/ContentCompletionEntity.js
@@ -8,7 +8,7 @@ export class ContentCompletionEntity extends Entity {
 
 	/** @returns {bool} Whether or not the the content completion type is manual*/
 	isContentCompletionManual() {
-		return this._entity && this._entity.hasClass('manual');
+		return this._entity && this._entity.hasClass('requires-user-mark-as-complete');
 	}
 
 	/** @returns {bool} Whether or not the the content has been marked as completed*/


### PR DESCRIPTION
Rally Link: https://rally1.rallydev.com/#/289692574792d/custom/355050439968?detail=%2Fuserstory%2F667999409985

This PR updates the class we use to identify manually completable activity types from `manual` (which is also used for tool activity types e.g. assignments and quizzes, which we would not like to support for manual completion) to `requires-user-mark-as-complete`.

Related PR:
- LMS: https://github.com/Brightspace/lms/pull/31376