### PR TITLE
feat: add new entities for restricted topic type

### DIFF
--- a/src/activities/discussions/GroupEntity.js
+++ b/src/activities/discussions/GroupEntity.js
@@ -1,0 +1,10 @@
+import { Entity } from '../../es6/Entity.js';
+
+export class GroupEntity extends Entity {
+
+	name() {
+		const subEntity = this._entity && this._entity.getSubEntityByClass('name');
+		return subEntity && subEntity.properties && subEntity.properties.name;
+	}
+
+}

--- a/src/activities/discussions/GroupSectionRestrictionActionsEntity.js
+++ b/src/activities/discussions/GroupSectionRestrictionActionsEntity.js
@@ -53,4 +53,30 @@ export class GroupSectionRestrictionActionsEntity extends Entity {
 			return new RestrictedTopicCollectionEntity(entity);
 		});
 	}
+	canToggleGroupsRestrictedTopic() {
+		if (!this._entity) return null;
+		const subEntity = this._entity.getSubEntityByClass('restricted-topic');
+		return subEntity && subEntity.hasActionByName(Actions.discussions.groupSectionRestrictions.toggleGroupsRestrictedTopic);
+	}
+	_formatToggleGroupsRestrictedTopicAction(toggleGroupIds) {
+		if (!toggleGroupIds) return;
+		if (!this.canToggleGroupsRestrictedTopic()) return;
+		const subEntity = this._entity.getSubEntityByClass('restricted-topic');
+		const action = subEntity.getActionByName(Actions.discussions.groupSectionRestrictions.toggleGroupsRestrictedTopic);
+		const fields = [
+			{ name: 'toggleGroupIds', value: toggleGroupIds },
+		];
+
+		return { action, fields };
+	}
+	async toggleGroupsRestrictedTopic(toggleGroupIds) {
+		if (!toggleGroupIds) return;
+		if (!this.canToggleGroupsRestrictedTopic()) return;
+
+		const sirenAction = this._formatToggleGroupsRestrictedTopicAction(toggleGroupIds);
+		if (!sirenAction) return;
+
+		const { action, fields } = sirenAction;
+		await performSirenAction(this._token, action, fields);
+	}
 }

--- a/src/activities/discussions/GroupSectionRestrictionActionsEntity.js
+++ b/src/activities/discussions/GroupSectionRestrictionActionsEntity.js
@@ -1,4 +1,4 @@
-import { Actions } from '../../hypermedia-constants.js';
+import { Actions, Classes } from '../../hypermedia-constants.js';
 import { Entity } from '../../es6/Entity.js';
 import { performSirenAction } from '../../es6/SirenAction.js';
 import { RestrictedTopicCollectionEntity } from './RestrictedTopicCollectionEntity.js';
