### PR TITLE
feat: US152381 create Activity entity which contains activity name

### DIFF
--- a/src/activities/ActivityEntity.js
+++ b/src/activities/ActivityEntity.js
@@ -1,0 +1,79 @@
+import { Actions, Classes, Rels } from '../hypermedia-constants.js';
+import { Entity } from '../es6/Entity.js';
+import { performSirenAction } from '../es6/SirenAction.js';
+
+export class ActivityEntity extends Entity {
+    _nameEntity() {
+        return this._entity?.getSubEntityByRel(Classes.activities.activityName);
+    }
+
+    name() {
+        return this._nameEntity()?.properties?.name;
+    }
+
+    canUpdateName() {
+        const nameEntity = this._nameEntity();
+        if( !nameEntity ) {
+            return false;
+        }
+        return nameEntity.hasActionByName(Actions.activities.updateName);
+    }
+
+    _hasFieldValueChanged(currentValue, initialValue) {
+		return currentValue !== initialValue;
+	}
+
+    /**
+	 * @summary Formats action and fields if activity name has changed and user has edit permission
+	 * @param {object} activity the activity that's being modified
+	 * @returns {object} the appropriate action/fields to update
+	 */
+	_formatUpdateNameAction(activity) {
+		const { name } = activity || {};
+
+		if (!name) return;
+		if (!this._hasFieldValueChanged(name, this.name())) return;
+		if (!this.canUpdateName()) return;
+
+		const action = this._nameEntity().getActionByName(Actions.activities.updateName);
+		const fields = [
+			{ name: 'name', value: name }
+		];
+
+		return { action, fields };
+	}
+
+    /**
+	 * @summary Checks if activity entity has changed, primarily used for dirty check
+	 * @param {object} activity the activity that's being modified
+	 */
+	equals(activity) {
+		const diffs = [
+			[activity.name, this.name()]
+		];
+
+		for (const [current, initial] of diffs) {
+			if (current !== initial) {
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+    /**
+	 * @summary Fires all the formatted siren actions collectively
+	 * @param {object} activity the activity that's being modified
+	 */
+	async save(activity) {
+		if (!activity) return;
+
+		const updateNameAction = this._formatUpdateNameAction(activity);
+
+		const sirenActions = [
+			updateNameAction
+		];
+
+		await performSirenActions(this._token, sirenActions);
+	}
+}

--- a/src/activities/ActivityEntity.js
+++ b/src/activities/ActivityEntity.js
@@ -1,29 +1,29 @@
-import { Actions, Classes, Rels } from '../hypermedia-constants.js';
+import { Actions, Classes } from '../hypermedia-constants.js';
 import { Entity } from '../es6/Entity.js';
-import { performSirenAction } from '../es6/SirenAction.js';
+import { performSirenActions } from '../es6/SirenAction.js';
 
 export class ActivityEntity extends Entity {
-    _nameEntity() {
-        return this._entity?.getSubEntityByRel(Classes.activities.activityName);
-    }
+	_nameEntity() {
+		return this._entity?.getSubEntityByRel(Classes.activities.activityName);
+	}
 
-    name() {
-        return this._nameEntity()?.properties?.name;
-    }
+	name() {
+		return this._nameEntity()?.properties?.name;
+	}
 
-    canUpdateName() {
-        const nameEntity = this._nameEntity();
-        if( !nameEntity ) {
-            return false;
-        }
-        return nameEntity.hasActionByName(Actions.activities.updateName);
-    }
+	canUpdateName() {
+		const nameEntity = this._nameEntity();
+		if (!nameEntity) {
+			return false;
+		}
+		return nameEntity.hasActionByName(Actions.activities.updateName);
+	}
 
-    _hasFieldValueChanged(currentValue, initialValue) {
+	_hasFieldValueChanged(currentValue, initialValue) {
 		return currentValue !== initialValue;
 	}
 
-    /**
+	/**
 	 * @summary Formats action and fields if activity name has changed and user has edit permission
 	 * @param {object} activity the activity that's being modified
 	 * @returns {object} the appropriate action/fields to update
@@ -43,7 +43,7 @@ export class ActivityEntity extends Entity {
 		return { action, fields };
 	}
 
-    /**
+	/**
 	 * @summary Checks if activity entity has changed, primarily used for dirty check
 	 * @param {object} activity the activity that's being modified
 	 */
@@ -61,7 +61,7 @@ export class ActivityEntity extends Entity {
 		return true;
 	}
 
-    /**
+	/**
 	 * @summary Fires all the formatted siren actions collectively
 	 * @param {object} activity the activity that's being modified
 	 */

--- a/src/activities/ActivityUsageEntity.js
+++ b/src/activities/ActivityUsageEntity.js
@@ -11,6 +11,17 @@ import { UserActivityUsageEntity } from '../enrollments/UserActivityUsageEntity.
 
 export class ActivityUsageEntity extends Entity {
 	/**
+	 * @returns {string} URL of the activity associated with the activity usage, if present
+	 */
+	activityHref() {
+		if (!this._entity || !this._entity.hasLinkByRel(Rels.Activities.activity)) {
+			return;
+		}
+
+		return this._entity.getLinkByRel(Rels.Activities.activity).href;
+	}
+	
+	/**
 	 * @returns {string} URL of the organization associated with the activity usage, if present
 	 */
 	organizationHref() {

--- a/src/activities/ActivityUsageEntity.js
+++ b/src/activities/ActivityUsageEntity.js
@@ -20,7 +20,7 @@ export class ActivityUsageEntity extends Entity {
 
 		return this._entity.getLinkByRel(Rels.Activities.activity).href;
 	}
-	
+
 	/**
 	 * @returns {string} URL of the organization associated with the activity usage, if present
 	 */

--- a/src/hypermedia-constants.js
+++ b/src/hypermedia-constants.js
@@ -48,6 +48,7 @@ export const Rels = {
 	widgetSettings: 'https://api.brightspace.com/rels/widget-settings',
 	// Activities API sub-domain rels
 	Activities: {
+		activity: 'https://activities.api.brightspace.com/rels/activity',
 		myActivities: 'https://activities.api.brightspace.com/rels/my-activities',
 		myActivitiesEmpty: 'https://activities.api.brightspace.com/rels/my-activities#empty',
 		myOrganizationActivities: 'https://activities.api.brightspace.com/rels/my-organization-activities',
@@ -295,6 +296,7 @@ export const Classes = {
 		draftPublishedEntity: 'draft-published-entity',
 		exempt: 'exempt',
 		feedbackDate: 'feedback-date',
+		activityName: 'activity-name',
 		published: 'published',
 		scoreOutOf: 'score-out-of',
 		selected: 'selected',
@@ -635,6 +637,7 @@ export const Actions = {
 		startAddNew: 'start-add-new',
 		update: 'update',
 		updateDraft: 'update-draft',
+		updateName: 'update-name',
 		scoreOutOf: {
 			update: 'update'
 		},

--- a/test/activities/ActivityEntity.test.js
+++ b/test/activities/ActivityEntity.test.js
@@ -1,0 +1,93 @@
+import { ActivityEntity } from '../../src/activities/ActivityEntity.js';
+import { expect } from '@open-wc/testing';
+import fetchMock from 'fetch-mock/esm/client.js';
+import { getFormData } from '../utility/test-helpers.js';
+import SirenParse from 'siren-parser';
+import { testData } from './data/ActivityEntity.js';
+
+describe('ActivityEntity', () => {
+	let entity, readonlyEntity, entityJson;
+
+	beforeEach(() => {
+		entityJson = SirenParse(testData.activityEntityEditable);
+		entity = new ActivityEntity(entityJson);
+
+		const readonlyJson = SirenParse(testData.activityEntityReadOnly);
+		readonlyEntity = new ActivityEntity(readonlyJson);
+	});
+
+	describe('Name', () => {
+		describe('Can edit', () => {
+			it('gets name', () => {
+				expect(entity.name()).to.equal('Sample Activity Name');
+			});
+
+			it('can edit name', () => {
+				expect(entity.canUpdateName()).to.be.true;
+			});
+		});
+
+		describe('Can NOT edit', () => {
+			it('gets name', () => {
+				expect(readonlyEntity.name()).to.equal('Sample Activity Name');
+			});
+
+			it('can NOT edit name', () => {
+				expect(readonlyEntity.canUpdateName()).to.be.false;
+			});
+		});
+	});
+
+	describe('Saves', () => {
+
+		afterEach(() => {
+			fetchMock.reset();
+		});
+
+		describe('name', () => {
+			it('saves name', async() => {
+				fetchMock.patchOnce('https://d53287c1-ad48-4c2e-a0a7-bd53c3029e95.activities.api.dev.brightspace.com/activities/5', entityJson);
+
+				await entity.save({
+					name: 'New Name'
+				});
+
+				const form = await getFormData(fetchMock.lastCall().request);
+				if (!form.notSupported) {
+					expect(form.get('name')).to.equal('New Name');
+				}
+				expect(fetchMock.called()).to.be.true;
+			});
+
+			it('skips save if not dirty', async() => {
+				await entity.save({
+					name: 'Sample Activity Name'
+				});
+
+				expect(fetchMock.done());
+			});
+
+			it('skips save if not editable', async() => {
+				await readonlyEntity.save({
+					name: 'New Name'
+				});
+
+				expect(fetchMock.done());
+			});
+		});
+	});
+
+	describe('Equals', () => {
+		it('return true when equal', () => {
+			expect(entity.equals({
+				name: 'Sample Activity Name'
+			})).to.be.true;
+		});
+
+		it('return false when not equal', () => {
+			expect(entity.equals({
+				name: 'New Name'
+			})).to.be.false;
+		});
+	});
+});

--- a/test/activities/ActivityUsageEntity.test.js
+++ b/test/activities/ActivityUsageEntity.test.js
@@ -18,6 +18,10 @@ describe('ActivityUsageEntity', () => {
 	});
 
 	describe('Basic loading', () => {
+		it('can get activity href', () => {
+			expect(entity.activityHref()).to.equal('http://vlx1-mdulat.desire2learn.d2l:44444/d2l/api/hm/activities/activities/5');
+		});
+
 		it('can get organizationHref', () => {
 			expect(entity.organizationHref()).to.equal('http://vlx1-mdulat.desire2learn.d2l:44444/d2l/api/hm/organizations/6609');
 		});

--- a/test/activities/data/ActivityEntity.js
+++ b/test/activities/data/ActivityEntity.js
@@ -1,0 +1,62 @@
+export const testData = {
+	activityEntityEditable: {
+		'class': ['activity'],
+		'entities': [
+			{
+				'class': [
+					'activity-name'
+				],
+				'properties': {
+					'name': 'Sample Activity Name'
+				},
+				'actions': [
+					{
+						'href': 'https://d53287c1-ad48-4c2e-a0a7-bd53c3029e95.activities.api.dev.brightspace.com/activities/5',
+						'name': 'update-name',
+						'method': 'PATCH',
+						'fields': [
+							{
+								'type': 'text',
+								'name': 'name',
+								'value': 'Sample Activity Name'
+							}
+						]
+					}
+				],
+				'rel': ['activity-name']
+			}
+		],
+
+		'links': [
+			{
+				'rel': [
+					'self'
+				],
+				'href': 'https://d53287c1-ad48-4c2e-a0a7-bd53c3029e95.activities.api.dev.brightspace.com/activities/5'
+			}
+		]
+	},
+	activityEntityReadOnly: {
+		'class': ['activity'],
+		'entities': [
+			{
+				'class': [
+					'activity-name'
+				],
+				'properties': {
+					'name': 'Sample Activity Name'
+				},
+				'rel': ['activity-name']
+			}
+		],
+
+		'links': [
+			{
+				'rel': [
+					'self'
+				],
+				'href': 'https://d53287c1-ad48-4c2e-a0a7-bd53c3029e95.activities.api.dev.brightspace.com/activities/5'
+			}
+		]
+	}
+};

--- a/test/activities/data/ActivityUsageEntity.js
+++ b/test/activities/data/ActivityUsageEntity.js
@@ -86,6 +86,13 @@ export const testData = {
 		'links': [
 			{
 				'rel': [
+					'https://activities.api.brightspace.com/rels/activity',
+					'self'
+				],
+				'href': 'http://vlx1-mdulat.desire2learn.d2l:44444/d2l/api/hm/activities/activities/5'
+			},
+			{
+				'rel': [
 					'https://activities.api.brightspace.com/rels/activity-usage',
 					'self'
 				],
@@ -247,6 +254,13 @@ export const testData = {
 			}
 		],
 		'links': [
+			{
+				'rel': [
+					'https://activities.api.brightspace.com/rels/activity',
+					'self'
+				],
+				'href': 'http://vlx1-mdulat.desire2learn.d2l:44444/d2l/api/hm/activities/activities/5'
+			},
 			{
 				'rel': [
 					'https://activities.api.brightspace.com/rels/activity-usage',


### PR DESCRIPTION
[US152381](https://rally1.rallydev.com/#/?detail=/userstory/700183222253&fdp=true): [ui] Edit name for Compound activity

Adds an Activity Entity to represent the activity, which currently contains only a name. I kept the functions general in case we add more sub-entities to the Activity entity, but for now it just has the name.

Assuming the entity returned from the activity endpoint looks like:
```{
    "class": ["activity"],
    "entities": [
        {
            "class": [
                "activity-name"
            ],
            "properties": {
                "name": "Sample Activity Name"
            },
            "actions": [
                {
                    "href": "https://d53287c1-ad48-4c2e-a0a7-bd53c3029e95.activities.api.dev.brightspace.com/activities/{activityId}",
                    "name": "update-name",
                    "method": "PATCH",
                    "fields": [
                        {
                            "type": "text",
                            "name": "name",
                            "value": "Sample Activity Name"
                        }
                    ]
                }
            ]
        }
    ],
    
    "links": [
        {
            "rel": [
                "self"
            ],
            "href": "https://d53287c1-ad48-4c2e-a0a7-bd53c3029e95.activities.api.dev.brightspace.com/activities/{activityId}"
        }
    ]
}```