### PR TITLE
feat: US152381 add rel for activity-name

### DIFF
--- a/src/activities/ActivityEntity.js
+++ b/src/activities/ActivityEntity.js
@@ -1,4 +1,4 @@
-import { Actions, Classes, Rels } from '../hypermedia-constants.js';
+import { Actions, Rels } from '../hypermedia-constants.js';
 import { Entity } from '../es6/Entity.js';
 import { performSirenActions } from '../es6/SirenAction.js';
 

--- a/src/activities/ActivityEntity.js
+++ b/src/activities/ActivityEntity.js
@@ -1,10 +1,10 @@
-import { Actions, Classes } from '../hypermedia-constants.js';
+import { Actions, Classes, Rels } from '../hypermedia-constants.js';
 import { Entity } from '../es6/Entity.js';
 import { performSirenActions } from '../es6/SirenAction.js';
 
 export class ActivityEntity extends Entity {
 	_nameEntity() {
-		return this._entity?.getSubEntityByRel(Classes.activities.activityName);
+		return this._entity?.getSubEntityByRel(Rels.Activities.activityName);
 	}
 
 	name() {

--- a/src/hypermedia-constants.js
+++ b/src/hypermedia-constants.js
@@ -81,7 +81,8 @@ export const Rels = {
 		associateGrade: 'https://activities.api.brightspace.com/rels/associate-grade',
 		associateMultipleGrades: 'https://activities.api.brightspace.com/rels/associate-multiple-grades',
 		evaluation: 'https://activities.api.brightspace.com/rels/evaluation',
-		pagingType: 'https://activities.api.brightspace.com/rels/activity-collection/paging-type'
+		pagingType: 'https://activities.api.brightspace.com/rels/activity-collection/paging-type',
+		activityName: 'https://activities.api.brightspace.com/rels/activity-name'
 	},
 	Conditions: {
 		conditions: 'https://conditions.api.brightspace.com/rels/conditions',

--- a/test/activities/data/ActivityEntity.js
+++ b/test/activities/data/ActivityEntity.js
@@ -6,6 +6,9 @@ export const testData = {
 				'class': [
 					'activity-name'
 				],
+				'rel': [
+					'https://activities.api.brightspace.com/rels/activity-name'
+				],
 				'properties': {
 					'name': 'Sample Activity Name'
 				},
@@ -22,8 +25,7 @@ export const testData = {
 							}
 						]
 					}
-				],
-				'rel': ['activity-name']
+				]
 			}
 		],
 
@@ -43,10 +45,12 @@ export const testData = {
 				'class': [
 					'activity-name'
 				],
+				'rel': [
+					'https://activities.api.brightspace.com/rels/activity-name'
+				],
 				'properties': {
 					'name': 'Sample Activity Name'
-				},
-				'rel': ['activity-name']
+				}
 			}
 		],
 


### PR DESCRIPTION
[US152381](https://rally1.rallydev.com/#/?detail=/userstory/700183222253&fdp=true): [ui] Edit name for Compound activity

Add rel for activity-name sub-entity. Apparently a rel is required for sub-entities, otherwise the fetch throws errors.