### PR TITLE
DE51360: [CERT] Manual Completion rendering for incorrect ActivityTypes

### DIFF
--- a/src/activities/content/ContentCompletionEntity.js
+++ b/src/activities/content/ContentCompletionEntity.js
@@ -8,7 +8,7 @@ export class ContentCompletionEntity extends Entity {
 
 	/** @returns {bool} Whether or not the the content completion type is manual*/
 	isContentCompletionManual() {
-		return this._entity && this._entity.hasClass('manual');
+		return this._entity && this._entity.hasClass('requires-user-mark-as-complete');
 	}
 
 	/** @returns {bool} Whether or not the the content has been marked as completed*/


### PR DESCRIPTION
Change name of class used to determine manual completion component visibility

Backport of: https://github.com/BrightspaceHypermediaComponents/siren-sdk/pull/566

# Related PRs:

- LMS: https://github.com/Brightspace/lms/pull/31470
- BSI: https://github.com/Brightspace/brightspace-integration/pull/8035
- Erroneous backport: https://github.com/BrightspaceHypermediaComponents/siren-sdk/pull/568
- Erroneous backport 2: https://github.com/BrightspaceHypermediaComponents/siren-sdk/pull/569