### PR TITLE
DE51142 Remove auto set graded checkbox from dirty check for quiz entity

### DIFF
--- a/src/activities/quizzes/QuizEntity.js
+++ b/src/activities/quizzes/QuizEntity.js
@@ -1036,7 +1036,6 @@ export class QuizEntity extends Entity {
 			[this.password(), quiz.password],
 			[this.notificationEmail(), quiz.notificationEmail],
 			[this.isPreventMovingBackwardsEnabled(), quiz.preventMovingBackwards],
-			[this.isAutoSetGradedEnabled(), quiz.autoSetGraded],
 			[this.isSyncGradebookEnabled(), quiz.syncGradebook],
 			[this.isSyncGradebookDefault(), quiz.syncGradebookDefault],
 			[this.descriptionEditorHtml(), quiz.description],

--- a/test/activities/quizzes/QuizEntity.test.js
+++ b/test/activities/quizzes/QuizEntity.test.js
@@ -91,10 +91,10 @@ describe('QuizEntity', () => {
 			expect(quizEntity.equals(modifiedEntity)).to.be.false;
 		});
 
-		it('returns false when autoSetGraded not equal', () => {
+		it('returns true even when autoSetGraded not equal', () => {
 			const quizEntity = new QuizEntity(editableEntity);
 			modifiedEntity.autoSetGraded = false;
-			expect(quizEntity.equals(modifiedEntity)).to.be.false;
+			expect(quizEntity.equals(modifiedEntity)).to.be.true;
 		});
 
 		it('returns false when syncGradebook not equal', () => {


### PR DESCRIPTION
### Motivation/Context
auto set graded checkbox is now called "Auto-publish attempt results immediately upon completion":
<img src="https://user-images.githubusercontent.com/10677430/211107545-37af50f4-a580-47d3-96a8-eca98d2f92ee.png" width="300" />


[We are setting the checkbox to true by default if it's a new quiz in FACE](https://github.com/BrightspaceHypermediaComponents/activities/pull/2058) but since this happens after the initial load of quiz entity, new quiz would always be marked as dirty. The idea here is to move dirty check to the component level because the component has information to whether the quiz is new and if save in place has been clicked yet, so it can accurately determine whether the checkbox should be considered dirty.

Related PR: https://github.com/BrightspaceHypermediaComponents/activities/pull/3450

### Rally Defect
[DE51142](https://rally1.rallydev.com/#/?detail=/defect/672370058493&fdp=true): [New Quiz Creation] > Dirty check broken in 23.01