### PR TITLE
remove registry-url from Brightspace/setup-node

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,6 @@ jobs:
       - uses: Brightspace/setup-node@main
         with:
           node-version-file: .nvmrc
-          registry-url: "https://registry.npmjs.org"
       - name: Incremental Release
         uses: BrightspaceUI/actions/incremental-release@main
         with:

--- a/package.json
+++ b/package.json
@@ -17,7 +17,8 @@
     "/src"
   ],
   "publishConfig": {
-    "access": "public"
+    "access": "public",
+    "registry": "https://registry.npmjs.org/"
   },
   "dependencies": {
     "@brightspace-ui/core": "^3",


### PR DESCRIPTION
The `registry-url` input will soon be managed by Brightspace/setup-node itself.
The registry to publish packages to is now defined in `publishConfig` in `package.json`.

[HOD-4561 - Proxy Registry > Update Brightspace/setup-node](https://desire2learn.atlassian.net/browse/HOD-4561)