### PR TITLE
FED-2765 fix alignment links

### DIFF
--- a/src/activities/assignments/AssignmentEntity.js
+++ b/src/activities/assignments/AssignmentEntity.js
@@ -26,6 +26,7 @@ export class AssignmentEntity extends Entity {
 			return;
 		}
 		return this._entity.getLinkByRel(Rels.Assignments.recommendAlignments).href;
+	}
 
 	instructionsHref() {
 		if (!this._entity || !this._entity.hasLinkByRel(Rels.Assignments.instructionsText)) {

--- a/src/activities/assignments/AssignmentEntity.js
+++ b/src/activities/assignments/AssignmentEntity.js
@@ -21,6 +21,20 @@ export class AssignmentEntity extends Entity {
 		return this._entity && this._entity.properties && this._entity.properties.name;
 	}
 
+	recommendAlignmentsEndpoint() {
+		if (!this._entity || !this._entity.hasLinkByRel(Rels.Assignments.recommendAlignments)) {
+			return;
+		}
+		return this._entity.getLinkByRel(this._entity.getLinkByRel(Rels.Assignments.recommendAlignments)).href;
+	}
+
+	instructionsHref() {
+		if (!this._entity || !this._entity.hasLinkByRel(Rels.Assignments.instructionsText)) {
+			return;
+		}
+		return this._entity.getLinkByRel(this._entity.getLinkByRel(Rels.Assignments.instructionsText)).href;
+	}
+
 	/**
 	 * @returns {bool} Whether or not the edit name action is present on the assignment entity
 	 */

--- a/src/activities/assignments/AssignmentEntity.js
+++ b/src/activities/assignments/AssignmentEntity.js
@@ -25,14 +25,14 @@ export class AssignmentEntity extends Entity {
 		if (!this._entity || !this._entity.hasLinkByRel(Rels.Assignments.recommendAlignments)) {
 			return;
 		}
-		return this._entity.getLinkByRel(this._entity.getLinkByRel(Rels.Assignments.recommendAlignments)).href;
+		return this._entity.getLinkByRel(Rels.Assignments.recommendAlignments).href;
 	}
 
 	instructionsHref() {
 		if (!this._entity || !this._entity.hasLinkByRel(Rels.Assignments.instructionsText)) {
 			return;
 		}
-		return this._entity.getLinkByRel(this._entity.getLinkByRel(Rels.Assignments.instructionsText)).href;
+		return this._entity.getLinkByRel(Rels.Assignments.instructionsText).href;
 	}
 
 	/**

--- a/src/hypermedia-constants.js
+++ b/src/hypermedia-constants.js
@@ -114,7 +114,9 @@ export const Rels = {
 		filesSubmissionLimit: 'https://assignments.api.brightspace.com/rels/files-submission-limit',
 		submissionsRule: 'https://assignments.api.brightspace.com/rels/submissions-rule',
 		notificationEmail: 'https://assignments.api.brightspace.com/rels/notification-email',
-		categories: 'https://assignments.api.brightspace.com/rels/categories'
+		categories: 'https://assignments.api.brightspace.com/rels/categories',
+		instructionsText: 'https://assignments.api.brightspace.com/rels/instructions-text',
+		recommendAlignments: 'https://assignments.api.brightspace.com/rels/recommend-alignments'
 	},
 	// Awards
 	Awards: {


### PR DESCRIPTION
https://desire2learn.atlassian.net/browse/FED-2765?atlOrigin=eyJpIjoiMzU0MzEwZDlkYzAyNGE5ZjgwMDA3ZTBhYjc1MzU5NTEiLCJwIjoiaiJ9

Fix extra calls to `getLinkByRel` (typos) that caused weird behavior where the instructions href was set to the alignments endpoint.