### PR TITLE
PHNX-1698: Add customAccentColour to content module entity

### DIFF
--- a/src/activities/content/ContentModuleEntity.js
+++ b/src/activities/content/ContentModuleEntity.js
@@ -56,6 +56,13 @@ export class ContentModuleEntity extends Entity {
 	}
 
 	/**
+	 * @returns {string} The custom accent colour for the root content-module
+	 */
+	customAccentColour() {
+		return this._entity && this._entity.properties && this._entity.properties.customAccentColour;
+	}
+
+	/**
 	 * Updates the module to have the given description
 	 * @param {string} richText description to set on the module
 	 */
@@ -114,7 +121,8 @@ export class ContentModuleEntity extends Entity {
 			[this.title(), contentModule.title],
 			[this.depth(), contentModule.depth],
 			[this.descriptionRichText(), contentModule.descriptionRichText],
-			[this.rawDescriptionRichText(), contentModule.rawDescriptionRichText]
+			[this.rawDescriptionRichText(), contentModule.rawDescriptionRichText],
+			[this.customAccentColour(), contentModule.customAccentColour]
 		];
 		for (const [left, right] of diffs) {
 			if (left !== right) {

--- a/test/activities/content/ContentModuleEntity.test.js
+++ b/test/activities/content/ContentModuleEntity.test.js
@@ -34,6 +34,10 @@ describe('ContentModuleEntity', () => {
 		it('reads depth', () => {
 			expect(contentModuleEntity.depth()).to.equal(8675309);
 		});
+
+		it('reads custom accent colour', () => {
+			expect(contentModuleEntity.customAccentColour()).to.equal('FF0000CC');
+		});
 	});
 
 	describe('Equality tests', () => {
@@ -42,7 +46,8 @@ describe('ContentModuleEntity', () => {
 				title: 'Test Content Module Title',
 				descriptionRichText: '<p>description text</p>',
 				rawDescriptionRichText: '<p>description text</p>',
-				depth: 8675309
+				depth: 8675309,
+				customAccentColour: 'FF0000CC'
 			};
 			expect(contentModuleEntity.equals(contentModule)).to.equal(true);
 		});
@@ -52,7 +57,8 @@ describe('ContentModuleEntity', () => {
 				title: 'Different Content Module Title',
 				descriptionRichText: '<p>description text</p>',
 				rawDescriptionRichText: '<p>description text</p>',
-				depth: 8675309
+				depth: 8675309,
+				customAccentColour: 'FF0000CC'
 			};
 			expect(contentModuleEntity.equals(contentModule)).to.equal(false);
 		});
@@ -62,7 +68,8 @@ describe('ContentModuleEntity', () => {
 				title: 'Test Content Module Title',
 				descriptionRichText: '<p>Different description text</p>',
 				rawDescriptionRichText: '<p>description text</p>',
-				depth: 8675309
+				depth: 8675309,
+				customAccentColour: 'FF0000CC'
 			};
 			expect(contentModuleEntity.equals(contentModule)).to.equal(false);
 		});
@@ -72,7 +79,19 @@ describe('ContentModuleEntity', () => {
 				title: 'Test Content Module Title',
 				descriptionRichText: '<p>description text</p>',
 				rawDescriptionRichText: '<p>description text</p>',
-				depth: 1
+				depth: 1,
+				customAccentColour: 'FF0000CC'
+			};
+			expect(contentModuleEntity.equals(contentModule)).to.equal(false);
+		});
+
+		it('Equality should return false when custom accent color is different', () => {
+			const contentModule = {
+				title: 'Test Content Module Title',
+				descriptionRichText: '<p>description text</p>',
+				rawDescriptionRichText: '<p>description text</p>',
+				depth: 1,
+				customAccentColour: 'AAAAAAAA'
 			};
 			expect(contentModuleEntity.equals(contentModule)).to.equal(false);
 		});

--- a/test/activities/content/data/TestContentModuleEntity.js
+++ b/test/activities/content/data/TestContentModuleEntity.js
@@ -38,7 +38,8 @@ export const contentModuleData = {
 	],
 	'properties': {
 		'title': 'Test Content Module Title',
-		'depth': 8675309
+		'depth': 8675309,
+		'customAccentColour': 'FF0000CC',
 	},
 	'entities': [
 		{


### PR DESCRIPTION
## Jira Link
[PHNX-1698](https://desire2learn.atlassian.net/jira/software/c/projects/PHNX/boards/341?selectedIssue=PHNX-1698): On Module FACE identify if the accent colour should be visible or not

## Description
This PR adds the `customAccentColour` property to the `ContentModuleEntity` entity, introduced in https://github.com/Brightspace/lms/pull/51506.

## Related PRs

- https://github.com/Brightspace/lms/pull/51506
- https://github.com/BrightspaceHypermediaComponents/activities/pull/4629

[PHNX-1698]: https://desire2learn.atlassian.net/browse/PHNX-1698?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