### PR TITLE
Add _error property to EntityMixinLit

### DIFF
--- a/src/es6/EntityFactory.js
+++ b/src/es6/EntityFactory.js
@@ -67,7 +67,7 @@ export function entityFactory(entityType, href, token, onChange, entity) {
 	const entityListener = new EntityListener();
 	const onChangeWrapped = (entity, error) => {
 		if (entity) {
-			onChange(new entityType(entity, token, entityListener), null);
+			onChange(new entityType(entity, token, entityListener));
 		} else {
 			onChange(null, error);
 		}

--- a/src/es6/EntityFactory.js
+++ b/src/es6/EntityFactory.js
@@ -67,7 +67,7 @@ export function entityFactory(entityType, href, token, onChange, entity) {
 	const entityListener = new EntityListener();
 	const onChangeWrapped = (entity, error) => {
 		if (entity) {
-			onChange(new entityType(entity, token, entityListener));
+			onChange(new entityType(entity, token, entityListener), null);
 		} else {
 			onChange(null, error);
 		}

--- a/src/mixin/entity-mixin-lit.js
+++ b/src/mixin/entity-mixin-lit.js
@@ -24,7 +24,7 @@ const InternalEntityMixinLit = superclass => class extends superclass {
 			/**
 			 * Error object is set if there is an error fetching entity. Null if entity was successfully retrieved.
 			 */
-			_error: { type: Object }
+			_entityError: { type: Object }
 		};
 	}
 
@@ -71,7 +71,7 @@ const InternalEntityMixinLit = superclass => class extends superclass {
 
 			entityFactory(this._entityType, this.href, this.token, (entity, error) => {
 				this._entity = entity;
-				this._error = error;
+				this._entityError = error;
 				if (pendingResolve) {
 					pendingResolve();
 					pendingResolve = null;

--- a/src/mixin/entity-mixin-lit.js
+++ b/src/mixin/entity-mixin-lit.js
@@ -20,7 +20,11 @@ const InternalEntityMixinLit = superclass => class extends superclass {
 			/**
 			 * Entity object that extends the Entity class.
 			 */
-			_entity: { type: Object }
+			_entity: { type: Object },
+			/**
+			 * Error object is set if there is an error fetching entity. Null if entity was successfully retrieved.
+			 */
+			_error: { type: Object }
 		};
 	}
 
@@ -65,8 +69,9 @@ const InternalEntityMixinLit = superclass => class extends superclass {
 			const pendingEvent = new AsyncStateEvent(pendingPromise);
 			this.dispatchEvent(pendingEvent);
 
-			entityFactory(this._entityType, this.href, this.token, entity => {
+			entityFactory(this._entityType, this.href, this.token, (entity, error) => {
 				this._entity = entity;
+				this._error = error;
 				if (pendingResolve) {
 					pendingResolve();
 					pendingResolve = null;

--- a/src/mixin/entity-mixin-lit.js
+++ b/src/mixin/entity-mixin-lit.js
@@ -22,7 +22,7 @@ const InternalEntityMixinLit = superclass => class extends superclass {
 			 */
 			_entity: { type: Object },
 			/**
-			 * Error object is set if there is an error fetching entity. Null if entity was successfully retrieved.
+			 * Error object is set if there is an error fetching entity. Undefined if entity was successfully retrieved.
 			 */
 			_entityError: { type: Object }
 		};


### PR DESCRIPTION
- [US148957](https://rally1.rallydev.com/#/255540250444d/iterationstatus?detail=%2Fuserstory%2F685985340191&fdp=true&view=607e378b-5b78-43dc-a109-b9177724b734)
- The purpose of this PR is to set an error property when an entity cannot be fetched with `EntityMixinLit`
- This will make it possible to catch the case where a user navigates to a route with an invalid org unit, to be redirected to another page