@@ -45,7 +45,7 @@ export class GroupSectionRestrictionActionsEntity extends Entity {
 	restrictedTopicCollection() {
 		if (!this._entity) return null;
 
-		const subEntity = this._entity.getSubEntityByClass('restricted-topic');
+		const subEntity = this._entity.getSubEntityByClass(Classes.discussions.restrictedTopic);
 		if (!subEntity) {
 			return null;
 		}
@@ -55,17 +55,17 @@ export class GroupSectionRestrictionActionsEntity extends Entity {
 	}
 	canToggleGroupsRestrictedTopic() {
 		if (!this._entity) return null;
-		const subEntity = this._entity.getSubEntityByClass('restricted-topic');
+		const subEntity = this._entity.getSubEntityByClass(Classes.discussions.restrictedTopic);
 		return subEntity && subEntity.hasActionByName(Actions.discussions.groupSectionRestrictions.toggleGroupsRestrictedTopic);
 	}
 	_formatToggleGroupsRestrictedTopicAction(toggleGroupIds) {
 		if (!toggleGroupIds) return;
 		if (!this.canToggleGroupsRestrictedTopic()) return;
-		const subEntity = this._entity.getSubEntityByClass('restricted-topic');
+		const subEntity = this._entity.getSubEntityByClass(Classes.discussions.restrictedTopic);
 		const action = subEntity.getActionByName(Actions.discussions.groupSectionRestrictions.toggleGroupsRestrictedTopic);
-		const fields = [
-			{ name: 'toggleGroupIds', value: toggleGroupIds },
-		];
+		const fields = toggleGroupIds.map(id => {
+			return { name: 'toggleGroupIds', value: id };
+		});
 
 		return { action, fields };
 	}

--- a/src/activities/discussions/GroupSectionRestrictionActionsEntity.js
+++ b/src/activities/discussions/GroupSectionRestrictionActionsEntity.js
@@ -67,9 +67,32 @@ export class GroupSectionRestrictionActionsEntity extends Entity {
 
 		return { action, fields };
 	}
-	async toggleGroupsRestrictedTopic(toggleGroupIds) {
-		if (!toggleGroupIds) return;
+	_restrictedTopicToggle(selectedIds) {
+		const outputToggle = [];
+		const oldRestrictedTopicCollection = this.restrictedTopicCollection().getRestrictedTopics();
+		if (!oldRestrictedTopicCollection) return;
+
+		const newRestrictedTopicMap = {};
+		selectedIds.forEach(ids => {
+			newRestrictedTopicMap[ids] = ids;
+		});
+
+		oldRestrictedTopicCollection.forEach(oldTopic => {
+			const oldTopicId = oldTopic.id();
+			const newIsSelected = newRestrictedTopicMap[oldTopicId] !== undefined;
+			if (oldTopic.isSelected() !== newIsSelected) {
+				outputToggle.push(oldTopicId);
+			}
+		});
+
+		return outputToggle;
+	}
+
+	async toggleGroupsRestrictedTopic(selectedIds) {
+		if (!selectedIds) return;
 		if (!this.canToggleGroupsRestrictedTopic()) return;
+
+		const toggleGroupIds = this._restrictedTopicToggle(selectedIds);
 
 		const sirenAction = this._formatToggleGroupsRestrictedTopicAction(toggleGroupIds);
 		if (!sirenAction) return;

--- a/src/activities/discussions/GroupSectionRestrictionActionsEntity.js
+++ b/src/activities/discussions/GroupSectionRestrictionActionsEntity.js
@@ -49,9 +49,7 @@ export class GroupSectionRestrictionActionsEntity extends Entity {
 		if (!subEntity) {
 			return null;
 		}
-		return (subEntity.getSubEntitiesByRel('item') || []).map(entity => {
-			return new RestrictedTopicCollectionEntity(entity);
-		});
+		return new RestrictedTopicCollectionEntity(subEntity);
 	}
 	canToggleGroupsRestrictedTopic() {
 		if (!this._entity) return null;

--- a/src/activities/discussions/GroupSectionRestrictionActionsEntity.js
+++ b/src/activities/discussions/GroupSectionRestrictionActionsEntity.js
@@ -75,6 +75,7 @@ export class GroupSectionRestrictionActionsEntity extends Entity {
 		if (!sirenAction) return;
 
 		const { action, fields } = sirenAction;
-		await performSirenAction(this._token, action, fields);
+
+		performSirenAction(this._token, action, fields);
 	}
 }

--- a/src/activities/discussions/GroupSectionRestrictionActionsEntity.js
+++ b/src/activities/discussions/GroupSectionRestrictionActionsEntity.js
@@ -1,6 +1,7 @@
 import { Actions } from '../../hypermedia-constants.js';
 import { Entity } from '../../es6/Entity.js';
 import { performSirenAction } from '../../es6/SirenAction.js';
+import { RestrictedTopicCollectionEntity } from './RestrictedTopicCollectionEntity.js';
 
 export class GroupSectionRestrictionActionsEntity extends Entity {
 	canSetToRestrictedTopic() {
@@ -40,5 +41,16 @@ export class GroupSectionRestrictionActionsEntity extends Entity {
 		const fields = action.getFieldByName('groupTypeId');
 		return fields && fields.value;
 
+	}
+	restrictedTopicCollection() {
+		if (!this._entity) return null;
+
+		const subEntity = this._entity.getSubEntityByClass('restricted-topic');
+		if (!subEntity) {
+			return null;
+		}
+		return (subEntity.getSubEntitiesByRel('item') || []).map(entity => {
+			return new RestrictedTopicCollectionEntity(entity);
+		});
 	}
 }

--- a/src/activities/discussions/NamedEntity.js
+++ b/src/activities/discussions/NamedEntity.js
@@ -1,6 +1,6 @@
 import { Entity } from '../../es6/Entity.js';
 
-export class GroupEntity extends Entity {
+export class NamedEntity extends Entity {
 
 	name() {
 		const subEntity = this._entity && this._entity.getSubEntityByClass('name');

--- a/src/activities/discussions/RestrictedTopicCollectionEntity.js
+++ b/src/activities/discussions/RestrictedTopicCollectionEntity.js
@@ -1,6 +1,7 @@
 import { Classes } from '../../hypermedia-constants.js';
 import { Entity } from '../../es6/Entity.js';
-import { GroupEntity } from './GroupEntity.js';
+import { NamedEntity } from './NamedEntity.js';
+import { performSirenAction } from '../../es6/SirenAction.js';
 
 export class RestrictedTopicCollectionEntity extends Entity {
 	isSelected() {
@@ -30,12 +31,17 @@ export class RestrictedTopicCollectionEntity extends Entity {
 	nameHref() {
 		return this._entity && this._entity.entities && this._entity.entities[0] && this._entity.entities[0].href;
 	}
-	onGroupChange(onChange) {
-		if (!this._entity) return;
+	async getName() {
+		if (!this._entity) {
+			return null;
+		}
 
-		const href = this.nameHref();
-		if (!href) return;
+		const action = this.nameHref();
 
-		this._subEntity(GroupEntity, href, onChange);
+		const fields = [];
+		const returnedEntity = await performSirenAction(this._token, action, fields, false, true);
+		if (!returnedEntity) return;
+
+		return new NamedEntity(returnedEntity);
 	}
 }

--- a/src/activities/discussions/RestrictedTopicCollectionEntity.js
+++ b/src/activities/discussions/RestrictedTopicCollectionEntity.js
@@ -1,47 +1,12 @@
-import { Classes } from '../../hypermedia-constants.js';
 import { Entity } from '../../es6/Entity.js';
-import { NamedEntity } from './NamedEntity.js';
-import { performSirenAction } from '../../es6/SirenAction.js';
+import { RestrictedTopicEntity } from './RestrictedTopicEntity.js';
 
 export class RestrictedTopicCollectionEntity extends Entity {
-	isSelected() {
-		if (!this._entity) {
-			return false;
-		}
-		return this._entity.hasClass(Classes.discussions.selected);
-	}
-	hasParentId() {
-		if (!this._entity) {
-			return false;
-		}
-		return typeof this._entity.properties?.parent !== 'undefined';
-	}
-	parentId() {
-		if (!this._entity || !this.hasParentId()) {
-			return null;
-		}
-		return this._entity.properties?.parent;
-	}
-	id() {
-		if (!this._entity) {
-			return null;
-		}
-		return this._entity.properties?.id;
-	}
-	nameHref() {
-		return this._entity && this._entity.entities && this._entity.entities[0] && this._entity.entities[0].href;
-	}
-	async getName() {
-		if (!this._entity) {
-			return null;
-		}
+	getRestrictedTopics() {
+		if (!this._entity) return [];
 
-		const action = this.nameHref();
-
-		const fields = [];
-		const returnedEntity = await performSirenAction(this._token, action, fields, false, true);
-		if (!returnedEntity) return;
-
-		return new NamedEntity(returnedEntity);
+		return (this._entity.getSubEntitiesByRel('item') || []).map(subEntity => {
+			return new RestrictedTopicEntity(subEntity);
+		});
 	}
 }

--- a/src/activities/discussions/RestrictedTopicCollectionEntity.js
+++ b/src/activities/discussions/RestrictedTopicCollectionEntity.js
@@ -1,0 +1,41 @@
+import { Classes } from '../../hypermedia-constants.js';
+import { Entity } from '../../es6/Entity.js';
+import { GroupEntity } from './GroupEntity.js';
+
+export class RestrictedTopicCollectionEntity extends Entity {
+	isSelected() {
+		if (!this._entity) {
+			return false;
+		}
+		return this._entity.hasClass(Classes.discussions.selected);
+	}
+	hasParentId() {
+		if (!this._entity) {
+			return false;
+		}
+		return typeof this._entity.properties?.parent !== 'undefined';
+	}
+	parentId() {
+		if (!this._entity || !this.hasParentId()) {
+			return null;
+		}
+		return this._entity.properties?.parent;
+	}
+	id() {
+		if (!this._entity) {
+			return null;
+		}
+		return this._entity.properties?.id;
+	}
+	nameHref() {
+		return this._entity && this._entity.entities && this._entity.entities[0] && this._entity.entities[0].href;
+	}
+	onGroupChange(onChange) {
+		if (!this._entity) return;
+
+		const href = this.nameHref();
+		if (!href) return;
+
+		this._subEntity(GroupEntity, href, onChange);
+	}
+}

--- a/src/activities/discussions/RestrictedTopicEntity.js
+++ b/src/activities/discussions/RestrictedTopicEntity.js
@@ -1,0 +1,47 @@
+import { Classes } from '../../hypermedia-constants.js';
+import { Entity } from '../../es6/Entity.js';
+import { NamedEntity } from './NamedEntity.js';
+import { performSirenAction } from '../../es6/SirenAction.js';
+
+export class RestrictedTopicEntity extends Entity {
+	isSelected() {
+		if (!this._entity) {
+			return false;
+		}
+		return this._entity.hasClass(Classes.discussions.selected);
+	}
+	hasParentId() {
+		if (!this._entity) {
+			return false;
+		}
+		return typeof this._entity.properties?.parent !== 'undefined';
+	}
+	parentId() {
+		if (!this._entity || !this.hasParentId()) {
+			return null;
+		}
+		return this._entity.properties?.parent;
+	}
+	id() {
+		if (!this._entity) {
+			return null;
+		}
+		return this._entity.properties?.id;
+	}
+	nameHref() {
+		return this._entity && this._entity.entities && this._entity.entities[0] && this._entity.entities[0].href;
+	}
+	async getName() {
+		if (!this._entity) {
+			return null;
+		}
+
+		const action = this.nameHref();
+
+		const fields = [];
+		const returnedEntity = await performSirenAction(this._token, action, fields, false, true);
+		if (!returnedEntity) return;
+
+		return new NamedEntity(returnedEntity);
+	}
+}

--- a/src/activities/discussions/RestrictedTopicEntity.js
+++ b/src/activities/discussions/RestrictedTopicEntity.js
@@ -1,7 +1,5 @@
 import { Classes } from '../../hypermedia-constants.js';
 import { Entity } from '../../es6/Entity.js';
-import { NamedEntity } from './NamedEntity.js';
-import { performSirenAction } from '../../es6/SirenAction.js';
 
 export class RestrictedTopicEntity extends Entity {
 	isSelected() {

--- a/src/activities/discussions/RestrictedTopicEntity.js
+++ b/src/activities/discussions/RestrictedTopicEntity.js
@@ -31,17 +31,4 @@ export class RestrictedTopicEntity extends Entity {
 	nameHref() {
 		return this._entity && this._entity.entities && this._entity.entities[0] && this._entity.entities[0].href;
 	}
-	async getName() {
-		if (!this._entity) {
-			return null;
-		}
-
-		const action = this.nameHref();
-
-		const fields = [];
-		const returnedEntity = await performSirenAction(this._token, action, fields, false, true);
-		if (!returnedEntity) return;
-
-		return new NamedEntity(returnedEntity);
-	}
 }

--- a/src/hypermedia-constants.js
+++ b/src/hypermedia-constants.js
@@ -390,6 +390,7 @@ export const Classes = {
 		bySection: 'by-section',
 		groupCategory: 'group-category',
 		section: 'section',
+		selected: 'selected',
 		allGroups: 'all-groups',
 		allSections: 'all-sections'
 	},

--- a/src/hypermedia-constants.js
+++ b/src/hypermedia-constants.js
@@ -733,7 +733,8 @@ export const Actions = {
 		groupSectionRestrictions: {
 			startUpdateRestrictions: 'start-update-restrictions',
 			setToRestrictedTopic: 'set-to-restricted-topic',
-			setToRestrictedThreads: 'set-to-restricted-threads'
+			setToRestrictedThreads: 'set-to-restricted-threads',
+			toggleGroupsRestrictedTopic: 'toggle-groups-restricted-topic'
 		}
 	},
 	rubrics: {


### PR DESCRIPTION
Implement the group list in the Group and Section Restrictions dialog for restricted-topic types:
[US146337](https://rally1.rallydev.com/#/?detail=/userstory/672777987809&fdp=true)