### PR TITLE
MAJ-1931 Enable/Disable/"Delete" Processors - Siren SDK

### DIFF
--- a/src/activities/assetProcessor/APAttachedProcessorsCollectionEntity.js
+++ b/src/activities/assetProcessor/APAttachedProcessorsCollectionEntity.js
@@ -78,7 +78,7 @@ class APAttachedProcessorEntity extends Entity {
 	 * @returns {bool} Whether this processor is enabled.
 	 */
 	enabled() {
-		return this._entity && this._entity.properties && this._entity.properties.enabled;
+		return this._entity && this._entity.properties && this._entity.properties.isEnabled;
 	}
 
 	/**

--- a/src/activities/assetProcessor/APAttachedProcessorsCollectionEntity.js
+++ b/src/activities/assetProcessor/APAttachedProcessorsCollectionEntity.js
@@ -1,10 +1,8 @@
-import { Classes } from '../../hypermedia-constants.js';
+import { Actions, Classes } from '../../hypermedia-constants.js';
 import { Entity } from '../../es6/Entity.js';
+import { performSirenAction } from '../../es6/SirenAction.js';
 
-class APAttachedProcessorEntity {
-	constructor(_entity) {
-		this._entity = _entity;
-	}
+class APAttachedProcessorEntity extends Entity {
 
 	/**
 	 * @returns {string} The external deployment id of the deployment this processor belongs to.
@@ -74,6 +72,80 @@ class APAttachedProcessorEntity {
 	 */
 	height() {
 		return this._entity && this._entity.properties && this._entity.properties.height;
+	}
+
+	/**
+	 * @returns {bool} Whether this processor is enabled.
+	 */
+	enabled() {
+		return this._entity && this._entity.properties && this._entity.properties.enabled;
+	}
+
+	/**
+	 * @returns {bool} Whether this processor can be enabled.
+	 */
+	canEnable() {
+		return !this.enabled() && this._entity.hasActionByName(Actions.LTI.enableAssetProcessor);
+	}
+
+	/**
+	 * @returns {bool} Whether this processor can be disabled.
+	 */
+	canDisable() {
+		return this.enabled() && this._entity.hasActionByName(Actions.LTI.disableAssetProcessor);
+	}
+
+	/**
+	 * @returns {bool} Whether this processor can be deleted.
+	 */
+	canDelete() {
+		return this._entity.hasActionByName(Actions.LTI.deleteAssetProcessor);
+	}
+
+	/**
+	 * @summary Enables this processor.
+	 */
+	async enable() {
+		const action = this.canEnable() && this._entity.getActionByName(Actions.LTI.enableAssetProcessor);
+		if (!action) {
+			return;
+		}
+
+		const fields = [
+			{ name: 'isEnabled', value: true }
+		];
+
+		await performSirenAction(this._token, action, fields);
+	}
+
+	/**
+	 * @summary Disables this processor.
+	 */
+	async disable() {
+		const action = this.canDisable() && this._entity.getActionByName(Actions.LTI.disableAssetProcessor);
+		if (!action) {
+			return;
+		}
+
+		const fields = [
+			{ name: 'isEnabled', value: false }
+		];
+
+		await performSirenAction(this._token, action, fields);
+	}
+
+	/**
+	 * @summary Deletes this processor.
+	 */
+	async delete() {
+		const action = this.canDelete() && this._entity.getActionByName(Actions.LTI.deleteAssetProcessor);
+		if (!action) {
+			return;
+		}
+
+		await performSirenAction(this._token, action, []).then(() => {
+			this.dispose();
+		});
 	}
 }
 

--- a/src/activities/assetProcessor/APAttachedProcessorsCollectionEntity.js
+++ b/src/activities/assetProcessor/APAttachedProcessorsCollectionEntity.js
@@ -2,7 +2,7 @@ import { Actions, Classes } from '../../hypermedia-constants.js';
 import { Entity } from '../../es6/Entity.js';
 import { performSirenAction } from '../../es6/SirenAction.js';
 
