### PR TITLE
Add typescript jsdoc for better IDE integration

### DIFF
--- a/src/es6/Entity.js
+++ b/src/es6/Entity.js
@@ -2,14 +2,19 @@ import { dispose, entityFactory, updateEntity } from './EntityFactory.js';
 import { EntitySirenProperties } from './EntitySirenProperties.js';
 
 /**
+ * @typedef {import('siren-parser').Entity} ParsedEntity
+ * @typedef {import('./EntityFactory').EntityListener} EntityListener
+ */
+
+/**
  * Abstract Entity class to help create entity classes.
  */
 export class Entity extends EntitySirenProperties {
 	/**
 	 * Primes the object used by the entityFactory. Should never be called outside.
-	 * @param {Object} entity A hypermedia siren entity as defined by [the siren specification]{@link https://github.com/kevinswiber/siren}
-	 * @param {String|Function|null} token JWT Token for brightspace | a function that returns a JWT token for brightspace | null (defaults to cookie authentication in a browser)
-	 * @param {Function} listener Listener helper class
+	 * @param {ParsedEntity} entity A hypermedia siren entity as defined by [the siren specification]{@link https://github.com/kevinswiber/siren}
+	 * @param {String|Function} [token] JWT Token for brightspace | a function that returns a JWT token for brightspace | null (defaults to cookie authentication in a browser)
+	 * @param {EntityListener} listener Listener helper class
 	 */
 	constructor(entity, token, listener) {
 		super();
@@ -17,6 +22,10 @@ export class Entity extends EntitySirenProperties {
 			throw new TypeError('Cannot construct Entity instances directly');
 		}
 		this._entity = entity;
+
+		/**
+		 * @type {Map<string, EntitySirenProperties>}
+		 */
 		this._subEntities = new Map();
 		this._token = token;
 		this._listener = listener;
@@ -35,6 +44,10 @@ export class Entity extends EntitySirenProperties {
 	subEntitiesLoaded() {
 		return Promise.all(this._subEntitiesLoadStatus);
 	}
+
+	/**
+	 * @param {ParsedEntity} entity
+	 */
 	update(entity) {
 		updateEntity(this.self(), this._token, entity);
 	}
@@ -49,9 +62,11 @@ export class Entity extends EntitySirenProperties {
 	}
 	/**
 	 * Protected: Add a listener to a subentity of this entity.
-	 * @param {*} entityType A entity class that extends this class.
-	 * @param {*} href Href or Entity of the entity to be created
-	 * @param {*} onChange callback function that accepts an {entityType} to be called when subentity changes.
+	 *
+	 * @template {EntitySirenProperties} EntityType
+	 * @param {new (...args: any[]) => EntityType} entityType A entity class that extends this class.
+	 * @param {string|ParsedEntity} href Href or Entity of the entity to be created
+	 * @param {(entityType: EntityType, error: any) => void} onChange callback function that accepts an {entityType} to be called when subentity changes.
 	 */
 	_subEntity(entityType, href, onChange) {
 		if (!href) {
@@ -67,9 +82,11 @@ export class Entity extends EntitySirenProperties {
 
 	/**
 	 * Protected: Add a listener to a subentity of this entity.
-	 * @param {*} entityType A entity class that extends this class.
-	 * @param {*} source Href of the entity to be created
-	 * @param {*} onChange callback function that accepts an {entityType} to be called when subentity changes.
+	 *
+	 * @template {EntitySirenProperties} EntityType
+	 * @param {new (...args: any[]) => EntityType} entityType A entity class that extends this class.
+	 * @param {string} source Href of the entity to be created
+	 * @param {(entityType: EntityType, error: any) => void} onChange callback function that accepts an {entityType} to be called when subentity changes.
 	 */
 	_subEntityByHref(entityType, source, onChange) {
 		// Clean up if that href has already been added.
@@ -102,9 +119,11 @@ export class Entity extends EntitySirenProperties {
 
 	/**
 	 * Protected: Add a listener to a subentity of this entity.
-	 * @param {*} entityType A entity class that extends this class.
-	 * @param {*} entity Entity that has already been fetched as a sub-entity. Requires either an href or a self link
-	 * @param {*} onChange callback function that accepts an {entityType} to be called when subentity changes.
+	 *
+	 * @template {EntitySirenProperties} EntityType
+	 * @param {new (...args: any[]) => EntityType} entityType A entity class that extends this class.
+	 * @param {ParsedEntity} entity Entity that has already been fetched as a sub-entity. Requires either an href or a self link
+	 * @param {(entityType: EntityType, error: any) => void} onChange callback function that accepts an {entityType} to be called when subentity changes.
 	 */
 	_subEntityByEntity(entityType, entity, onChange) {
 		if (!entity) {

--- a/src/es6/EntityFactory.js
+++ b/src/es6/EntityFactory.js
@@ -1,7 +1,13 @@
 import 'd2l-polymer-siren-behaviors/store/entity-store.js';
 
+/**
+ * @typedef {import('siren-parser').Entity} ParsedEntity
+ * @typedef {import('siren-parser').Link} SirenLink
+ * @typedef {import('./EntitySirenProperties').EntitySirenProperties} EntitySirenProperties
+ */
+
 /** Allows one to manage the event store listeners. Makes it easy to update, add and remove a listener for the entity store. */
-class EntityListener {
+export class EntityListener {
 	constructor() {
 		this._href;
 		this._token;
@@ -57,11 +63,11 @@ class EntityListener {
 
 /**
  * This creates and fetch a new entity. Whenever the entity changes onChange is called.
- * @param {Function} entityType The type of the entity. For example OrganizationEntity
- * @param {Object|String} href Siren Link or Href of the entity to be created
- * @param {String|Token|Null} token JWT Token for brightspace | a function that returns a JWT token for brightspace | null (defaults to cookie authentication in a browser)
- * @param {Function} onChange Callback function that accepts an {entityType} to be called when entity changes. If there are errors onChange is called with (null, error)
- * @param {Object} entity (Optional) Entity that has already been fetched.
+ * @param {new(...args: any[]) => EntitySirenProperties} entityType The type of the entity. For example OrganizationEntity
+ * @param {SirenLink|String} href Siren Link or Href of the entity to be created
+ * @param {String|Function} [token] JWT Token for brightspace | a function that returns a JWT token for brightspace | null (defaults to cookie authentication in a browser)
+ * @param {(entity: EntitySirenProperties, error: any) => void} onChange Callback function that accepts an {entityType} to be called when entity changes. If there are errors onChange is called with (null, error)
+ * @param {ParsedEntity} entity (Optional) Entity that has already been fetched.
  */
 export function entityFactory(entityType, href, token, onChange, entity) {
 	const entityListener = new EntityListener();
@@ -99,7 +105,7 @@ export function updateEntity(href, token, entity) {
 
 /**
  * Some times the entity doesn't exists so this allows the cleanup code to be cleaner.
- * @param {Object|Null} entity Object that is of an Entity type.
+ * @param {EntitySirenProperties|null} entity Object that is of an Entity type.
  */
 export function dispose(entity) {
 	entity && entity.dispose && entity.dispose();

--- a/src/es6/SelflessEntity.js
+++ b/src/es6/SelflessEntity.js
@@ -1,14 +1,19 @@
 import { EntitySirenProperties } from './EntitySirenProperties.js';
 
 /**
+ * @typedef {import('siren-parser').Entity} ParsedEntity
+ * @typedef {import('./Entity').Entity} SDKEntity
+ */
+
+/**
  * Abstract Entity class to help create entity classes without self-links.
  * These entities are transient, and are not saved within the Entity Store.
  */
 export class SelflessEntity extends EntitySirenProperties {
 	/**
 	 * Sets the parent object and setups the siren entity ready to be decoded by extending this class.
-	 * @param {Object} sdkParentEntity Parent entity that is a Entity.
-	 * @param {Object} entity A hypermedia siren entity as defined by [the siren specification]{@link https://github.com/kevinswiber/siren}
+	 * @param {SDKEntity} sdkParentEntity Parent entity that is a Entity.
+	 * @param {ParsedEntity} entity A hypermedia siren entity as defined by [the siren specification]{@link https://github.com/kevinswiber/siren}
 	 */
 	constructor(sdkParentEntity, entity) {
 		super();
@@ -20,9 +25,11 @@ export class SelflessEntity extends EntitySirenProperties {
 	}
 	/**
 	 * Protected: Add a listener to a subentity of the this entity and gives ownership to parent entity.
-	 * @param {*} entityType A entity class that extends this class.
-	 * @param {*} href Href or Entity of the entity to be created
-	 * @param {*} onChange callback function that accepts an {entityType} to be called when subentity changes.
+	 *
+	 * @template {EntitySirenProperties} EntityType
+	 * @param {new (...args: any[]) => EntityType} entityType A entity class that extends this class.
+	 * @param {string} href Href or Entity of the entity to be created
+	 * @param {(entityType: EntityType, error: any) => void} onChange callback function that accepts an {entityType} to be called when subentity changes.
 	 */
 	_subEntity(entityType, href, onChange) {
 		this._sdkParentEntity._subEntity(entityType, href, onChange);

--- a/src/es6/SirenAction.js
+++ b/src/es6/SirenAction.js
@@ -232,7 +232,7 @@ const _combineActions = function(actionsAndFields) {
  *
  * @param {string|Function} token
  * @param {{ action: Action, fields: FieldOverride[] }[]} actionsAndFields
- * @returns {ParsedEntity[]>}
+ * @returns {Promise<ParsedEntity[]>}
  */
 export const performSirenActions = function(token, actionsAndFields) {
 	if (!actionsAndFields || !actionsAndFields.length) return;

--- a/src/es6/SirenAction.js
+++ b/src/es6/SirenAction.js
@@ -3,6 +3,17 @@ import 'd2l-polymer-siren-behaviors/store/entity-store.js';
 import 'd2l-polymer-siren-behaviors/store/action-queue.js';
 import SirenParse from 'siren-parser';
 
+/**
+ * @typedef {import('siren-parser').Action} Action
+ * @typedef {import('siren-parser').Field} Field
+ * @typedef {import('siren-parser').Entity} ParsedEntity
+ * @typedef {{ name: string; value: string }} FieldOverride
+ */
+
+/**
+ * @param {Action} action
+ * @returns {FieldOverride[]}
+ */
 const _getSirenFields = function(action) {
 	const url = new URL(action.href, window.location.origin);
 	const fields = [];
@@ -24,6 +35,10 @@ const _getSirenFields = function(action) {
 	return fields;
 };
 
+/**
+ * @param {FieldOverride[]} fields
+ * @returns {URLSearchParams}
+ */
 const _createURLSearchParams = function(fields) {
 	const sequence = [];
 	for (let i = 0; i < fields.length; i++) {
@@ -33,6 +48,11 @@ const _createURLSearchParams = function(fields) {
 	return new URLSearchParams(sequence);
 };
 
+/**
+ * @param {Action} action
+ * @param {FieldOverride[]} fields
+ * @returns {URL}
+ */
 const _getEntityUrl = function(action, fields) {
 	if (!action) {
 		return null;
@@ -55,6 +75,11 @@ const _createFormData = function(fields) {
 	return formData;
 };
 
+/**
+ * @param {Action} action
+ * @param {FieldOverride[]} fields
+ * @returns {FieldOverride[]}
+ */
 const _appendHiddenFields = function(action, fields) {
 	if (action.fields && action.fields.forEach) {
 		action.fields.forEach((field) => {
@@ -204,6 +229,10 @@ const _combineActions = function(actionsAndFields) {
 /**
  * Combines actions that share the same action href and method into one action.
  * Then executes list of combined actions. Performing siren actions immediately not supported.
+ *
+ * @param {string|Function} token
+ * @param {{ action: Action, fields: FieldOverride[] }[]} actionsAndFields
+ * @returns {ParsedEntity[]>}
  */
 export const performSirenActions = function(token, actionsAndFields) {
 	if (!actionsAndFields || !actionsAndFields.length) return;
@@ -221,6 +250,14 @@ export const performSirenActions = function(token, actionsAndFields) {
 		});
 };
 
+/**
+ * @param {string|Function} token
+ * @param {Action} action
+ * @param {FieldOverride[]} fields
+ * @param {boolean} [immediate]
+ * @param {boolean} [bypassCache]
+ * @returns {Promise<ParsedEntity>}
+ */
 export const performSirenAction = function(token, action, fields, immediate, bypassCache) {
 	return window.D2L.Siren.EntityStore.getToken(token)
 		.then((resolved) => {
@@ -231,6 +268,13 @@ export const performSirenAction = function(token, action, fields, immediate, byp
 		});
 };
 
+/**
+ * @param {string|Function} token
+ * @param {() => Action} actionFactory
+ * @param {FieldOverride[]} fieldOverrides
+ * @param {boolean} [bypassCache]
+ * @returns {Promise<ParsedEntity>}
+ */
 export const performLazySirenAction = function(token, actionFactory, fieldOverrides, bypassCache) {
 	fieldOverrides = fieldOverrides || {};
 	return window.D2L.Siren.EntityStore.getToken(token).then(


### PR DESCRIPTION
I started looking into adding JSDoc to improve VSCode navigation and tooltips. I've been following https://www.typescriptlang.org/docs/handbook/jsdoc-supported-types.html. Since this is a commonly used library in our projects, this is a useful place to add typing.

If the IDE doesn't support jsdoc/typescript, there would be no effect, and the extra documentation would be useful.