### PR TITLE
feat: US137422 - Support action on root entity to navigate directly to merged course

### DIFF
--- a/src/hypermedia-constants.js
+++ b/src/hypermedia-constants.js
@@ -764,6 +764,7 @@ export const Actions = {
 		sisCourseMerge: {
 			deselect: 'deselect',
 			mergeCourseOfferings: 'merge-course-offerings',
+			mergedCourseOffering: 'merged-course-offering',
 			searchCourseOfferings: 'search-course-offerings',
 			select: 'select',
 			selectAsTarget: 'select-as-target',

--- a/src/ipsis/course-merge/CourseMergeRootEntity.js
+++ b/src/ipsis/course-merge/CourseMergeRootEntity.js
@@ -1,5 +1,6 @@
+import { Actions, Rels } from '../../hypermedia-constants.js';
 import { Entity } from '../../es6/Entity.js';
-import { Rels } from '../../hypermedia-constants.js';
+import { getEntityUrl } from '../../es6/SirenAction.js';
 
 export class CourseMergeRootEntity extends Entity {
 	courseMergeOfferingsListHref() {
@@ -8,5 +9,22 @@ export class CourseMergeRootEntity extends Entity {
 		}
 
 		return this._entity.getLinkByRel(Rels.ipsis.sisCourseMerge.courseMergeOfferings).href;
+	}
+
+	getCourseMergeMergedOfferingAction() {
+		if (!this._entity.hasActionByName(Actions.ipsis.sisCourseMerge.mergedCourseOffering)) {
+			return;
+		}
+
+		return this._entity.getActionByName(Actions.ipsis.sisCourseMerge.mergedCourseOffering);
+	}
+
+	courseMergeMergedOfferingHref(orgUnitId) {
+		const action = this.getCourseMergeMergedOfferingAction();
+		if (!action) {
+			return;
+		}
+
+		return getEntityUrl(action, [{ name: 'orgUnitId', value: orgUnitId }]);
 	}
 }


### PR DESCRIPTION
### Rally Story:
[US137422](https://rally1.rallydev.com/#/?detail=/userstory/630445645669&fdp=true): Course Merge-UI-Select to Unmerge Courses

### Related PRs:
* https://github.com/Brightspace/lms/pull/32814
* https://github.com/Brightspace/ipsis-sis-course-merge/pull/68