### PR TITLE
maj-2141 - lti - adding allowed submission types for asset processor array

### DIFF
--- a/src/activities/assignments/AssignmentEntity.js
+++ b/src/activities/assignments/AssignmentEntity.js
@@ -965,6 +965,13 @@ export class AssignmentEntity extends Entity {
 		return this._entity.getLinkByRel(Rels.LTI.assetProcessorAttachedProcessors).href;
 	}
 
+	/**
+	 * @returns {string} Submission Types allowed when asset processor items are attached
+	 */
+	allowedSubmissionTypesForAssetProcessor() {
+		return this._entity && this._entity.properties && this._entity.properties.allowedSubmissionTypesForAssetProcessor;
+	}
+
 	canSave() {
 		return this._entity && this._entity.hasActionByName(Actions.assignments.update);
 	}

--- a/test/activities/assignments/AssignmentEntity.test.js
+++ b/test/activities/assignments/AssignmentEntity.test.js
@@ -53,7 +53,8 @@ describe('AssignmentEntity', () => {
 				assignmentType: 'group',
 				groupTypeId: '314',
 				filesSubmissionLimit: 'unlimited',
-				defaultScoringRubricId: null
+				defaultScoringRubricId: null,
+				allowedSubmissionTypesForAssetProcessor: [ 0, 1, 4 ],
 			})).to.be.true;
 		});
 

--- a/test/activities/assignments/data/EditableAssignment.js
+++ b/test/activities/assignments/data/EditableAssignment.js
@@ -3,7 +3,12 @@ export const editableAssignment = {
 		'assignment'
 	],
 	'properties': {
-		'name': 'Extra Special Assignment'
+		'name': 'Extra Special Assignment',
+		'allowedSubmissionTypesForAssetProcessor': [
+			0,
+			1,
+			4
+		]
 	},
 	'entities': [
 		{


### PR DESCRIPTION
https://desire2learn.atlassian.net/browse/MAJ-2141

The API returns a list of submission types that are allowed when asset processors have been attached

<img width="1544" height="1194" alt="image" src="https://github.com/user-attachments/assets/cfbcc00f-6a84-4566-b41f-5cb30e7c66e8" />
