### PR TITLE
DE52094 return promise from toggle action

### DIFF
--- a/src/activities/discussions/GroupSectionRestrictionActionsEntity.js
+++ b/src/activities/discussions/GroupSectionRestrictionActionsEntity.js
@@ -103,6 +103,6 @@ export class GroupSectionRestrictionActionsEntity extends Entity {
 
 		const { action, fields } = sirenAction;
 
-		performSirenAction(this._token, action, fields);
+		return performSirenAction(this._token, action, fields);
 	}
 }


### PR DESCRIPTION
[DE52094](https://rally1.rallydev.com/#/?detail=/defect/685692839235&fdp=true): Restriction Updates sometimes don't save

In order to await the toggle action we need to return the promise so that we can await it.

Goes with https://github.com/BrightspaceHypermediaComponents/activities/pull/3586