### PR TITLE
FED-4436 add support for ai origin on content file

### DIFF
--- a/src/activities/content/ContentFileEntity.js
+++ b/src/activities/content/ContentFileEntity.js
@@ -196,7 +196,6 @@ export class ContentFileEntity extends ContentWorkingCopyEntity {
 		const diffs = [
 			[this.title(), contentFile.title],
 			[this.getFileHref(), contentFile.fileHref],
-			[this.aiHumanOrigin(), contentFile.aiHumanOrigin],
 			...(contentFile.fileType !== FILE_TYPES.html ? [[this.descriptionRichText(), contentFile.descriptionRichText]] : [])
 		];
 		for (const [left, right] of diffs) {


### PR DESCRIPTION
Allow the aiHumanOrigin = 3 to be sent to the backend.

Story related:
https://desire2learn.atlassian.net/browse/FED-4436

Changes related to this:
Activities: https://github.com/BrightspaceHypermediaComponents/activities/pull/5044
LMS: https://github.com/Brightspace/lms/pull/59787