### PR TITLE
feat: US137422 - Updates to handle viewing merged course offerings

### DIFF
--- a/src/hypermedia-constants.js
+++ b/src/hypermedia-constants.js
@@ -556,8 +556,10 @@ export const Classes = {
 	},
 	relativeUri: 'relative-uri',
 	ipsis: {
-		originalTarget: 'original-target',
-		target: 'target'
+		sisCourseMerge: {
+			originalTarget: 'original-target',
+			target: 'target'
+		}
 	}
 };
 

--- a/src/hypermedia-constants.js
+++ b/src/hypermedia-constants.js
@@ -175,7 +175,8 @@ export const Rels = {
 		SISCourseMerge: {
 			courseMergeOfferings: 'https://ipsis.api.brightspace.com/rels/course-merge-offerings',
 			courseMergeOffering: 'https://ipsis.api.brightspace.com/rels/course-merge-offering',
-			selectedCourseMergeOfferings: 'https://ipsis.api.brightspace.com/rels/selected-course-merge-offerings'
+			selectedCourseMergeOfferings: 'https://ipsis.api.brightspace.com/rels/selected-course-merge-offerings',
+			mergedCourseOfferings: 'https://ipsis.api.brightspace.com/rels/merged-course-offerings'
 		}
 	},
 	// Quizzes API sub-domain rels
