### PR TITLE
US152358: Handling not supported completion criteria+ requirement combinations

### DIFF
--- a/src/activities/ActivityUsageEntity.js
+++ b/src/activities/ActivityUsageEntity.js
@@ -90,6 +90,19 @@ export class ActivityUsageEntity extends Entity {
 	}
 
 	/**
+	 * @returns {Array} Available completion criteria values for this activity, for use with the updateCompletionCriteria action
+	 */
+	availableCriteria() {
+		const completionCriteriaEntity = this._getSubEntityByClass(Classes.content.completionCriteria);
+
+		if (!completionCriteriaEntity) {
+			return;
+		}
+
+		return completionCriteriaEntity.properties.availableCriteria;
+	}
+
+	/**
 	 * @returns {Array} Enabled completion criteria values for this activity, for use with the updateCompletionCriteria action
 	 */
 	enabledCriteria() {


### PR DESCRIPTION
https://rally1.rallydev.com/#/289692574792d/custom/355050439968?detail=%2Fuserstory%2F700141410177

When on the FACE page, we want to disable some `CompletionCriteria` options depending on the state of the `CompletionRequirement`. If the activity is `required`, we will allow all possibilities, but if the activity is `optional`, the only valid state is `Automatic`, so all other options will be disabled. This will allow us to prevent the user from creating possibilities that are not currently supported by the `CompletionTypes` enum.

This is achieved by adding a new list of criteria to pass to the front end. For clarity I renamed the existing list, and used that name for the new one. So going forward:

`AvailableCriteria`: refers to all possibilities the user _could_ choose from, though they might not necessarily be enabled. This list will always include all options in enabled criteria.
`EnabledCriteria`: refers to all possibilities the user actually has the ability to change to.

## SCREENSHOTS

### Requirement = Required. All options enabled

![image](https://github.com/BrightspaceHypermediaComponents/activities/assets/14796305/c8b4d218-f0e7-42d3-833a-0f28428d28e6)
![image](https://github.com/BrightspaceHypermediaComponents/activities/assets/14796305/4f4139b9-acc3-49c1-9250-875ab45c9c54)

### Requirement = Optional. Only automatic enabled

![image](https://github.com/BrightspaceHypermediaComponents/activities/assets/14796305/6c60d952-633b-49ab-974d-36a373fb13f5)
![image](https://github.com/BrightspaceHypermediaComponents/activities/assets/14796305/2cb74e05-ee28-41d1-a88d-d7371e3dd6e9)

lms: https://github.com/Brightspace/lms/pull/36234
activities: https://github.com/BrightspaceHypermediaComponents/activities/pull/3898
