### PR TITLE
FED-3529 change setIsAiInspired to use new action and fix logic

### DIFF
--- a/src/activities/content/ContentModuleEntity.js
+++ b/src/activities/content/ContentModuleEntity.js
@@ -70,11 +70,11 @@ export class ContentModuleEntity extends Entity {
 
 	/**
 	 * @summary Set AiInspired property if summary has been ai inspired
-	 * @param {object} summary the summary that's being modified
+	 * @param {object} isAiInspired the status of the module summary that's being modified
 	 */
 	async setIsAiInspired(isAiInspired) {
-		const action = this._entity.getActionByName(Actions.content.updateDescription);
-		if (!this._entity || !action || isAiInspired !== this.isAiInspired()) return;
+		const action = this._entity.getActionByName(Actions.content.updateAiOrigin);
+		if (!this._entity || !action || isAiInspired === this.isAiInspired()) return;
 		const fields = [{ name: 'aiHumanOrigin', value: isAiInspired ? AI_INSPIRED : HUMAN_GENERATED }];
 		await performSirenAction(this._token, action, fields);
 	}

--- a/src/hypermedia-constants.js
+++ b/src/hypermedia-constants.js
@@ -746,7 +746,8 @@ export const Actions = {
 		updateTitle: 'update-title',
 		updateDescription: 'update-description',
 		updateCompletionCriteria: 'update-completion-criteria',
-		updateColor: 'update-color'
+		updateColor: 'update-color',
+		updateAiOrigin: 'update-ai-origin'
 	},
 	module: {
 		deleteModule: 'delete-module'


### PR DESCRIPTION
https://desire2learn.atlassian.net/browse/FED-3529

Requires: https://github.com/Brightspace/lms/pull/54122 to work.

Updates `setIsAiInspired` to use it's own action (trying to use the description action was not getting sent. Could this be deduping?).

Also fixes logic around if the action should run. Previously it would not run if the desired value was different than the current value which didn't allow it to run at all.