### PR TITLE
hai-788 persist remediation candidates

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "@open-wc/dedupe-mixin": "^1",
     "@polymer/polymer": "^3",
     "d2l-fetch": "^2",
-    "d2l-polymer-siren-behaviors": "^2"
+    "d2l-polymer-siren-behaviors": "^2",
+    "lodash-es": "^4.17.21"
   },
   "devDependencies": {
     "@babel/core": "^7",

--- a/src/hypermedia-constants.js
+++ b/src/hypermedia-constants.js
@@ -231,7 +231,8 @@ export const Rels = {
 		studySupportEnabled: 'https://quizzes.api.brightspace.com/rels/study-support-enabled',
 		studySupportCompatibility: 'https://quizzes.api.brightspace.com/rels/study-support-compatibility',
 		showResultsOverview: 'https://quizzes.api.brightspace.com/rels/show-results-overview',
-		suggestContent: 'https://quizzes.api.brightspace.com/rels/suggest-content-selection'
+		suggestContent: 'https://quizzes.api.brightspace.com/rels/suggest-content-selection',
+		remediationCandidates: 'https://quizzes.api.brightspace.com/rels/remediation-candidates'
 	},
 	// Themes API sub-domain rels
 	Themes: {
@@ -512,6 +513,7 @@ export const Classes = {
 		studySupportCompatible: 'study-support-compatible',
 		showResultsOverview: 'show-results-overview',
 		suggestContent: 'suggest-content-selection',
+		remediationCandidates: 'remediation-candidates',
 		timing: {
 			recommended: 'recommended',
 			enforced: 'enforced',
@@ -902,6 +904,7 @@ export const Actions = {
 		updateStudySupportEnabled: 'study-support-enabled',
 		updateShowResultsOverview: 'show-results-overview',
 		updateSuggestContent: 'suggest-content-selection',
+		updateRemediationCandidates: 'remediation-candidates',
 		timing: {
 			updateType: 'update-timing-type',
 			updateTimeLimit: 'update-timing-time-limit',

--- a/test/activities/quizzes/QuizEntity.test.js
+++ b/test/activities/quizzes/QuizEntity.test.js
@@ -49,7 +49,11 @@ describe('QuizEntity', () => {
 				passingPercentage: 75,
 				studySupportEnabled: true,
 				showResultsOverview: true,
-				suggestContent: '1'
+				suggestContent: '1',
+				remediationCandidates: [{
+					ToolId: 37000,
+					ToolObjectId: 97705
+				}]
 			};
 		});
 
@@ -150,6 +154,14 @@ describe('QuizEntity', () => {
 		it('returns false when suggestContent not equal', () => {
 			const quizEntity = new QuizEntity(editableEntity);
 			modifiedEntity.suggestContent = '0';
+			expect(quizEntity.equals(modifiedEntity)).to.be.false;
+		});
+		it('returns false when remediationCandidates not equal', () => {
+			const quizEntity = new QuizEntity(editableEntity);
+			modifiedEntity.remediationCandidates = [{
+				ToolId: 37000,
+				ToolObjectId: 97706
+			}];
 			expect(quizEntity.equals(modifiedEntity)).to.be.false;
 		});
 	});
@@ -447,7 +459,13 @@ describe('QuizEntity', () => {
 				header: 'New header',
 				footer: 'New footer',
 				passingPercentage: 30,
-				studySupportEnabled: false
+				studySupportEnabled: false,
+				showResultsOverview: false,
+				suggestContent: '0',
+				remediationCandidates: [{
+					ToolId: 37000,
+					ToolObjectId: 97706
+				}]
 			});
 
 			const form = await getFormData(fetchMock.lastCall().request);
@@ -468,6 +486,9 @@ describe('QuizEntity', () => {
 				expect(form.get('footer')).to.equal('New footer');
 				expect(form.get('passingPercentage')).to.equal('30');
 				expect(form.get('studySupportEnabled')).to.equal('false');
+				expect(form.get('showResultsOverview')).to.equal(null); // not included when studySupportEnabled is false
+				expect(form.get('suggestContent')).to.equal(null); // not included when studySupportEnabled is false
+				expect(form.get('remediationCandidates')).to.equal(null); // not included when studySupportEnabled is false
 			}
 
 			expect(fetchMock.called()).to.be.true;
@@ -494,7 +515,11 @@ describe('QuizEntity', () => {
 				passingPercentage: 75,
 				studySupportEnabled: true,
 				showResultsOverview: true,
-				suggestContent: '1'
+				suggestContent: '1',
+				remediationCandidates: [{
+					ToolId: 37000,
+					ToolObjectId: 97705
+				}]
 			});
 
 			expect(fetchMock.done());
@@ -687,6 +712,21 @@ describe('QuizEntity', () => {
 			it('returns undefined when suggestContent is undefined', () => {
 				const quizEntity = new QuizEntity(nonEditableEntity);
 				expect(quizEntity.suggestContent()).to.be.undefined;
+			});
+		});
+
+		describe('remediationCandidates', () => {
+			it('returns object when remediationCandidates contains an object', () => {
+				const quizEntity = new QuizEntity(editableEntity);
+				expect(quizEntity.remediationCandidates()).to.deep.include({
+					ToolId: 37000,
+					ToolObjectId: 97705
+				});
+			});
+
+			it('returns undefined when remediationCandidates is undefined', () => {
+				const quizEntity = new QuizEntity(nonEditableEntity);
+				expect(quizEntity.remediationCandidates()).to.be.undefined;
 			});
 		});
 

--- a/test/activities/quizzes/data/EditableQuiz.js
+++ b/test/activities/quizzes/data/EditableQuiz.js
@@ -345,6 +345,36 @@ export const editableQuiz = {
 							]
 						}
 					]
+				},
+				{
+					'class': [
+						'remediation-candidates'
+					],
+					'rel': [
+						'https://quizzes.api.brightspace.com/rels/remediation-candidates'
+					],
+					'properties': {
+						'remediationCandidates': [
+							{
+								'ToolId': 37000,
+								'ToolObjectId': 97705
+							}
+						]
+					},
+					'actions': [
+						{
+							'href': 'https://afe99802-9130-4320-a770-8d138b941e74.quizzes.api.proddev.d2l/6606/quizzes/22',
+							'name': 'remediation-candidates',
+							'method': 'PATCH',
+							'fields': [
+								{
+									'type': 'text',
+									'name': 'remediationCandidates',
+									'value': ['37000,97705']
+								}
+							]
+						}
+					]
 				}
 			],
 			'links': [


### PR DESCRIPTION
https://desire2learn.atlassian.net/browse/HAI-788

Adds functions to allow persisting of remediationCandidates.
Also fixed bug in SirenAction to allow multiple fields with the same name.

Related: 
https://github.com/BrightspaceHypermediaComponents/activities/pull/5177
https://github.com/Brightspace/generate-question/pull/429