### PR TITLE
DE56374 > Manual Completion Assignments don't show the manual complete button

### DIFF
--- a/src/activities/content/ContentCompletionEntity.js
+++ b/src/activities/content/ContentCompletionEntity.js
@@ -13,7 +13,7 @@ export class ContentCompletionEntity extends Entity {
 
 	/** @returns {bool} Whether or not the the content has been marked as completed*/
 	isContentCompleted() {
-		return this._entity && this._entity.hasClass('completed');
+		return this._entity && (this._entity.hasClass('completed') || this._entity.hasClass('complete'));
 	}
 
 	/**


### PR DESCRIPTION
## Rally Link
https://rally1.rallydev.com/#/?detail=/defect/734336124523&fdp=true
## Description
The manual completion button was being used by content completion and now it is now being used by assigned activities as well, unfortunately in the backend one uses the term `completed` and one uses `complete` , this captures both scenarios without making a change in the backend 