### PR TITLE
feat: US147212 Add Show Pending Enrollment Request Function

### DIFF
--- a/docs/presentation_PresentationEntity.js.html
+++ b/docs/presentation_PresentationEntity.js.html
@@ -19,11 +19,11 @@
 
     <h1 class="page-title">Source: presentation/PresentationEntity.js</h1>
 
-    
 
 
 
-    
+
+
     <section>
         <article>
             <pre class="prettyprint source linenums"><code>import { Entity } from '../es6/Entity.js';
@@ -52,6 +52,10 @@ export class PresentationEntity extends Entity {
 
 	showDropboxUnreadFeedback() {
 		return this._entity &amp;&amp; this._entity.properties &amp;&amp; this._entity.properties.ShowDropboxUnreadFeedback;
+	}
+
+	showPendingEnrollmentRequests() {
+		return this._entity &amp;&amp; this._entity.properties &amp;&amp; this._entity.properties.ShowPendingEnrollmentRequests;
 	}
 
 	showUnattemptedQuizzes() {

--- a/src/presentation/PresentationEntity.js
+++ b/src/presentation/PresentationEntity.js
@@ -26,6 +26,10 @@ export class PresentationEntity extends Entity {
 		return this._entity && this._entity.properties && this._entity.properties.ShowDropboxUnreadFeedback;
 	}
 
+	showPendingEnrollmentRequests() {
+		return this._entity && this._entity.properties && this._entity.properties.ShowPendingEnrollmentRequests;
+	}
+
 	showUnattemptedQuizzes() {
 		return this._entity && this._entity.properties && this._entity.properties.ShowUnattemptedQuizzes;
 	}

--- a/test/presentation/PresentationEntity.test.js
+++ b/test/presentation/PresentationEntity.test.js
@@ -1,0 +1,49 @@
+import { expect } from '@open-wc/testing';
+import { PresentationEntity } from '../../src/presentation/PresentationEntity.js';
+
+function createPresentationEntity(propertyValue) {
+	return {
+		properties: {
+			HideCourseStartDate: propertyValue,
+			HideCourseEndDate: propertyValue,
+			ShowCourseCode: propertyValue,
+			ShowSemester: propertyValue,
+			ShowDropboxUnreadFeedback: propertyValue,
+			ShowPendingEnrollmentRequests: propertyValue,
+			ShowUnattemptedQuizzes: propertyValue,
+			ShowUngradedQuizAttempts: propertyValue,
+			ShowUnreadDiscussionMessages: propertyValue,
+			ShowUnreadDropboxSubmissions: propertyValue
+		}
+	};
+}
+
+function assertPropertyValues(presentationEntity, expectedValue) {
+	expect(presentationEntity.hideCourseStartDate()).to.equal(expectedValue);
+	expect(presentationEntity.hideCourseEndDate()).to.equal(expectedValue);
+	expect(presentationEntity.showOrganizationCode()).to.equal(expectedValue);
+	expect(presentationEntity.showSemesterName()).to.equal(expectedValue);
+	expect(presentationEntity.showDropboxUnreadFeedback()).to.equal(expectedValue);
+	expect(presentationEntity.showPendingEnrollmentRequests()).to.equal(expectedValue);
+	expect(presentationEntity.showUnattemptedQuizzes()).to.equal(expectedValue);
+	expect(presentationEntity.showUngradedQuizAttempts()).to.equal(expectedValue);
+	expect(presentationEntity.showUnreadDiscussionMessages()).to.equal(expectedValue);
+	expect(presentationEntity.showUnreadDropboxSubmissions()).to.equal(expectedValue);
+}
+
+describe('PresentationEntity', () => {
+	describe('Tests for actions', () => {
+
+		[true, false].forEach(expectedValue => {
+			it(`should return ${expectedValue} for all properties`, () => {
+				const presentationEntity = new PresentationEntity(createPresentationEntity(expectedValue));
+				assertPropertyValues(presentationEntity, expectedValue);
+			});
+		});
+
+		it('should return undefined for missing properties', () => {
+			const presentationEntity = new PresentationEntity({});
+			assertPropertyValues(presentationEntity, undefined);
+		});
+	});
+});


### PR DESCRIPTION
Context for [US147212](https://rally1.rallydev.com/#/?detail=/userstory/675556921241&fdp=true): Add a new counter/icon in Course Cards that shows pending approval requests

This PR is one of many that is focused on adding a new counter icon to the courses on the My Courses homepage widget. Other changes include changes in [`d2l-organization-updates`](https://github.com/BrightspaceHypermediaComponents/organizations/pull/273), [`d2l-enrollment-card`](https://github.com/BrightspaceHypermediaComponents/enrollments/pull/287) and the [LMS](https://github.com/Brightspace/lms/pull/34181). Future changes include modifying [`d2l-courses-card-grid`](https://github.com/Brightspace/d2l-my-courses-ui/blob/master/src/d2l-my-courses-card-grid.js#L234) to use this call.

![image](https://user-images.githubusercontent.com/71081906/224821536-dc69c21b-a3e3-44c0-91bd-40ed43eed8ca.png)

The purpose of this PR is to add the `showPendingEnrollmentRequests` function that retrieves the `ShowPendingEnrollmentRequests` Boolean property from `PresentationEntity`. This is so that we can retrieve that value from [`d2l-courses-card-grid`](https://github.com/Brightspace/d2l-my-courses-ui/blob/master/src/d2l-my-courses-card-grid.js#L234) similarly to the other widget settings found in the `d2l-my-courses-ui` component, as seen in the screenshot below.

![image](https://user-images.githubusercontent.com/71081906/224822205-436cbdaf-1275-4081-b576-71b2f86b8142.png)

I've updated the documentation to include this function and also added tests for `PresentationEntity` since none existed yet.