### PR TITLE
DE51385 add support for name field in submission views

### DIFF
--- a/src/activities/quizzes/submissionViews/QuizSubmissionViewEntity.js
+++ b/src/activities/quizzes/submissionViews/QuizSubmissionViewEntity.js
@@ -158,6 +158,35 @@ export class QuizSubmissionViewEntity extends Entity {
 		return this._entity && this._entity.hasClass(Classes.quizzes.submissionView.showStatsScoreDistribution);
 	}
 
+	/** NAME SUB-ENTITY */
+
+	_nameSubEntity() {
+		return this._entity && this._entity.getSubEntityByClass(Classes.quizzes.submissionView.viewName.viewName);
+	}
+
+	async setName(value) {
+		const subEntity = this._nameSubEntity();
+		const action = subEntity.getActionByName(Actions.quizzes.submissionView.setName);
+		const fields = [
+			{ name: 'subviewName', value }
+		];
+
+		const returnedEntity = await performSirenAction(this._token, action, fields);
+		if (!returnedEntity) return;
+		return new QuizSubmissionViewEntity(returnedEntity, this._token);
+	}
+
+	viewName() {
+		const subEntity = this._nameSubEntity();
+		if (!subEntity) return;
+		return subEntity.properties.name;
+	}
+
+	canUpdateName() {
+		const subEntity = this._nameSubEntity();
+		return subEntity && subEntity.hasActionByName(Actions.quizzes.submissionView.setName);
+	}
+
 	/** MESSAGE SUB-ENTITY */
 	canUpdateMessage() {
 		const subEntity = this._messageSubEntity();

--- a/src/hypermedia-constants.js
+++ b/src/hypermedia-constants.js
@@ -499,6 +499,9 @@ export const Classes = {
 				showCorrectAnswers: 'show-correct-answers',
 				showLearnerResponses: 'show-learner-responses',
 				showQuestionScore: 'show-question-score'
+			},
+			viewName: {
+				viewName: 'subview-name'
 			}
 		},
 		types: {
@@ -849,7 +852,8 @@ export const Actions = {
 			updateShowStatsClassAverage: 'update-show-stats-class-average',
 			updateShowStatsScoreDistribution: 'update-show-stats-score-distribution',
 			updateTimeLimit: 'update-time-limit',
-			deleteSubmissionView: 'delete-submission-view'
+			deleteSubmissionView: 'delete-submission-view',
+			setName:'update-subview-name'
 		},
 		submissionViews: {
 			add: 'add'

--- a/test/activities/quizzes/data/submissionViews/SubmissionViewEntity.js
+++ b/test/activities/quizzes/data/submissionViews/SubmissionViewEntity.js
@@ -294,6 +294,27 @@ export const editableSecondaryView = {
 			]
 		},
 		{
+			class: ['subview-name'],
+			rel: ['related'],
+			properties: {
+				name: 'Sample View'
+			},
+			actions: [
+				{
+					href: '/{orgUnitId}/quizzes/{quizId}/submissionviews/7?workingCopyId=123',
+					name: 'update-subview-name',
+					method: 'PATCH',
+					fields: [
+						{
+							type: 'text',
+							name: 'subviewName',
+							value: 'Sample View'
+						}
+					]
+				}
+			]
+		},
+		{
 			class: ['attempt-restrictions', 'grade-restrictions'],
 			rel: ['related'],
 			properties: {
@@ -682,6 +703,13 @@ export const nonEditableSecondaryView = {
 					}
 				}
 			]
+		},
+		{
+			class: ['subview-name'],
+			rel: ['related'],
+			properties: {
+				name: 'Sample View'
+			}
 		},
 		{
 			class: ['time-limit'],

--- a/test/activities/quizzes/submissionViews/QuizSubmissionViewEntity.test.js
+++ b/test/activities/quizzes/submissionViews/QuizSubmissionViewEntity.test.js
@@ -279,6 +279,26 @@ describe('QuizSubmissionViewEntity', () => {
 		});
 	});
 
+	describe('Name Sub-entity', () => {
+		it('returns correct Name for editable secondary view', () => {
+			const entity = new QuizSubmissionViewEntity(editableSecondaryViewEntity);
+			const actualNameValue = entity.viewName();
+			expect(actualNameValue).to.be.equal('Sample View');
+		});
+		it('should have action as it is editable secondary view', () => {
+			const entity = new QuizSubmissionViewEntity(editableSecondaryViewEntity);
+			expect(entity.canUpdateName()).to.be.true;
+		});
+		it('should not have action as it is non editable secondary view', () => {
+			const entity = new QuizSubmissionViewEntity(nonEditableSecondaryViewEntity);
+			expect(entity.canUpdateName()).to.be.false;
+		});
+		it('should not have action (no subentity) as it is a primary view', () => {
+			const entity = new QuizSubmissionViewEntity(editablePrimaryViewEntity);
+			expect(entity.canUpdateName()).to.be.undefined;
+		});
+	});
+
 	describe('Attempt Restrictions Sub-entity', () => {
 		describe('attempt restrictions', () => {
 			it('returns correct attempt restrictions for editable secondary view', () => {


### PR DESCRIPTION
https://rally1.rallydev.com/#/29180338367d/custom/486232622040?detail=%2Fdefect%2F673800671099

Related LMS PR: https://github.com/Brightspace/lms/pull/33944. 

- From LMS PR: Following discussions with Joseph, it was decided that we will save the additional view name with respect to the users current lang/locale at the time of save. After switching locales, unless we save again, it will remain in the previous locale's translation. For now, we're sticking to this implementation.
- 
- In this PR, added support for the name field for individual submission views, and added test cases. 