### PR TITLE
MAN-2876 Add outcome-settings link to OrganizationEntity

### DIFF
--- a/src/hypermedia-constants.js
+++ b/src/hypermedia-constants.js
@@ -266,7 +266,8 @@ export const Rels = {
 	Outcomes: {
 		intents: 'https://outcomes.api.brightspace.com/rels/intents',
 		intent: 'https://outcomes.api.brightspace.com/rels/intent',
-		outcome: 'https://outcomes.api.brightspace.com/rels/outcome'
+		outcome: 'https://outcomes.api.brightspace.com/rels/outcome',
+		settings: 'https://outcomes.api.brightspace.com/rels/outcomes-settings'
 	},
 	Meetings: {
 		meetingManagementTool: 'https://meetings.api.brightspace.com/rels/meeting-management-tool'

--- a/src/organizations/OrganizationEntity.js
+++ b/src/organizations/OrganizationEntity.js
@@ -159,6 +159,9 @@ export class OrganizationEntity extends Entity {
 	copyCoursePageUrl() {
 		return this._getHref(Rels.copyCoursePage);
 	}
+	outcomesSettingsUrl() {
+		return this._getHref(Rels.Outcomes.settings);
+	}
 
 	canChangeCourseImage() {
 		return this._entity


### PR DESCRIPTION
Being added in https://github.com/Brightspace/lms/pull/49836, this does what it says on the tin and links to the Outcomes Settings page for the organization.

https://desire2learn.atlassian.net/browse/MAN-2876