### PR TITLE
BREAKING CHANGE: upgrade to Lit 3

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,11 +20,11 @@
     "access": "public"
   },
   "dependencies": {
-    "@brightspace-ui/core": "^2",
+    "@brightspace-ui/core": "^3",
     "@open-wc/dedupe-mixin": "^1",
     "@polymer/polymer": "^3",
     "d2l-fetch": "^2",
-    "d2l-polymer-siren-behaviors": "^1"
+    "d2l-polymer-siren-behaviors": "^2"
   },
   "devDependencies": {
     "@babel/core": "^7",


### PR DESCRIPTION
⚠️  **DO NOT MERGE yet!** ⚠️ 

👋 Hey, we're upgrading to Lit 3! 🎉  This PR prepares this repo for the upgrade, which will happen starting May 21st. Someone from team Gaudí will take care of everything (except approving this PR), so sit back and enjoy the upgrade!

### A Phased Approach

Merges will happen in several phases based on where each repo sits in the overall dependency graph of Lit-related things.

This repo will be in phase: **2 of 8**

Since this repo is in a downstream phase, its dependency versions that use Lit 3 haven't released yet, so its CI will be in a broken state. This will be resolved when the previous phase of upgrades completes.

### siren-parser

We're also taking this opportunity to switch every repo that uses `siren-parser` to the latest `v9` release, and this repo has an indirect dependency on it via `d2l-polymer-siren-behaviors`.

### Next steps

- [ ] `CODEOWNERS` approvals received  👍 (you can do that now to avoid holding up the upgrade later!)
- [ ] Wait until this repo's phase of the upgrade arrives ⌛ 
- [ ] Rebase from `main` / `master` to pick up latest changes
- [ ] If this repo has a `package-lock.json`, update to latest dependencies
- [ ] CI goes green ✅
- [ ] Merge & trigger a MAJOR version bump