### PR TITLE
Reduce the number of errors in Firefox and Safari when navigating while fetching.

### DIFF
--- a/src/es6/Entity.js
+++ b/src/es6/Entity.js
@@ -85,12 +85,16 @@ export class Entity extends EntitySirenProperties {
 					reject && reject();
 					resolve = null;
 					reject = null;
-				} else {
+				} else if (entity) {
 					Promise.all(entity._subEntitiesLoadStatus).then(() => {
 						resolve && resolve();
 						resolve = null;
 						reject = null;
 					});
+				} else {
+					resolve && resolve();
+					resolve = null;
+					reject = null;
 				}
 			});
 		}));

--- a/src/es6/EntityFactory.js
+++ b/src/es6/EntityFactory.js
@@ -66,6 +66,19 @@ class EntityListener {
 export function entityFactory(entityType, href, token, onChange, entity) {
 	const entityListener = new EntityListener();
 	const onChangeWrapped = (entity, error) => {
+
+		if (!entity && error) {
+			// Prevent errors from being thrown in the Firefox & Safari console when the user navigates away while fetches are in progress
+			// https://desire2learn.atlassian.net/browse/GAUD-158
+			if (
+				(error['name'] === 'TypeError' && (error['message'] === 'NetworkError when attempting to fetch resource.' || error['message'] === 'Load failed')) ||
+				(error['name'] === 'AbortError' && error['message'] === 'The operation was aborted')
+			) {
+				console.warn(`${error.toString()} (Possibly due to navigation while fetching)`);
+				return;
+			}
+		}
+
 		if (entity) {
 			onChange(new entityType(entity, token, entityListener));
 		} else {


### PR DESCRIPTION
[GAUD-158](https://desire2learn.atlassian.net/browse/GAUD-158)

This PR updates the `entityFactory` so that it will not invoke the consumer's `onChange` callback when there are `TypeError: NetworkError when attempting to fetch resource.` or `AbortError: The operation was aborted` errors. These errors often occur when the user navigates away while the HM fetches are still in progress. The `onChange` callback often generates an additional error when it tries to use a `null` entity.

[GAUD-158]: https://desire2learn.atlassian.net/browse/GAUD-158?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