### PR TITLE
[ MAJ-2143 ] Add Requires EULA to APDeeplinkCollectionEntity

### DIFF
--- a/src/activities/assetProcessor/APDeepLinksCollectionEntity.js
+++ b/src/activities/assetProcessor/APDeepLinksCollectionEntity.js
@@ -33,6 +33,10 @@ class APDeepLinkEntity {
 	deepLinkLaunchRoute() {
 		return this._entity && this._entity.properties && this._entity.properties.deepLinkLaunchRoute;
 	}
+
+	requiresEula() {
+		return this._entity && this._entity.properties && (this._entity.properties.requiresEula ?? false);
+	}
 }
 
 /**

--- a/test/activities/assetProcessor/APDeepLinksCollectionEntity.test.js
+++ b/test/activities/assetProcessor/APDeepLinksCollectionEntity.test.js
@@ -21,6 +21,7 @@ describe('APDeepLinksCollectionEntity', () => {
 				expect(deepLink.linkId()).to.be.a('number');
 				expect(deepLink.linkName()).to.be.a('string');
 				expect(deepLink.deepLinkLaunchRoute()).to.be.a('string');
+				expect(deepLink.requiresEula()).to.be.a('boolean');
 			});
 		});
 	});

--- a/test/activities/assetProcessor/data/DeepLinksCollection.js
+++ b/test/activities/assetProcessor/data/DeepLinksCollection.js
@@ -15,7 +15,8 @@ export const deepLinksCollection = {
 				'deploymentName': 'LTI Testing Tool   - 902b47c0',
 				'linkId': 10,
 				'linkName': 'LTI Asset Processor Deeplink Launch',
-				'deepLinkLaunchRoute': '/d2l/le/lti/6609/deepLinkingLaunch/10/assetprocessor/dropbox/1'
+				'deepLinkLaunchRoute': '/d2l/le/lti/6609/deepLinkingLaunch/10/assetprocessor/dropbox/1',
+				'requiresEula' : false
 			}
 		},
 		{
@@ -30,6 +31,7 @@ export const deepLinksCollection = {
 				'linkId': 11,
 				'linkName': 'LTI Asset Processor Create Launch 2',
 				'deepLinkLaunchRoute': '/d2l/le/lti/6609/deepLinkingLaunch/11/assetprocessor/dropbox/1',
+				'requiresEula' : true
 			}
 		},
 	]


### PR DESCRIPTION
https://desire2learn.atlassian.net/browse/MAJ-2143

Adding "requires eula" to deeplinking entity to be used when attaching an asset processor