### PR TITLE
feat: DE55513 - add depth to content module entity

### DIFF
--- a/src/activities/content/ContentModuleEntity.js
+++ b/src/activities/content/ContentModuleEntity.js
@@ -49,6 +49,13 @@ export class ContentModuleEntity extends Entity {
 	}
 
 	/**
+	 * @returns {number|undefined} Depth of the content-module item
+	 */
+	depth() {
+		return this._entity && this._entity.properties && this._entity.properties.depth;
+	}
+
+	/**
 	 * Updates the module to have the given description
 	 * @param {string} richText description to set on the module
 	 */
@@ -105,6 +112,7 @@ export class ContentModuleEntity extends Entity {
 	equals(contentModule) {
 		const diffs = [
 			[this.title(), contentModule.title],
+			[this.depth(), contentModule.depth],
 			[this.descriptionRichText(), contentModule.descriptionRichText],
 			[this.rawDescriptionRichText(), contentModule.rawDescriptionRichText]
 		];

--- a/test/activities/content/ContentModuleEntity.test.js
+++ b/test/activities/content/ContentModuleEntity.test.js
@@ -30,6 +30,10 @@ describe('ContentModuleEntity', () => {
 		it('reads text description', () => {
 			expect(contentModuleEntity.descriptionText()).to.equal('description text');
 		});
+
+		it('reads depth', () => {
+			expect(contentModuleEntity.depth()).to.equal(8675309);
+		});
 	});
 
 	describe('Equality tests', () => {
@@ -37,7 +41,8 @@ describe('ContentModuleEntity', () => {
 			const contentModule = {
 				title: 'Test Content Module Title',
 				descriptionRichText: '<p>description text</p>',
-				rawDescriptionRichText: '<p>description text</p>'
+				rawDescriptionRichText: '<p>description text</p>',
+				depth: 8675309
 			};
 			expect(contentModuleEntity.equals(contentModule)).to.equal(true);
 		});
@@ -46,7 +51,8 @@ describe('ContentModuleEntity', () => {
 			const contentModule = {
 				title: 'Different Content Module Title',
 				descriptionRichText: '<p>description text</p>',
-				rawDescriptionRichText: '<p>description text</p>'
+				rawDescriptionRichText: '<p>description text</p>',
+				depth: 8675309
 			};
 			expect(contentModuleEntity.equals(contentModule)).to.equal(false);
 		});
@@ -55,7 +61,18 @@ describe('ContentModuleEntity', () => {
 			const contentModule = {
 				title: 'Test Content Module Title',
 				descriptionRichText: '<p>Different description text</p>',
-				rawDescriptionRichText: '<p>description text</p>'
+				rawDescriptionRichText: '<p>description text</p>',
+				depth: 8675309
+			};
+			expect(contentModuleEntity.equals(contentModule)).to.equal(false);
+		});
+
+		it('Equality should return false when depth is different', () => {
+			const contentModule = {
+				title: 'Test Content Module Title',
+				descriptionRichText: '<p>description text</p>',
+				rawDescriptionRichText: '<p>description text</p>',
+				depth: 1
 			};
 			expect(contentModuleEntity.equals(contentModule)).to.equal(false);
 		});

--- a/test/activities/content/data/TestContentModuleEntity.js
+++ b/test/activities/content/data/TestContentModuleEntity.js
@@ -37,7 +37,8 @@ export const contentModuleData = {
 		'module'
 	],
 	'properties': {
-		'title': 'Test Content Module Title'
+		'title': 'Test Content Module Title',
+		'depth': 8675309
 	},
 	'entities': [
 		{


### PR DESCRIPTION
[DE55513](https://rally1.rallydev.com/#/42960320374d/custom/236803223728?detail=%2Fdefect%2F729399482859)

This adds the depth as a new property on the content module entity. The dependency PR below uses the depth to figure out the appropriate type of lessons module ( i.e. Unit, Lesson, Folder )

Dependency for this PR:
- https://github.com/BrightspaceHypermediaComponents/activities/pull/4377