### PR TITLE
MAN-3653 -- Remove registryId property from module entity

### DIFF
--- a/src/activities/content/ContentModuleEntity.js
+++ b/src/activities/content/ContentModuleEntity.js
@@ -110,14 +110,6 @@ export class ContentModuleEntity extends Entity {
 	}
 
 	/**
-	 * @returns {string} The registryId of the content-module (read-only)
-	 */
-
-	registryId() {
-		return this._entity && this._entity.properties && this._entity.properties.registryId;
-	}
-
-	/**
 	 * @returns {string} Returns the endpoint for generating a summary for the module
 	 */
 	generateSummaryEndpoint() {

--- a/test/activities/content/ContentModuleEntity.test.js
+++ b/test/activities/content/ContentModuleEntity.test.js
@@ -47,10 +47,6 @@ describe('ContentModuleEntity', () => {
 			expect(contentModuleEntity.moduleId()).to.equal('12345');
 		});
 
-		it('reads registry id', () => {
-			expect(contentModuleEntity.registryId()).to.equal('38db1f7d-7917-445d-867e-67034387744b');
-		});
-
 		it('reads generate module summary url', () => {
 			expect(contentModuleEntity.generateSummaryEndpoint()).to.equal('https://fake-tenant-id.modules.api.proddev.d2l/6613/modules/12345/summary');
 		});

--- a/test/activities/content/data/TestContentModuleEntity.js
+++ b/test/activities/content/data/TestContentModuleEntity.js
@@ -56,7 +56,6 @@ export const contentModuleData = {
 		'customAccentColor': 'FF0000',
 		'orgUnitId': '6613',
 		'moduleId': '12345',
-		'registryId': '38db1f7d-7917-445d-867e-67034387744b',
 		'aiHumanOrigin': 0
 	},
 	'entities': [


### PR DESCRIPTION
https://desire2learn.atlassian.net/browse/MAN-3653

With https://github.com/Brightspace/generate-question/pull/527 and https://github.com/BrightspaceHypermediaComponents/activities/pull/5559 there is now no longer a need for the registryId property on module entities.

Will remove it from the LMS once this is merged.