### PR TITLE
bbuegare/US155015 Respect config for group and section restriction

### DIFF
--- a/src/activities/discussions/GroupSectionRestrictionActionsEntity.js
+++ b/src/activities/discussions/GroupSectionRestrictionActionsEntity.js
@@ -105,4 +105,12 @@ export class GroupSectionRestrictionActionsEntity extends Entity {
 
 		return performSirenAction(this._token, action, fields);
 	}
+	isRestrictedTopicDefault() {
+		if (!this._entity) return;
+		return this._entity.hasClass(Classes.discussions.restrictedTopicDefault);
+	}
+	isRestrictedThreadsDefault() {
+		if (!this._entity) return;
+		return this._entity.hasClass(Classes.discussions.restrictedThreadsDefault);
+	}
 }

--- a/src/hypermedia-constants.js
+++ b/src/hypermedia-constants.js
@@ -414,7 +414,9 @@ export const Classes = {
 		section: 'section',
 		selected: 'selected',
 		allGroups: 'all-groups',
-		allSections: 'all-sections'
+		allSections: 'all-sections',
+		restrictedTopicDefault: 'restricted-topic-default',
+		restrictedThreadsDefault: 'restricted-threads-default'
 	},
 	enrollments: {
 		enrollment: 'enrollment',


### PR DESCRIPTION
https://rally1.rallydev.com/#/?detail=/userstory/707430937329&fdp=true

These changes are for checking the correct radio button in the dialog `Group and Section Restrictions` according to the `d2l.Tools.Discuss.GroupSectionRestrictionDefault` value
![image](https://github.com/Brightspace/lms/assets/138625743/95ff9b7d-14d5-42de-b46b-c6f70fb628b9)

PRs that complements this one are:

- https://github.com/Brightspace/lms/pull/40331
- https://github.com/BrightspaceHypermediaComponents/activities/pull/4156