### PR TITLE
fix: Course Merge broken paging

### DIFF
--- a/src/ipsis/course-merge/BaseCollectionEntity.js
+++ b/src/ipsis/course-merge/BaseCollectionEntity.js
@@ -6,14 +6,14 @@ export class BaseCollectionEntity extends Entity {
 		this._allEntities = null;
 	}
 
-	courseOfferings() {
+	courseMergeOfferings() {
 		if (!this._entity) {
 			return;
 		}
 		return this._allEntities ?? this._entity.entities;
 	}
 
-	prependCourseOfferings(previousCourseOfferings) {
+	prependCourseMergeOfferings(previousCourseOfferings) {
 		this._allEntities = previousCourseOfferings.concat(this._entity.entities);
 	}
 
@@ -32,7 +32,7 @@ export class BaseCollectionEntity extends Entity {
 	loadMorePageSize() {
 		const pageSize = this._pagingInfo()?.pageSize;
 		const totalCount = this.totalCount() ?? 0;
-		const courseMergeOfferingsLength = this.courseOfferings()?.length ?? 0;
+		const courseMergeOfferingsLength = this.courseMergeOfferings()?.length ?? 0;
 		// if pageSize is larger than the number remaining items, return the number of remaining items to be loaded
 		if (totalCount < courseMergeOfferingsLength + (pageSize ?? 0)) {
 			return totalCount - courseMergeOfferingsLength;
@@ -68,12 +68,7 @@ export class BaseCollectionEntity extends Entity {
 		return this._entity.getLinkByRel('prev').href;
 	}
 
-	clearAllEntities() {
-		this._allEntities = null;
-	}
-
 	updateEntity(entity) {
-		this.clearAllEntities();
 		this._entity = entity;
 	}
 }

--- a/src/ipsis/course-merge/BaseCollectionEntity.js
+++ b/src/ipsis/course-merge/BaseCollectionEntity.js
@@ -1,6 +1,22 @@
 import { Entity } from '../../es6/Entity.js';
 
 export class BaseCollectionEntity extends Entity {
+	constructor(entity, token, listener) {
+		super(entity, token, listener);
+		this._allEntities = null;
+	}
+
+	courseOfferings() {
+		if (!this._entity) {
+			return;
+		}
+		return this._allEntities ?? this._entity.entities;
+	}
+
+	prependCourseOfferings(previousCourseOfferings) {
+		this._allEntities = previousCourseOfferings.concat(this._entity.entities);
+	}
+
 	totalCount() {
 		return this._pagingInfo()?.totalCount;
 	}
@@ -16,7 +32,7 @@ export class BaseCollectionEntity extends Entity {
 	loadMorePageSize() {
 		const pageSize = this._pagingInfo()?.pageSize;
 		const totalCount = this.totalCount() ?? 0;
-		const courseMergeOfferingsLength = this._entity?.entities?.length ?? 0;
+		const courseMergeOfferingsLength = this.courseOfferings()?.length ?? 0;
 		// if pageSize is larger than the number remaining items, return the number of remaining items to be loaded
 		if (totalCount < courseMergeOfferingsLength + (pageSize ?? 0)) {
 			return totalCount - courseMergeOfferingsLength;
@@ -50,6 +66,15 @@ export class BaseCollectionEntity extends Entity {
 		}
 
 		return this._entity.getLinkByRel('prev').href;
+	}
+
+	clearAllEntities() {
+		this._allEntities = null;
+	}
+
+	updateEntity(entity) {
+		this.clearAllEntities();
+		this._entity = entity;
 	}
 }
 

--- a/src/ipsis/course-merge/CourseMergeMergedOfferingCollectionEntity.js
+++ b/src/ipsis/course-merge/CourseMergeMergedOfferingCollectionEntity.js
@@ -8,7 +8,7 @@ import { performSirenAction } from '../../es6/SirenAction.js';
 
 export class CourseMergeMergedOfferingCollectionEntity extends BaseCollectionEntity {
 	originalSourceCourseMergeOfferings() {
-		return this._entity?.courseOfferings()?.filter(course => !course.class.includes(Classes.ipsis.sisCourseMerge.originalTarget));
+		return this._entity?.courseMergeOfferings()?.filter(course => !course.class.includes(Classes.ipsis.sisCourseMerge.originalTarget));
 	}
 
 	originalTargetCourseMergeOffering() {

--- a/src/ipsis/course-merge/CourseMergeMergedOfferingCollectionEntity.js
+++ b/src/ipsis/course-merge/CourseMergeMergedOfferingCollectionEntity.js
@@ -16,7 +16,7 @@ export class CourseMergeMergedOfferingCollectionEntity extends BaseCollectionEnt
 	}
 
 	prependOriginalSourceCourseMergeOfferings(previousCourseMergeMergedOfferingCollectionEntity) {
-		this.prependCourseOfferings(previousCourseMergeMergedOfferingCollectionEntity.originalSourceCourseMergeOfferings());
+		this.prependCourseMergeOfferings(previousCourseMergeMergedOfferingCollectionEntity.originalSourceCourseMergeOfferings());
 	}
 
 	userOwnedByMultipleSourceSystems() {

--- a/src/ipsis/course-merge/CourseMergeMergedOfferingCollectionEntity.js
+++ b/src/ipsis/course-merge/CourseMergeMergedOfferingCollectionEntity.js
@@ -8,7 +8,7 @@ import { performSirenAction } from '../../es6/SirenAction.js';
 
 export class CourseMergeMergedOfferingCollectionEntity extends BaseCollectionEntity {
 	originalSourceCourseMergeOfferings() {
-		return this._entity?.entities?.filter(course => !course.class.includes(Classes.ipsis.sisCourseMerge.originalTarget));
+		return this._entity?.courseOfferings()?.filter(course => !course.class.includes(Classes.ipsis.sisCourseMerge.originalTarget));
 	}
 
 	originalTargetCourseMergeOffering() {
@@ -16,7 +16,7 @@ export class CourseMergeMergedOfferingCollectionEntity extends BaseCollectionEnt
 	}
 
 	prependOriginalSourceCourseMergeOfferings(previousCourseMergeMergedOfferingCollectionEntity) {
-		this._entity.entities.unshift(...previousCourseMergeMergedOfferingCollectionEntity.originalSourceCourseMergeOfferings());
+		this.prependCourseOfferings(previousCourseMergeMergedOfferingCollectionEntity.originalSourceCourseMergeOfferings());
 	}
 
 	userOwnedByMultipleSourceSystems() {

--- a/src/ipsis/course-merge/CourseMergeOfferingCollectionEntity.js
+++ b/src/ipsis/course-merge/CourseMergeOfferingCollectionEntity.js
@@ -9,18 +9,18 @@ export class CourseMergeOfferingCollectionEntity extends BaseCollectionEntity {
 
 	constructor(entity, token, listener) {
 		super(entity, token, listener);
-		this.allEntities = null;
+		this._allEntities = null;
 	}
 
 	courseMergeOfferings() {
 		if (!this._entity) {
 			return;
 		}
-		return this.allEntities ?? this._entity.entities;
+		return this._allEntities ?? this._entity.entities;
 	}
 
 	prependCourseMergeOfferings(previousCourseMergeOfferingCollectionEntity) {
-		this.allEntities = previousCourseMergeOfferingCollectionEntity.courseMergeOfferings().concat(this._entity.entities);
+		this._allEntities = previousCourseMergeOfferingCollectionEntity.courseMergeOfferings().concat(this._entity.entities);
 	}
 
 	userOwnedByMultipleSourceSystems() {
@@ -65,7 +65,7 @@ export class CourseMergeOfferingCollectionEntity extends BaseCollectionEntity {
 
 	updateEntity(entity) {
 		this._entity = entity;
-		this.allEntities = null;
+		this._allEntities = null;
 	}
 }
 

--- a/src/ipsis/course-merge/CourseMergeOfferingCollectionEntity.js
+++ b/src/ipsis/course-merge/CourseMergeOfferingCollectionEntity.js
@@ -6,11 +6,17 @@ import { Actions, Rels } from '../../hypermedia-constants.js';
 import { BaseCollectionEntity } from './BaseCollectionEntity.js';
 
 export class CourseMergeOfferingCollectionEntity extends BaseCollectionEntity {
+
+	constructor(entity, token, listener) {
+		super(entity, token, listener);
+		this.allEntities = null;
+	}
+
 	courseMergeOfferings() {
 		if (!this._entity) {
 			return;
 		}
-		return allEntities ?? this._entity.entities;
+		return this.allEntities ?? this._entity.entities;
 	}
 
 	prependCourseMergeOfferings(previousCourseMergeOfferingCollectionEntity) {

--- a/src/ipsis/course-merge/CourseMergeOfferingCollectionEntity.js
+++ b/src/ipsis/course-merge/CourseMergeOfferingCollectionEntity.js
@@ -6,21 +6,8 @@ import { Actions, Rels } from '../../hypermedia-constants.js';
 import { BaseCollectionEntity } from './BaseCollectionEntity.js';
 
 export class CourseMergeOfferingCollectionEntity extends BaseCollectionEntity {
-
-	constructor(entity, token, listener) {
-		super(entity, token, listener);
-		this._allEntities = null;
-	}
-
-	courseMergeOfferings() {
-		if (!this._entity) {
-			return;
-		}
-		return this._allEntities ?? this._entity.entities;
-	}
-
 	prependCourseMergeOfferings(previousCourseMergeOfferingCollectionEntity) {
-		this._allEntities = previousCourseMergeOfferingCollectionEntity.courseMergeOfferings().concat(this._entity.entities);
+		this.prependCourseOfferings(previousCourseMergeOfferingCollectionEntity.courseOfferings());
 	}
 
 	userOwnedByMultipleSourceSystems() {
@@ -61,11 +48,6 @@ export class CourseMergeOfferingCollectionEntity extends BaseCollectionEntity {
 		}
 
 		return this._entity.getActionByName(Actions.ipsis.sisCourseMerge.searchCourseOfferings);
-	}
-
-	updateEntity(entity) {
-		this._entity = entity;
-		this._allEntities = null;
 	}
 }
 

--- a/src/ipsis/course-merge/CourseMergeOfferingCollectionEntity.js
+++ b/src/ipsis/course-merge/CourseMergeOfferingCollectionEntity.js
@@ -10,11 +10,11 @@ export class CourseMergeOfferingCollectionEntity extends BaseCollectionEntity {
 		if (!this._entity) {
 			return;
 		}
-		return this._entity.entities;
+		return allEntities ?? this._entity.entities;
 	}
 
 	prependCourseMergeOfferings(previousCourseMergeOfferingCollectionEntity) {
-		this._entity.entities.unshift(...previousCourseMergeOfferingCollectionEntity._entity.entities);
+		this.allEntities = previousCourseMergeOfferingCollectionEntity.courseMergeOfferings().concat(this._entity.entities);
 	}
 
 	userOwnedByMultipleSourceSystems() {
@@ -59,6 +59,7 @@ export class CourseMergeOfferingCollectionEntity extends BaseCollectionEntity {
 
 	updateEntity(entity) {
 		this._entity = entity;
+		this.allEntities = null;
 	}
 }
 

--- a/src/ipsis/course-merge/CourseMergeOfferingCollectionEntity.js
+++ b/src/ipsis/course-merge/CourseMergeOfferingCollectionEntity.js
@@ -7,7 +7,7 @@ import { BaseCollectionEntity } from './BaseCollectionEntity.js';
 
 export class CourseMergeOfferingCollectionEntity extends BaseCollectionEntity {
 	prependCourseMergeOfferings(previousCourseMergeOfferingCollectionEntity) {
-		this.prependCourseOfferings(previousCourseMergeOfferingCollectionEntity.courseOfferings());
+		super.prependCourseMergeOfferings(previousCourseMergeOfferingCollectionEntity.courseMergeOfferings());
 	}
 
 	userOwnedByMultipleSourceSystems() {


### PR DESCRIPTION
This fix is part of https://github.com/Brightspace/ipsis-sis-course-merge/pull/65
[DE49910](https://rally1.rallydev.com/#/?detail=/defect/646222579899&fdp=true): Course Merge - Load more doesn't work after search

DE: [DE51900](https://rally1.rallydev.com/#/?detail=/defect/684796230521&fdp=true): Course Merge - Duplicate courses after search

Bug description: 
* The previous page is added to the next page's entity, which leads to duplicate pages after searching and then clearing the search (i.e., returning to the first page without reloading the browser page).