### PR TITLE
feat: hai-453 always include showResultsOverview subEntity

### DIFF
--- a/src/activities/quizzes/QuizEntity.js
+++ b/src/activities/quizzes/QuizEntity.js
@@ -249,7 +249,7 @@ export class QuizEntity extends Entity {
 	}
 
 	showResultsOverview() {
-		if (!this.isStudySupportEnabledVisible() || !this.isStudySupportEnabled()) {
+		if (!this.isStudySupportEnabledVisible()) {
 			return;
 		}
 		const studySupportEntity = this._entity.getSubEntityByRel(Rels.Quizzes.studySupportEnabled);


### PR DESCRIPTION
https://desire2learn.atlassian.net/browse/HAI-453

ShowResultsOverview entity is always included now, even if study support is disabled, so that we can track/set it in the UI immediately when study support is enabled.