### PR TITLE
DE45495 > Replacement strings not working for modules

### DIFF
--- a/src/activities/content/ContentHelperFunctions.js
+++ b/src/activities/content/ContentHelperFunctions.js
@@ -13,6 +13,13 @@ const ContentHelperFunctions = {
 		}
 		return subEntity;
 	},
+	getRawDescriptionSubEntity: (entity) => {
+		const [subEntity] = entity.getSubEntitiesByClass(Classes.content.rawDescription);
+		if (!subEntity || !subEntity.properties) {
+			return null;
+		}
+		return subEntity;
+	},
 	getLastModifiedSubEntity: (entity) => {
 		const [subEntity] = entity.getSubEntitiesByClass(Classes.content.lastModified);
 

--- a/src/activities/content/ContentModuleEntity.js
+++ b/src/activities/content/ContentModuleEntity.js
@@ -20,6 +20,17 @@ export class ContentModuleEntity extends Entity {
 	}
 
 	/**
+	 * @returns {string|null} Raw description html of the content-module item
+	 */
+	rawDescriptionRichText() {
+		const rawDescriptionSubEntity = ContentHelperFunctions.getRawDescriptionSubEntity(this._entity);
+		if (!rawDescriptionSubEntity) {
+			return null;
+		}
+		return rawDescriptionSubEntity.properties.html || '';
+	}
+
+	/**
 	 * @returns {string|null} Description text of the content-module item
 	 */
 	descriptionText() {
@@ -94,7 +105,7 @@ export class ContentModuleEntity extends Entity {
 	equals(contentModule) {
 		const diffs = [
 			[this.title(), contentModule.title],
-			[this.descriptionRichText(), contentModule.descriptionRichText]
+			[this.rawDescriptionRichText(), contentModule.descriptionRichText]
 		];
 		for (const [left, right] of diffs) {
 			if (left !== right) {

--- a/src/activities/content/ContentModuleEntity.js
+++ b/src/activities/content/ContentModuleEntity.js
@@ -105,7 +105,7 @@ export class ContentModuleEntity extends Entity {
 	equals(contentModule) {
 		const diffs = [
 			[this.title(), contentModule.title],
-			[this.rawDescriptionRichText(), contentModule.descriptionRichText]
+			[this.descriptionRichText(), contentModule.descriptionRichText]
 		];
 		for (const [left, right] of diffs) {
 			if (left !== right) {

--- a/src/activities/content/ContentModuleEntity.js
+++ b/src/activities/content/ContentModuleEntity.js
@@ -105,7 +105,7 @@ export class ContentModuleEntity extends Entity {
 	equals(contentModule) {
 		const diffs = [
 			[this.title(), contentModule.title],
-			[this.descriptionRichText(), contentModule.descriptionRichText]
+			[this.rawDescriptionRichText(), contentModule.descriptionRichText]
 		];
 		for (const [left, right] of diffs) {
 			if (left !== right) {

--- a/src/activities/content/ContentModuleEntity.js
+++ b/src/activities/content/ContentModuleEntity.js
@@ -105,6 +105,7 @@ export class ContentModuleEntity extends Entity {
 	equals(contentModule) {
 		const diffs = [
 			[this.title(), contentModule.title],
+			[this.descriptionRichText(), contentModule.descriptionRichText],
 			[this.rawDescriptionRichText(), contentModule.rawDescriptionRichText]
 		];
 		for (const [left, right] of diffs) {

--- a/src/activities/content/ContentModuleEntity.js
+++ b/src/activities/content/ContentModuleEntity.js
@@ -105,7 +105,7 @@ export class ContentModuleEntity extends Entity {
 	equals(contentModule) {
 		const diffs = [
 			[this.title(), contentModule.title],
-			[this.rawDescriptionRichText(), contentModule.descriptionRichText]
+			[this.rawDescriptionRichText(), contentModule.rawDescriptionRichText]
 		];
 		for (const [left, right] of diffs) {
 			if (left !== right) {

--- a/src/hypermedia-constants.js
+++ b/src/hypermedia-constants.js
@@ -346,6 +346,7 @@ export const Classes = {
 		content: 'content',
 		sequencedActivity: 'sequenced-activity',
 		description: 'description',
+		rawDescription: 'raw-description',
 		lastModified: 'lastModified'
 	},
 	webLink: {

--- a/test/activities/content/ContentModuleEntity.test.js
+++ b/test/activities/content/ContentModuleEntity.test.js
@@ -24,7 +24,7 @@ describe('ContentModuleEntity', () => {
 		});
 
 		it('reads rich text description', () => {
-			expect(contentModuleEntity.rawDescriptionRichText()).to.equal('<p>description text</p>');
+			expect(contentModuleEntity.descriptionRichText()).to.equal('<p>description text</p>');
 		});
 
 		it('reads text description', () => {
@@ -36,7 +36,7 @@ describe('ContentModuleEntity', () => {
 		it('Equality should return true when details match', () => {
 			const contentModule = {
 				title: 'Test Content Module Title',
-				rawDescriptionRichText: '<p>description text</p>'
+				descriptionRichText: '<p>description text</p>'
 			};
 			expect(contentModuleEntity.equals(contentModule)).to.equal(true);
 		});
@@ -44,7 +44,7 @@ describe('ContentModuleEntity', () => {
 		it('Equality should return false when title is different', () => {
 			const contentModule = {
 				title: 'Different Content Module Title',
-				rawDescriptionRichText: '<p>description text</p>'
+				descriptionRichText: '<p>description text</p>'
 			};
 			expect(contentModuleEntity.equals(contentModule)).to.equal(false);
 		});
@@ -52,7 +52,7 @@ describe('ContentModuleEntity', () => {
 		it('Equality should return false when description is different', () => {
 			const contentModule = {
 				title: 'Test Content Module Title',
-				rawDescriptionRichText: '<p>Different description text</p>'
+				descriptionRichText: '<p>Different description text</p>'
 			};
 			expect(contentModuleEntity.equals(contentModule)).to.equal(false);
 		});

--- a/test/activities/content/ContentModuleEntity.test.js
+++ b/test/activities/content/ContentModuleEntity.test.js
@@ -24,7 +24,7 @@ describe('ContentModuleEntity', () => {
 		});
 
 		it('reads rich text description', () => {
-			expect(contentModuleEntity.descriptionRichText()).to.equal('<p>description text</p>');
+			expect(contentModuleEntity.rawDescriptionRichText()).to.equal('<p>description text</p>');
 		});
 
 		it('reads text description', () => {
@@ -36,7 +36,7 @@ describe('ContentModuleEntity', () => {
 		it('Equality should return true when details match', () => {
 			const contentModule = {
 				title: 'Test Content Module Title',
-				descriptionRichText: '<p>description text</p>'
+				rawDescriptionRichText: '<p>description text</p>'
 			};
 			expect(contentModuleEntity.equals(contentModule)).to.equal(true);
 		});
@@ -44,7 +44,7 @@ describe('ContentModuleEntity', () => {
 		it('Equality should return false when title is different', () => {
 			const contentModule = {
 				title: 'Different Content Module Title',
-				descriptionRichText: '<p>description text</p>'
+				rawDescriptionRichText: '<p>description text</p>'
 			};
 			expect(contentModuleEntity.equals(contentModule)).to.equal(false);
 		});
@@ -52,7 +52,7 @@ describe('ContentModuleEntity', () => {
 		it('Equality should return false when description is different', () => {
 			const contentModule = {
 				title: 'Test Content Module Title',
-				descriptionRichText: '<p>Different description text</p>'
+				rawDescriptionRichText: '<p>Different description text</p>'
 			};
 			expect(contentModuleEntity.equals(contentModule)).to.equal(false);
 		});

--- a/test/activities/content/ContentModuleEntity.test.js
+++ b/test/activities/content/ContentModuleEntity.test.js
@@ -24,7 +24,7 @@ describe('ContentModuleEntity', () => {
 		});
 
 		it('reads rich text description', () => {
-			expect(contentModuleEntity.descriptionRichText()).to.equal('<p>description text</p>');
+			expect(contentModuleEntity.rawDescriptionRichText()).to.equal('<p>description text</p>');
 		});
 
 		it('reads text description', () => {

--- a/test/activities/content/ContentModuleEntity.test.js
+++ b/test/activities/content/ContentModuleEntity.test.js
@@ -36,7 +36,8 @@ describe('ContentModuleEntity', () => {
 		it('Equality should return true when details match', () => {
 			const contentModule = {
 				title: 'Test Content Module Title',
-				descriptionRichText: '<p>description text</p>'
+				descriptionRichText: '<p>description text</p>',
+				rawDescriptionRichText: '<p>description text</p>'
 			};
 			expect(contentModuleEntity.equals(contentModule)).to.equal(true);
 		});
@@ -44,7 +45,8 @@ describe('ContentModuleEntity', () => {
 		it('Equality should return false when title is different', () => {
 			const contentModule = {
 				title: 'Different Content Module Title',
-				descriptionRichText: '<p>description text</p>'
+				descriptionRichText: '<p>description text</p>',
+				rawDescriptionRichText: '<p>description text</p>'
 			};
 			expect(contentModuleEntity.equals(contentModule)).to.equal(false);
 		});
@@ -52,7 +54,8 @@ describe('ContentModuleEntity', () => {
 		it('Equality should return false when description is different', () => {
 			const contentModule = {
 				title: 'Test Content Module Title',
-				descriptionRichText: '<p>Different description text</p>'
+				descriptionRichText: '<p>Different description text</p>',
+				rawDescriptionRichText: '<p>description text</p>'
 			};
 			expect(contentModuleEntity.equals(contentModule)).to.equal(false);
 		});

--- a/test/activities/content/ContentModuleEntity.test.js
+++ b/test/activities/content/ContentModuleEntity.test.js
@@ -24,7 +24,7 @@ describe('ContentModuleEntity', () => {
 		});
 
 		it('reads rich text description', () => {
-			expect(contentModuleEntity.rawDescriptionRichText()).to.equal('<p>description text</p>');
+			expect(contentModuleEntity.descriptionRichText()).to.equal('<p>description text</p>');
 		});
 
 		it('reads text description', () => {

--- a/test/activities/content/data/TestContentModuleEntity.js
+++ b/test/activities/content/data/TestContentModuleEntity.js
@@ -39,10 +39,17 @@ export const contentModuleData = {
 	'properties': {
 		'title': 'Test Content Module Title'
 	},
-	'entities': [{
-		'class': ['richtext', 'description'],
-		'properties': { 'text': 'description text', 'html': '<p>description text</p>' },
-		'rel': []
-	}],
+	'entities': [
+		{
+			'class': ['richtext', 'description'],
+			'properties': { 'text': 'description text', 'html': '<p>description text</p>' },
+			'rel': []
+		},
+		{
+			'class': ['richtext', 'raw-description'],
+			'properties': { 'text': 'description text', 'html': '<p>description text</p>' },
+			'rel': []
+		}
+	],
 	'rel': []
 };


### PR DESCRIPTION
## Relevant Rally Link
https://rally1.rallydev.com/#/?detail=/defect/610830681123&fdp=true
## Description
Adding support to retrieve the `raw-description` entity's html to be loaded into the editor. Also want to have dirty check to compare against what is in the db not the replaced version.
## Related PRs
https://github.com/Brightspace/lms/pull/32150