### PR TITLE
feat: Add user progress organization entity

### DIFF
--- a/src/hypermedia-constants.js
+++ b/src/hypermedia-constants.js
@@ -269,7 +269,8 @@ export const Rels = {
 		ancestors: 'https://organizations.api.brightspace.com/rels/ancestors',
 		departments: 'https://organizations.api.brightspace.com/rels/ancestors#departments',
 		semesters: 'https://organizations.api.brightspace.com/rels/ancestors#semesters',
-		components: 'https://organizations.api.brightspace.com/rels/components'
+		components: 'https://organizations.api.brightspace.com/rels/components',
+		userProgress: 'https://organizations.api.brightspace.com/rels/user-progress'
 	}
 };
 

--- a/src/organizations/OrganizationEntity.js
+++ b/src/organizations/OrganizationEntity.js
@@ -236,6 +236,10 @@ export class OrganizationEntity extends Entity {
 		return this._getHref(Rels.Organizations.components);
 	}
 
+	_userProgressHref() {
+		return this._getHref(Rels.Organizations.userProgress);
+	}
+
 	_semesterHref() {
 		return this._getHref(Rels.parentSemester);
 	}

--- a/src/organizations/userProgress/OrganizationUserProgressEntity.js
+++ b/src/organizations/userProgress/OrganizationUserProgressEntity.js
@@ -1,0 +1,10 @@
+import { Entity } from '@brightspace-hmc/siren-sdk/src/es6/Entity.js';
+
+/*
+ * An entity representing the user progress within an organization.
+ */
+export class OrganizationUserProgressEntity extends Entity {
+	hasUserProgress() {
+		return this._entity?.properties?.hasUserProgress;
+	}
+}


### PR DESCRIPTION
### Related Rally Story(s):
[US146577](https://rally1.rallydev.com/#/?detail=/userstory/673475675019&fdp=true): Course Merge - UI - Display course has content and/or user progress tags in course list

### Related PR(s):
* https://github.com/BrightspaceHypermediaComponents/siren-sdk/pull/619
* https://github.com/Brightspace/ipsis-sis-course-merge/pull/93
* https://github.com/Brightspace/ipsis-sis-course-merge/pull/109