### PR TITLE
FED-3500 add isAISummaryEnabled to activityUsageEntity

### DIFF
--- a/src/activities/ActivityUsageEntity.js
+++ b/src/activities/ActivityUsageEntity.js
@@ -675,6 +675,13 @@ export class ActivityUsageEntity extends Entity {
 	}
 
 	/**
+	 * @returns {bool} Whether or not the activity usage entity has AI summary functionality enabled
+	 */
+	isAISummaryEnabled() {
+		return this._entity && this._entity.hasClass('ai-summary-enabled');
+	}
+
+	/**
 	 * @returns {bool} Whether or not the activity usage entity is draft
 	 */
 	isDraft() {

--- a/src/hypermedia-constants.js
+++ b/src/hypermedia-constants.js
@@ -375,6 +375,7 @@ export const Classes = {
 		token: 'token'
 	},
 	content: {
+		AISummaryEnabled: 'ai-summary-enabled',
 		content: 'content',
 		completionCriteria: 'completion-criteria',
 		sequencedActivity: 'sequenced-activity',


### PR DESCRIPTION
https://desire2learn.atlassian.net/browse/FED-3500

Note: requires https://github.com/Brightspace/lms/pull/52907

Add isAISummaryEnabled to activityUsageEntity to be used by content module editor to decide to show the "generate summary" button.