-class APAttachedProcessorEntity extends Entity {
+export class APAttachedProcessorEntity extends Entity {
 
 	/**
 	 * @returns {string} The external deployment id of the deployment this processor belongs to.

--- a/src/hypermedia-constants.js
+++ b/src/hypermedia-constants.js
@@ -974,5 +974,10 @@ export const Actions = {
 		checkout: 'checkout',
 		checkin: 'checkin',
 		commit: 'commit'
+	},
+	LTI: {
+		enableAssetProcessor: 'enable-asset-processor',
+		disableAssetProcessor: 'disable-asset-processor',
+		deleteAssetProcessor: 'delete-asset-processor'
 	}
 };

--- a/test/activities/assetProcessor/APAttachedProcessorEntity.test.js
+++ b/test/activities/assetProcessor/APAttachedProcessorEntity.test.js
@@ -1,10 +1,10 @@
 import { APAttachedProcessorEntity } from '../../../src/activities/assetProcessor/APAttachedProcessorsCollectionEntity.js';
-import { disabledAttachedProcessor } from './data/DisabledProcessor.js';
 import { deletableAttachedProcessor } from './data/DeletableProcessor.js';
+import { disabledAttachedProcessor } from './data/DisabledProcessor.js';
 import { enabledAttachedProcessor } from './data/EnabledProcessor.js';
 import { expect } from '@open-wc/testing';
-import { getFormData } from '../../utility/test-helpers.js';
 import fetchMock from 'fetch-mock/esm/client.js';
+import { getFormData } from '../../utility/test-helpers.js';
 import SirenParse from 'siren-parser';
 
 describe('APAttachedProcessorEntity', () => {

--- a/test/activities/assetProcessor/APAttachedProcessorEntity.test.js
+++ b/test/activities/assetProcessor/APAttachedProcessorEntity.test.js
@@ -1,0 +1,118 @@
+import { APAttachedProcessorEntity } from '../../../src/activities/assetProcessor/APAttachedProcessorsCollectionEntity.js';
+import { disabledAttachedProcessor } from './data/DisabledProcessor.js';
+import { deletableAttachedProcessor } from './data/DeletableProcessor.js';
+import { enabledAttachedProcessor } from './data/EnabledProcessor.js';
+import { expect } from '@open-wc/testing';
+import { getFormData } from '../../utility/test-helpers.js';
+import fetchMock from 'fetch-mock/esm/client.js';
+import SirenParse from 'siren-parser';
+
+describe('APAttachedProcessorEntity', () => {
+	let enabledEntity, disabledEntity, deletableEntity;
+
+	beforeEach(() => {
+		enabledEntity = SirenParse(enabledAttachedProcessor);
+		disabledEntity = SirenParse(disabledAttachedProcessor);
+		deletableEntity = SirenParse(deletableAttachedProcessor);
+	});
+
+	afterEach(() => {
+		fetchMock.reset();
+	});
+
+	describe('enabled', () => {
+
+		it('returns true when processor is enabled', () => {
+			const enabledProcessor = new APAttachedProcessorEntity(enabledEntity);
+			expect(enabledProcessor.enabled()).to.be.true;
+		});
+
+		it('returns false when processor is disabled', () => {
+			const disabledProcessor = new APAttachedProcessorEntity(disabledEntity);
+			expect(disabledProcessor.enabled()).to.be.false;
+		});
+
+	});
+
+	describe('canEnable', () => {
+
+		it('returns true when processor is disabled & has enable action, false otherwise', () => {
+			const enabledProcessor = new APAttachedProcessorEntity(enabledEntity);
+			expect(enabledProcessor.canEnable()).to.be.false;
+
+			const disabledProcessor = new APAttachedProcessorEntity(disabledEntity);
+			expect(disabledProcessor.canEnable()).to.be.true;
+		});
+
+	});
+
+	describe('canDisable', () => {
+
+		it('returns true when processor is enabled & has disable action, false otherwise', () => {
+			const enabledProcessor = new APAttachedProcessorEntity(enabledEntity);
+			expect(enabledProcessor.canDisable()).to.be.true;
+
+			const disabledProcessor = new APAttachedProcessorEntity(disabledEntity);
+			expect(disabledProcessor.canDisable()).to.be.false;
+		});
+
+	});
+
+	describe('canDelete', () => {
+
+		it('returns true when processor has delete action, false otherwise', () => {
+			const enabledProcessor = new APAttachedProcessorEntity(enabledEntity);
+			expect(enabledProcessor.canDelete()).to.be.false;
+
+			const disabledProcessor = new APAttachedProcessorEntity(disabledEntity);
+			expect(disabledProcessor.canDelete()).to.be.false;
+
+			const deletableProcessor = new APAttachedProcessorEntity(deletableEntity);
+			expect(deletableProcessor.canDelete()).to.be.true;
+		});
+
+	});
+
+	describe('enable', () => {
+
+		it('updates isEnabled to true', async() => {
+			fetchMock.patchOnce('https://lti.api.brightspace.com/6609/asset-processor/1', disabledEntity);
+			const disabledProcessor = new APAttachedProcessorEntity(disabledEntity);
+
+			await disabledProcessor.enable();
+
+			const form = await getFormData(fetchMock.lastCall().request);
+			expect(form.get('isEnabled')).to.equal('true');
+			expect(fetchMock.called()).to.be.true;
+		});
+
+	});
+
+	describe('disable', () => {
+
+		it('updates isEnabled to false', async() => {
+			fetchMock.patchOnce('https://lti.api.brightspace.com/6609/asset-processor/1', enabledEntity);
+			const enabledProcessor = new APAttachedProcessorEntity(enabledEntity);
+
+			await enabledProcessor.disable();
+
+			const form = await getFormData(fetchMock.lastCall().request);
+			expect(form.get('isEnabled')).to.equal('false');
+			expect(fetchMock.called()).to.be.true;
+		});
+
+	});
+
+	describe('delete', () => {
+
+		it('deletes', async() => {
+			fetchMock.deleteOnce('https://lti.api.brightspace.com/6609/asset-processor/1', deletableEntity);
+			const deletableProcessor = new APAttachedProcessorEntity(deletableEntity);
+
+			await deletableProcessor.delete();
+
+			expect(fetchMock.called()).to.be.true;
+		});
+
+	});
+});

--- a/test/activities/assetProcessor/APAttachedProcessorEntity.test.js
+++ b/test/activities/assetProcessor/APAttachedProcessorEntity.test.js
@@ -76,7 +76,7 @@ describe('APAttachedProcessorEntity', () => {
 	describe('enable', () => {
 
 		it('updates isEnabled to true', async() => {
-			fetchMock.patchOnce('https://lti.api.brightspace.com/6609/asset-processor/1', disabledEntity);
+			fetchMock.patchOnce('https://lti.api.brightspace.com/6609/asset-processor/1/update', disabledEntity);
 			const disabledProcessor = new APAttachedProcessorEntity(disabledEntity);
 
 			await disabledProcessor.enable();
@@ -91,7 +91,7 @@ describe('APAttachedProcessorEntity', () => {
 	describe('disable', () => {
 
 		it('updates isEnabled to false', async() => {
-			fetchMock.patchOnce('https://lti.api.brightspace.com/6609/asset-processor/1', enabledEntity);
+			fetchMock.patchOnce('https://lti.api.brightspace.com/6609/asset-processor/1/update', enabledEntity);
 			const enabledProcessor = new APAttachedProcessorEntity(enabledEntity);
 
 			await enabledProcessor.disable();
@@ -106,7 +106,7 @@ describe('APAttachedProcessorEntity', () => {
 	describe('delete', () => {
 
 		it('deletes', async() => {
-			fetchMock.deleteOnce('https://lti.api.brightspace.com/6609/asset-processor/1', deletableEntity);
+			fetchMock.deleteOnce('https://lti.api.brightspace.com/6609/asset-processor/1/delete', deletableEntity);
 			const deletableProcessor = new APAttachedProcessorEntity(deletableEntity);
 
 			await deletableProcessor.delete();

--- a/test/activities/assetProcessor/data/DeletableProcessor.js
+++ b/test/activities/assetProcessor/data/DeletableProcessor.js
@@ -18,11 +18,11 @@ export const deletableAttachedProcessor = {
 		'width': 300,
 		'height': 399,
 	},
-	"actions": [
-	  {
-		"href": "https://lti.api.brightspace.com/6609/asset-processor/1",
-		"name": "delete-asset-processor",
-		"method": "DELETE"
-	  }
+	'actions': [
+		{
+			'href': 'https://lti.api.brightspace.com/6609/asset-processor/1',
+			'name': 'delete-asset-processor',
+			'method': 'DELETE'
+		}
 	]
 };

--- a/test/activities/assetProcessor/data/DeletableProcessor.js
+++ b/test/activities/assetProcessor/data/DeletableProcessor.js
@@ -20,7 +20,7 @@ export const deletableAttachedProcessor = {
 	},
 	'actions': [
 		{
-			'href': 'https://lti.api.brightspace.com/6609/asset-processor/1',
+			'href': 'https://lti.api.brightspace.com/6609/asset-processor/1/delete',
 			'name': 'delete-asset-processor',
 			'method': 'DELETE'
 		}

--- a/test/activities/assetProcessor/data/DeletableProcessor.js
+++ b/test/activities/assetProcessor/data/DeletableProcessor.js
@@ -1,0 +1,28 @@
+export const deletableAttachedProcessor = {
+	'class': [
+		'asset-processor-attached-processor'
+	],
+	'rel': [
+		'https://lti.api.brightspace.com/rels/asset-processor-attached-processor'
+	],
+	'properties': {
+		'externalDeploymentId': '65AE4832-5255-4806-804F-09D39945015E',
+		'deploymentName': 'Deployment',
+		'assetProcessorId': 1,
+		'title': 'Processor 1',
+		'settingsLinkId': 10,
+		'settingsLaunchRoute': '',
+		'eulaLaunchRoute': '',
+		'isEnabled': true,
+		'isExternalResource': false,
+		'width': 300,
+		'height': 399,
+	},
+	"actions": [
+	  {
+		"href": "https://lti.api.brightspace.com/6609/asset-processor/1",
+		"name": "delete-asset-processor",
+		"method": "DELETE"
+	  }
+	]
+};

--- a/test/activities/assetProcessor/data/DisabledProcessor.js
+++ b/test/activities/assetProcessor/data/DisabledProcessor.js
@@ -1,0 +1,35 @@
+export const disabledAttachedProcessor = {
+	'class': [
+		'asset-processor-attached-processor'
+	],
+	'rel': [
+		'https://lti.api.brightspace.com/rels/asset-processor-attached-processor'
+	],
+	'properties': {
+		'externalDeploymentId': '65AE4832-5255-4806-804F-09D39945015E',
+		'deploymentName': 'Deployment',
+		'assetProcessorId': 1,
+		'title': 'Processor 1',
+		'settingsLinkId': 10,
+		'settingsLaunchRoute': '',
+		'eulaLaunchRoute': '',
+		'isEnabled': false,
+		'isExternalResource': false,
+		'width': 300,
+		'height': 399,
+	},
+	"actions": [
+	  {
+		"href": "https://lti.api.brightspace.com/6609/asset-processor/1",
+		"name": "enable-asset-processor",
+		"method": "PATCH",
+		"fields": [
+			{
+				"type": "checkbox",
+				"name": "isEnabled",
+				"value": true
+			}
+		]
+	  }
+	]
+};

--- a/test/activities/assetProcessor/data/DisabledProcessor.js
+++ b/test/activities/assetProcessor/data/DisabledProcessor.js
@@ -20,7 +20,7 @@ export const disabledAttachedProcessor = {
 	},
 	'actions': [
 		{
-			'href': 'https://lti.api.brightspace.com/6609/asset-processor/1',
+			'href': 'https://lti.api.brightspace.com/6609/asset-processor/1/update',
 			'name': 'enable-asset-processor',
 			'method': 'PATCH',
 			'fields': [

--- a/test/activities/assetProcessor/data/DisabledProcessor.js
+++ b/test/activities/assetProcessor/data/DisabledProcessor.js
@@ -18,18 +18,18 @@ export const disabledAttachedProcessor = {
 		'width': 300,
 		'height': 399,
 	},
-	"actions": [
-	  {
-		"href": "https://lti.api.brightspace.com/6609/asset-processor/1",
-		"name": "enable-asset-processor",
-		"method": "PATCH",
-		"fields": [
-			{
-				"type": "checkbox",
-				"name": "isEnabled",
-				"value": true
-			}
-		]
-	  }
+	'actions': [
+		{
+			'href': 'https://lti.api.brightspace.com/6609/asset-processor/1',
+			'name': 'enable-asset-processor',
+			'method': 'PATCH',
+			'fields': [
+				{
+					'type': 'checkbox',
+					'name': 'isEnabled',
+					'value': true
+				}
+			]
+		}
 	]
 };

--- a/test/activities/assetProcessor/data/EnabledProcessor.js
+++ b/test/activities/assetProcessor/data/EnabledProcessor.js
@@ -20,7 +20,7 @@ export const enabledAttachedProcessor = {
 	},
 	'actions': [
 		{
-			'href': 'https://lti.api.brightspace.com/6609/asset-processor/1',
+			'href': 'https://lti.api.brightspace.com/6609/asset-processor/1/update',
 			'name': 'disable-asset-processor',
 			'method': 'PATCH',
 			'fields': [

--- a/test/activities/assetProcessor/data/EnabledProcessor.js
+++ b/test/activities/assetProcessor/data/EnabledProcessor.js
@@ -18,18 +18,18 @@ export const enabledAttachedProcessor = {
 		'width': 300,
 		'height': 399,
 	},
-	"actions": [
-	  {
-		"href": "https://lti.api.brightspace.com/6609/asset-processor/1",
-		"name": "disable-asset-processor",
-		"method": "PATCH",
-		"fields": [
-			{
-				"type": "checkbox",
-				"name": "isEnabled",
-				"value": false
-			}
-		]
-	  }
+	'actions': [
+		{
+			'href': 'https://lti.api.brightspace.com/6609/asset-processor/1',
+			'name': 'disable-asset-processor',
+			'method': 'PATCH',
+			'fields': [
+				{
+					'type': 'checkbox',
+					'name': 'isEnabled',
+					'value': false
+				}
+			]
+		}
 	]
 };

--- a/test/activities/assetProcessor/data/EnabledProcessor.js
+++ b/test/activities/assetProcessor/data/EnabledProcessor.js
@@ -1,0 +1,35 @@
+export const enabledAttachedProcessor = {
+	'class': [
+		'asset-processor-attached-processor'
+	],
+	'rel': [
+		'https://lti.api.brightspace.com/rels/asset-processor-attached-processor'
+	],
+	'properties': {
+		'externalDeploymentId': '65AE4832-5255-4806-804F-09D39945015E',
+		'deploymentName': 'Deployment',
+		'assetProcessorId': 1,
+		'title': 'Processor 1',
+		'settingsLinkId': 10,
+		'settingsLaunchRoute': '',
+		'eulaLaunchRoute': '',
+		'isEnabled': true,
+		'isExternalResource': false,
+		'width': 300,
+		'height': 399,
+	},
+	"actions": [
+	  {
+		"href": "https://lti.api.brightspace.com/6609/asset-processor/1",
+		"name": "disable-asset-processor",
+		"method": "PATCH",
+		"fields": [
+			{
+				"type": "checkbox",
+				"name": "isEnabled",
+				"value": false
+			}
+		]
+	  }
+	]
+};


### PR DESCRIPTION
https://desire2learn.atlassian.net/browse/MAJ-1931

**Related PRs**
- https://github.com/Brightspace/lms/pull/65776/
- https://github.com/BrightspaceHypermediaComponents/activities/pull/5546

**Changes in this PR**
- Added support for Enabling/Disabling/Deleting Asset Processors using `siren-sdk`

**Local Testing** (can't be testing on a real site
- Install `siren-sdk` and `activities` changes into local BSI
- Attached Processors correctly display "Disable" option in dropdown, when enabled ✔️ 
- Attached Processors correctly display "Enable" option in dropdown, when disabled ✔️ 
- Attached Processors correctly display a disabled status, when disabled ✔️ 
- Attached Processors always display "Delete" option in dropdown (temporary - but expected right now) ✔️ 
- Clicking "Disable" on an attached processor correctly calls the associated HM endpoint ✔️
- Clicking "Enable" on an attached processor correctly calls the associated HM endpoint ✔️ 
- Clicking "Delete" on an attached processor correctly calls the associated HM endpoint ✔️  

Local testing looks good. This is difficult to test on a CI site & blocks the `activites` PR, so I'll be merging this.