### PR TITLE
FED-5892 Add new property to check if AI modify content functionality enabled.

### DIFF
--- a/src/activities/ActivityUsageEntity.js
+++ b/src/activities/ActivityUsageEntity.js
@@ -682,6 +682,13 @@ export class ActivityUsageEntity extends Entity {
 	}
 
 	/**
+	 * @returns {bool} Whether or not the activity usage entity has AI modify content functionality enabled
+	 */
+	isAIContentEnabled() {
+		return this._entity && this._entity.hasClass('ai-content-enabled');
+	}
+
+	/**
 	 * @returns {bool} Whether or not the activity usage entity is draft
 	 */
 	isDraft() {

--- a/src/hypermedia-constants.js
+++ b/src/hypermedia-constants.js
@@ -400,6 +400,7 @@ export const Classes = {
 		rawDescription: 'raw-description',
 		lastModified: 'lastModified',
 		aiInspired: 'ai-inspired',
+		AIContentEnabled: 'ai-content-enabled'
 	},
 	contentStyler: {
 		contentStyler: 'content-styler',

--- a/test/activities/ActivityUsageEntity.test.js
+++ b/test/activities/ActivityUsageEntity.test.js
@@ -144,6 +144,12 @@ describe('ActivityUsageEntity', () => {
 			});
 		});
 
+		describe('isAIContentEnabled', () => {
+			it('gets AIContent Enabled', () => {
+				expect(entity.isAIContentEnabled()).to.be.true;
+			});
+		});
+
 		describe('Draft Status', () => {
 			describe('Can edit', () => {
 				let setDraftStatusSpy;

--- a/test/activities/data/ActivityUsageEntity.js
+++ b/test/activities/data/ActivityUsageEntity.js
@@ -3,7 +3,8 @@ export const testData = {
 		'class': [
 			'assignment-activity',
 			'draft-published-entity',
-			'draft'
+			'draft',
+			'ai-content-enabled'
 		],
 		'entities': [
 			{


### PR DESCRIPTION
Add `isAIContentEnabled` to activityUsageEntity to be used by pages to decide whether to show the "modify with AI" button.

Story Related
https://desire2learn.atlassian.net/browse/FED-5892

requires
https://github.com/Brightspace/lms/pull/69313