### PR TITLE
fix load more count

### DIFF
--- a/src/ipsis/course-merge/BaseCollectionEntity.js
+++ b/src/ipsis/course-merge/BaseCollectionEntity.js
@@ -47,13 +47,14 @@ export class BaseCollectionEntity extends Entity {
 	}
 
 	loadMorePageSize(collectionGetter) {
+		const pageSize = 20;
 		const totalCount = this.totalCount() ?? 0;
 		const collectionLength = collectionGetter()?.length ?? 0;
 		// if pageSize is larger than the number remaining items, return the number of remaining items to be loaded
-		if (totalCount < collectionLength + this.pageSize()) {
+		if (totalCount < collectionLength + pageSize) {
 			return totalCount - collectionLength;
 		}
-		return this.pageSize();
+		return pageSize;
 	}
 }
 


### PR DESCRIPTION
[US154265](https://rally1.rallydev.com/#/?detail=/userstory/705253427401&fdp=true): Course Merge - Audit Log UI- Paging

When there are more elements available, we want to show the count as "load 20 more" as we increment the page size by 20. 

Related PR(s):
* https://github.com/Brightspace/ipsis-sis-course-merge/pull/152
* https://github.com/BrightspaceHypermediaComponents/siren-sdk/pull/676