@@ -553,7 +554,11 @@ export const Classes = {
 	meetings: {
 		bookable: 'bookable'
 	},
-	relativeUri: 'relative-uri'
+	relativeUri: 'relative-uri',
+	ipsis: {
+		originalTarget: 'original-target',
+		target: 'target'
+	}
 };
 
 export const Actions = {
@@ -758,7 +763,8 @@ export const Actions = {
 			mergeCourseOfferings: 'merge-course-offerings',
 			searchCourseOfferings: 'search-course-offerings',
 			select: 'select',
-			selectAsTarget: 'select-as-target'
+			selectAsTarget: 'select-as-target',
+			unmergeCourseOfferings: 'unmerge-course-offerings'
 		}
 	},
 	quizzes: {

--- a/src/ipsis/course-merge/CourseMergeMergedOfferingCollectionEntity.js
+++ b/src/ipsis/course-merge/CourseMergeMergedOfferingCollectionEntity.js
@@ -1,6 +1,6 @@
 /**
- * SelectedCourseMergeOfferingCollectionEntity class representation of a list of course merge offering as defined in the LMS
- * See: ISirenCourseMergeSerializer.SerializeSelectedCourseOfferingListResult
+ * CourseMergeMergedOfferingCollectionEntity class representation of a list of course merge merged offerings as defined in the LMS
+ * See: ISirenCourseMergeSerializer.SerializeMergedCoursesListResult
  */
 import { Actions, Classes } from '../../hypermedia-constants.js';
 import { Entity } from '../../es6/Entity.js';
@@ -8,10 +8,7 @@ import { performSirenAction } from '../../es6/SirenAction.js';
 
 export class CourseMergeMergedOfferingCollectionEntity extends Entity {
 	originalSourceCourseMergeOfferings() {
-		if (!this._entity) {
-			return;
-		}
-		return this._entity.entities?.filter(course => !course.class.includes(Classes.ipsis.originalTarget));
+		return this._entity?.entities?.filter(course => !course.class.includes(Classes.ipsis.originalTarget));
 	}
 
 	originalTargetCourseMergeOffering() {
@@ -23,7 +20,7 @@ export class CourseMergeMergedOfferingCollectionEntity extends Entity {
 	}
 
 	hasUnmergeAction() {
-		return this._entity.hasActionByName(Actions.ipsis.sisCourseMerge.unmergeCourseOfferings);
+		return this._entity?.hasActionByName(Actions.ipsis.sisCourseMerge.unmergeCourseOfferings);
 	}
 
 	getUnmergeAction() {
@@ -34,13 +31,13 @@ export class CourseMergeMergedOfferingCollectionEntity extends Entity {
 		return this._entity.getActionByName(Actions.ipsis.sisCourseMerge.unmergeCourseOfferings);
 	}
 
-	async unmerge() {
+	unmerge() {
 		const action = this.getUnmergeAction();
 		if (!action) {
 			return;
 		}
 
-		return await performSirenAction(this._token, action, null, true);
+		return performSirenAction(this._token, action, null, true);
 	}
 }
 

--- a/src/ipsis/course-merge/CourseMergeMergedOfferingCollectionEntity.js
+++ b/src/ipsis/course-merge/CourseMergeMergedOfferingCollectionEntity.js
@@ -2,7 +2,7 @@
  * CourseMergeMergedOfferingCollectionEntity class representation of a list of course merge merged offerings as defined in the LMS
  * See: ISirenCourseMergeSerializer.SerializeMergedCoursesListResult
  */
-import { Actions, Classes } from '../../hypermedia-constants.js';
+import { Actions, Classes, Rels } from '../../hypermedia-constants.js';
 import { Entity } from '../../es6/Entity.js';
 import { performSirenAction } from '../../es6/SirenAction.js';
 
@@ -21,6 +21,14 @@ export class CourseMergeMergedOfferingCollectionEntity extends Entity {
 
 	canUnmergeCourses() {
 		return this._entity?.properties?.canUnmergeCourses;
+	}
+
+	courseMergeOfferingsHref() {
+		if (!this._entity?.hasLinkByRel(Rels.ipsis.sisCourseMerge.courseMergeOfferings)) {
+			return;
+		}
+
+		return this._entity.getLinkByRel(Rels.ipsis.sisCourseMerge.courseMergeOfferings).href;
 	}
 
 	hasUnmergeAction() {

--- a/src/ipsis/course-merge/CourseMergeMergedOfferingCollectionEntity.js
+++ b/src/ipsis/course-merge/CourseMergeMergedOfferingCollectionEntity.js
@@ -8,11 +8,11 @@ import { performSirenAction } from '../../es6/SirenAction.js';
 
 export class CourseMergeMergedOfferingCollectionEntity extends Entity {
 	originalSourceCourseMergeOfferings() {
-		return this._entity?.entities?.filter(course => !course.class.includes(Classes.ipsis.originalTarget));
+		return this._entity?.entities?.filter(course => !course.class.includes(Classes.ipsis.sisCourseMerge.originalTarget));
 	}
 
 	originalTargetCourseMergeOffering() {
-		return this._entity?.getSubEntitiesByClass(Classes.ipsis.originalTarget)?.[0];
+		return this._entity?.getSubEntitiesByClass(Classes.ipsis.sisCourseMerge.originalTarget)?.[0];
 	}
 
 	userOwnedByMultipleSourceSystems() {

--- a/src/ipsis/course-merge/CourseMergeMergedOfferingCollectionEntity.js
+++ b/src/ipsis/course-merge/CourseMergeMergedOfferingCollectionEntity.js
@@ -19,6 +19,10 @@ export class CourseMergeMergedOfferingCollectionEntity extends Entity {
 		return this._entity?.properties?.userOwnedByMultipleSourceSystems;
 	}
 
+	canUnmergeCourses() {
+		return this._entity?.properties?.canUnmergeCourses;
+	}
+
 	hasUnmergeAction() {
 		return this._entity?.hasActionByName(Actions.ipsis.sisCourseMerge.unmergeCourseOfferings);
 	}

--- a/src/ipsis/course-merge/CourseMergeMergedOfferingCollectionEntity.js
+++ b/src/ipsis/course-merge/CourseMergeMergedOfferingCollectionEntity.js
@@ -15,6 +15,61 @@ export class CourseMergeMergedOfferingCollectionEntity extends Entity {
 		return this._entity?.getSubEntitiesByClass(Classes.ipsis.sisCourseMerge.originalTarget)?.[0];
 	}
 
+	prependOriginalSourceCourseMergeOfferings(previousCourseMergeMergedOfferingCollectionEntity) {
+		this._entity.entities.unshift(...previousCourseMergeMergedOfferingCollectionEntity.originalSourceCourseMergeOfferings());
+	}
+
+	totalCount() {
+		return this._pagingInfo()?.totalCount;
+	}
+
+	page() {
+		return this._pagingInfo()?.page;
+	}
+
+	pageSize() {
+		return this._pagingInfo()?.pageSize;
+	}
+
+	loadMorePageSize() {
+		const pageSize = this.pageSize();
+		const totalCount = this.totalCount() ?? 0;
+		const courseMergeOfferingsLength = this._entity?.entities?.length ?? 0;
+		// if pageSize is larger than the number remaining items, return the number of remaining items to be loaded
+		if (totalCount < courseMergeOfferingsLength + (pageSize ?? 0)) {
+			return totalCount - courseMergeOfferingsLength;
+		}
+		return pageSize;
+	}
+
+	_pagingInfo() {
+		return this._entity?.properties?.pagingInfo;
+	}
+
+	hasNextPage() {
+		return this._entity.hasLinkByRel('next');
+	}
+
+	hasPrevPage() {
+		return this._entity.hasLinkByRel('prev');
+	}
+
+	nextPageHref() {
+		if (!this.hasNextPage()) {
+			return;
+		}
+
+		return this._entity.getLinkByRel('next').href;
+	}
+
+	prevPageHref() {
+		if (!this.hasPrevPage()) {
+			return;
+		}
+
+		return this._entity.getLinkByRel('prev').href;
+	}
+
 	userOwnedByMultipleSourceSystems() {
 		return this._entity?.properties?.userOwnedByMultipleSourceSystems;
 	}

--- a/src/ipsis/course-merge/CourseMergeMergedOfferingCollectionEntity.js
+++ b/src/ipsis/course-merge/CourseMergeMergedOfferingCollectionEntity.js
@@ -1,0 +1,46 @@
+/**
+ * SelectedCourseMergeOfferingCollectionEntity class representation of a list of course merge offering as defined in the LMS
+ * See: ISirenCourseMergeSerializer.SerializeSelectedCourseOfferingListResult
+ */
+import { Actions, Classes } from '../../hypermedia-constants.js';
+import { Entity } from '../../es6/Entity.js';
+import { performSirenAction } from '../../es6/SirenAction.js';
+
+export class CourseMergeMergedOfferingCollectionEntity extends Entity {
+	originalSourceCourseMergeOfferings() {
+		if (!this._entity) {
+			return;
+		}
+		return this._entity.entities?.filter(course => !course.class.includes(Classes.ipsis.originalTarget));
+	}
+
+	originalTargetCourseMergeOffering() {
+		return this._entity?.getSubEntitiesByClass(Classes.ipsis.originalTarget)?.[0];
+	}
+
+	userOwnedByMultipleSourceSystems() {
+		return this._entity?.properties?.userOwnedByMultipleSourceSystems;
+	}
+
+	hasUnmergeAction() {
+		return this._entity.hasActionByName(Actions.ipsis.sisCourseMerge.unmergeCourseOfferings);
+	}
+
+	getUnmergeAction() {
+		if (!this.hasUnmergeAction()) {
+			return;
+		}
+
+		return this._entity.getActionByName(Actions.ipsis.sisCourseMerge.unmergeCourseOfferings);
+	}
+
+	async unmerge() {
+		const action = this.getUnmergeAction();
+		if (!action) {
+			return;
+		}
+
+		return await performSirenAction(this._token, action, null, true);
+	}
+}
+

--- a/src/ipsis/course-merge/CourseMergeOfferingEntity.js
+++ b/src/ipsis/course-merge/CourseMergeOfferingEntity.js
@@ -110,9 +110,9 @@ export class CourseMergeOfferingEntity extends Entity {
 	}
 
 	mergedCourseOfferingsHref() {
-		if (!this._entity || !this._entity.hasLinkByRel(Rels.IPSIS.SISCourseMerge.mergedCourseOfferings)) {
+		if (!this._entity || !this._entity.hasLinkByRel(Rels.ipsis.sisCourseMerge.mergedCourseOfferings)) {
 			return;
 		}
-		return this._entity.getLinkByRel(Rels.IPSIS.SISCourseMerge.mergedCourseOfferings).href;
+		return this._entity.getLinkByRel(Rels.ipsis.sisCourseMerge.mergedCourseOfferings).href;
 	}
 }

--- a/src/ipsis/course-merge/CourseMergeOfferingEntity.js
+++ b/src/ipsis/course-merge/CourseMergeOfferingEntity.js
@@ -108,4 +108,11 @@ export class CourseMergeOfferingEntity extends Entity {
 	updateEntity(entity) {
 		this._entity = entity;
 	}
+
+	mergedCourseOfferingsHref() {
+		if (!this._entity || !this._entity.hasLinkByRel(Rels.IPSIS.SISCourseMerge.mergedCourseOfferings)) {
+			return;
+		}
+		return this._entity.getLinkByRel(Rels.IPSIS.SISCourseMerge.mergedCourseOfferings).href;
+	}
 }

--- a/src/ipsis/course-merge/SelectedCourseMergeOfferingCollectionEntity.js
+++ b/src/ipsis/course-merge/SelectedCourseMergeOfferingCollectionEntity.js
@@ -15,7 +15,7 @@ export class SelectedCourseMergeOfferingCollectionEntity extends Entity {
 	}
 
 	selectedCourseMergeOffering() {
-		return this._entity && this._entity.getSubEntitiesByClass(Classes.ipsis.target);
+		return this._entity && this._entity.getSubEntitiesByClass(Classes.ipsis.sisCourseMerge.target);
 	}
 
 	hasMergeAction() {

--- a/src/ipsis/course-merge/SelectedCourseMergeOfferingCollectionEntity.js
+++ b/src/ipsis/course-merge/SelectedCourseMergeOfferingCollectionEntity.js
@@ -2,7 +2,7 @@
  * SelectedCourseMergeOfferingCollectionEntity class representation of a list of course merge offering as defined in the LMS
  * See: ISirenCourseMergeSerializer.SerializeSelectedCourseOfferingListResult
  */
-import { Actions } from '../../hypermedia-constants.js';
+import { Actions, Classes } from '../../hypermedia-constants.js';
 import { Entity } from '../../es6/Entity.js';
 import { performSirenAction } from '../../es6/SirenAction.js';
 
@@ -15,7 +15,7 @@ export class SelectedCourseMergeOfferingCollectionEntity extends Entity {
 	}
 
 	selectedCourseMergeOffering() {
-		return this._entity && this._entity.getSubEntitiesByClass('target');
+		return this._entity && this._entity.getSubEntitiesByClass(Classes.ipsis.target);
 	}
 
 	hasMergeAction() {


### PR DESCRIPTION
This PR includes Renato's changes in https://github.com/BrightspaceHypermediaComponents/siren-sdk/pull/585 rather than causing merge conflicts.

### Rally Story:
[US137422](https://rally1.rallydev.com/#/?detail=/userstory/630445645669&fdp=true): Course Merge-UI-Select to Unmerge Courses

### Related PRs:
* https://github.com/Brightspace/ipsis-sis-course-merge/pull/61