### PR TITLE
US152524: [Front End] Include d2l-activity-content-completion-editor's information in the SAVE action for New Activities

### DIFF
--- a/src/activities/content/ContentFileEntity.js
+++ b/src/activities/content/ContentFileEntity.js
@@ -122,6 +122,24 @@ export class ContentFileEntity extends ContentWorkingCopyEntity {
 	}
 
 	/**
+	 * Updates the file to have the given completion criteria
+	 * @param {string} completionCriteria completion criteria to set for the file
+	 */
+	async setFileCompletionCriteria(completionCriteria) {
+		if (!this._entity) {
+			return;
+		}
+
+		const action = this._entity.getActionByName(Actions.content.updateCompletionCriteria);
+		if (!action) {
+			return;
+		}
+
+		const fields = [{ name: 'criteria', value: completionCriteria }];
+		return await performSirenAction(this._token, action, fields);
+	}
+
+	/**
 	 * Deletes the file
 	 */
 	async deleteFile() {

--- a/src/activities/content/ContentWebLinkEntity.js
+++ b/src/activities/content/ContentWebLinkEntity.js
@@ -158,6 +158,24 @@ export class ContentWebLinkEntity extends ContentWorkingCopyEntity {
 	}
 
 	/**
+	 * Updates the web link to have the given completion criteria
+	 * @param {string} completionCriteria completion criteria to set for the web link
+	 */
+	async setWebLinkCompletionCriteria(completionCriteria) {
+		if (!this._entity) {
+			return;
+		}
+
+		const action = this._entity.getActionByName(Actions.webLink.updateCompletionCriteria);
+		if (!action) {
+			return;
+		}
+
+		const fields = [{ name: 'criteria', value: completionCriteria }];
+		return await performSirenAction(this._token, action, fields);
+	}
+
+	/**
 	 * Deletes the web link
 	 */
 	async deleteWebLink() {

--- a/src/hypermedia-constants.js
+++ b/src/hypermedia-constants.js
@@ -689,6 +689,7 @@ export const Actions = {
 	},
 	webLink: {
 		updateUrl: 'update-url',
+		updateCompletionCriteria: 'update-completion-criteria',
 		updateExternalResource: 'update-external-resource',
 		deleteWeblink: 'delete-webLink',
 		deleteLTIlink: 'delete-ltiLink',

--- a/test/activities/content/ContentFileEntity.test.js
+++ b/test/activities/content/ContentFileEntity.test.js
@@ -87,6 +87,18 @@ describe('ContentFileEntity', () => {
 			expect(fetchMock.called()).to.be.true;
 		});
 
+		it('saves completion criteria', async() => {
+			fetchMock.patchOnce('https://fake-tenant-id.content.api.proddev.d2l/6613/files/12345', fileData);
+
+			await contentFileEntity.setFileCompletionCriteria('manual');
+
+			const form = await getFormData(fetchMock.lastCall().request);
+			if (!form.notSupported) {
+				expect(form.get('title')).to.equal('manual');
+			}
+			expect(fetchMock.called()).to.be.true;
+		});
+
 		it('performs delete request', async() => {
 			fetchMock.deleteOnce('https://fake-tenant-id.content.api.proddev.d2l/6613/files/12345', fileData);
 			await contentFileEntity.deleteFile();

--- a/test/activities/content/ContentFileEntity.test.js
+++ b/test/activities/content/ContentFileEntity.test.js
@@ -94,7 +94,7 @@ describe('ContentFileEntity', () => {
 
 			const form = await getFormData(fetchMock.lastCall().request);
 			if (!form.notSupported) {
-				expect(form.get('title')).to.equal('manual');
+				expect(form.get('criteria')).to.equal('manual');
 			}
 			expect(fetchMock.called()).to.be.true;
 		});

--- a/test/activities/content/ContentWebLinkEntity.test.js
+++ b/test/activities/content/ContentWebLinkEntity.test.js
@@ -127,6 +127,18 @@ describe('ContentWebLinkEntity', () => {
 			expect(fetchMock.called()).to.be.true;
 		});
 
+		it('saves completion criteria', async() => {
+			fetchMock.patchOnce('https://fake-tenant-id.weblinks.api.proddev.d2l/6613/weblinks/12345', webLinkData);
+
+			await contentWebLinkEntity.setWebLinkCompletionCriteria('manual');
+
+			const form = await getFormData(fetchMock.lastCall().request);
+			if (!form.notSupported) {
+				expect(form.get('criteria')).to.equal('manual');
+			}
+			expect(fetchMock.called()).to.be.true;
+		});
+
 		it('performs delete request', async() => {
 			fetchMock.deleteOnce('https://fake-tenant-id.weblinks.api.proddev.d2l/6613/weblinks/12345', webLinkData);
 			await contentWebLinkEntity.deleteWebLink();

--- a/test/activities/content/data/TestContentFileEntity.js
+++ b/test/activities/content/data/TestContentFileEntity.js
@@ -28,6 +28,19 @@ export const contentFileData = {
 		},
 		{
 			'href': 'https://fake-tenant-id.content.api.proddev.d2l/6613/files/12345',
+			'name': 'update-completion-criteria',
+			'method': 'PATCH',
+			'fields': [
+				{
+					'class': ['required'],
+					'type': 'text',
+					'name': 'criteria',
+					'value': 'manual'
+				}
+			]
+		},
+		{
+			'href': 'https://fake-tenant-id.content.api.proddev.d2l/6613/files/12345',
 			'name': 'delete-content-file',
 			'method': 'DELETE'
 		}

--- a/test/activities/content/data/TestContentWebLinkEntity.js
+++ b/test/activities/content/data/TestContentWebLinkEntity.js
@@ -53,6 +53,19 @@ export const contentWebLinkData = {
 		},
 		{
 			'href': 'https://fake-tenant-id.weblinks.api.proddev.d2l/6613/weblinks/12345',
+			'name': 'update-completion-criteria',
+			'method': 'PATCH',
+			'fields': [
+				{
+					'class': ['required'],
+					'type': 'text',
+					'name': 'criteria',
+					'value': 'manual'
+				}
+			]
+		},
+		{
+			'href': 'https://fake-tenant-id.weblinks.api.proddev.d2l/6613/weblinks/12345',
 			'name': 'delete-webLink',
 			'method': 'DELETE'
 		}


### PR DESCRIPTION
Rally Link: [US152524](https://rally1.rallydev.com/#/289692574792d/custom/355050439968?detail=%2Fuserstory%2F700607131769)

This PR add methods to update the completion criteria by executing the appropriate hypermedia action for files and weblinks.

The actions were added in the LMS [here](https://github.com/Brightspace/lms/pull/36335/files#diff-5fffac92544fb6fe130af06c57c8eac7c97d0938b3ab7332af66127c18f73989R282-R300) and [here](https://github.com/Brightspace/lms/pull/36335/files#diff-3ebfaf0535773a0728b72cfbcd35c2ff808221c0e802a08d4a9b0f1ca023dc08R252-R261)

Related PRs:
LMS - https://github.com/Brightspace/lms/pull/36335
Activities - https://github.com/BrightspaceHypermediaComponents/activities/pull/3904

Note: These changes are specifically being made the way they are to allow for completion criteria to be set for activities that are being created for the first time and make use of working copy.