### PR TITLE
MED-3086: add new action for saving to Createspace

### DIFF
--- a/src/activities/assignments/AssignmentEntity.js
+++ b/src/activities/assignments/AssignmentEntity.js
@@ -883,6 +883,18 @@ export class AssignmentEntity extends Entity {
 	}
 
 	/**
+	 * Saves the assignment to Createspace
+	 */
+	_formatSaveToCreatespaceAction() {
+		const action = this._entity && this._entity.getActionByName(Actions.assignments.saveToCreatespace);
+		if (!action) {
+			return;
+		}
+
+		return { action };
+	}
+
+	/**
 	 * @returns {bool} Whether or not the user can see and set annotation availability for the assignment entity
 	 */
 	canEditAnnotations() {
@@ -976,6 +988,7 @@ export class AssignmentEntity extends Entity {
 		const updateDefaultScoringRubricAction = this._formatDefaultScoringRubricAction(assignment.defaultScoringRubricId);
 		const updateNotificationEmailAction = this._formatUpdateNotificationEmailAction(assignment.notificationEmail);
 		const updateIsAiInspiredAction = this._formatUpdateAiInspiredAction(assignment.isAiInspired);
+		const saveToCreatespaceAction = this._formatSaveToCreatespaceAction();
 
 		const sirenActions = [
 			updateNameAction,
@@ -991,7 +1004,8 @@ export class AssignmentEntity extends Entity {
 			updateformatAssignmentTypeAction,
 			updateDefaultScoringRubricAction,
 			updateNotificationEmailAction,
-			updateIsAiInspiredAction
+			updateIsAiInspiredAction,
+			saveToCreatespaceAction
 		];
 
 		await performSirenActions(this._token, sirenActions);

--- a/src/hypermedia-constants.js
+++ b/src/hypermedia-constants.js
@@ -754,6 +754,7 @@ export const Actions = {
 	assignments: {
 		assign: 'assign',
 		delete: 'delete',
+		saveToCreatespace: 'save-to-createspace',
 		updateGroupType: 'update-group-type',
 		updateFolderType: 'update-folder-type',
 		updateInstructions: 'update-instructions',

--- a/test/activities/assignments/AssignmentEntity.test.js
+++ b/test/activities/assignments/AssignmentEntity.test.js
@@ -271,6 +271,36 @@ describe('AssignmentEntity', () => {
 			expect(fetchMock.called()).to.be.true;
 		});
 
+		it('saves to Createspace', async() => {
+			const createspaceHref = 'https://f5aa43d7-c082-485c-84f5-4808147fe98a.assignments.api.dev.brightspace.com/123065/folders/7/saveToCreatespace';
+			fetchMock.patchOnce('https://f5aa43d7-c082-485c-84f5-4808147fe98a.assignments.api.dev.brightspace.com/123065/folders/7', editableEntity);
+			fetchMock.postOnce(createspaceHref, {});
+
+			const createspaceAssignmentEntity = new AssignmentEntity(SirenParse({
+				...editableAssignment,
+				actions: [
+					...editableAssignment.actions,
+					{
+						href: createspaceHref,
+						name: 'save-to-createspace',
+						method: 'POST'
+					}
+				]
+			}));
+
+			await createspaceAssignmentEntity.save({
+				instructions: 'Instructions for Createspace assignment'
+			});
+
+			const calls = fetchMock.calls();
+			expect(calls.length).to.equal(2);
+			const form = await getFormData(calls[0].request);
+			if (!form.notSupported) {
+				expect(form.get('instructions')).to.equal('Instructions for Createspace assignment');
+			}
+			expect(calls[1][0]).to.equal(createspaceHref);
+		});
+
 		it('skips save if not dirty', async() => {
 			const assignmentEntity = new AssignmentEntity(editableEntity);
 


### PR DESCRIPTION
These changes help fix an issue where two versions are created instead of one when saving an assignment in Createspace.

Saving to Createspace is being separated out into its own action here: https://github.com/Brightspace/lms/pull/89792