### PR TITLE
bbuegare/US157367-TA179419-Add-forum-select-box-to-primary-panel

### DIFF
--- a/src/activities/discussions/DiscussionForumsEntity.js
+++ b/src/activities/discussions/DiscussionForumsEntity.js
@@ -23,6 +23,6 @@ export class DiscussionForumsEntity extends Entity {
 
 		const action = this._entity.getActionByName(Actions.discussions.forums.createForum);
 		const fields = [{ name: 'name', value: name }];
-		await performSirenAction(this._token, action, fields);
+		return await performSirenAction(this._token, action, fields);
 	}
 }


### PR DESCRIPTION
[US157367](https://rally1.rallydev.com/#/?detail=/userstory/721242597713&fdp=true)

Theses changes add the ability to create a new forum with the modified forum dialog without the need to save the Topic first. New forums should be created each time users click the save button on the dialog [TA179419](https://rally1.rallydev.com/#/?detail=/task/722207771517&fdp=true)

Related PRs

[Activities](https://github.com/BrightspaceHypermediaComponents/activities/pull/4204)
[LMS](https://github.com/Brightspace/lms/pull/40964)