### PR TITLE
MED-3086: add action to save to Createspace for discussions

### DIFF
--- a/src/activities/discussions/DiscussionTopicEntity.js
+++ b/src/activities/discussions/DiscussionTopicEntity.js
@@ -208,6 +208,15 @@ export class DiscussionTopicEntity extends Entity {
 		return { action, fields };
 	}
 
+	_formatSaveToCreatespaceAction() {
+		const action = this._entity && this._entity.getActionByName(Actions.discussions.topic.saveToCreatespace);
+		if (!action) {
+			return;
+		}
+
+		return { action };
+	}
+
 	/**
 	 * @returns {bool} Whether or not the edit description action is present on the topic description entity
 	 */
@@ -450,6 +459,7 @@ export class DiscussionTopicEntity extends Entity {
 		const updateParticipationOption = this._formatUpdateParticipationOptionAction(topic);
 		const updateRequiresApproval = this._formatUpdateRequiresApproval(topic);
 		const updateIsAiInspired = this._formatUpdateAiInspiredAction(topic);
+		const saveToCreatespace = this._formatSaveToCreatespaceAction();
 
 		const sirenActions = [
 			updateNameAction,
@@ -458,7 +468,8 @@ export class DiscussionTopicEntity extends Entity {
 			updateRatePostType,
 			updateParticipationOption,
 			updateRequiresApproval,
-			updateIsAiInspired
+			updateIsAiInspired,
+			saveToCreatespace
 		];
 
 		await performSirenActions(this._token, sirenActions);

--- a/src/hypermedia-constants.js
+++ b/src/hypermedia-constants.js
@@ -849,7 +849,8 @@ export const Actions = {
 			updateRatingType: 'update-ratingtype',
 			updateParticipationOption: 'update-participationtype',
 			createAndAssociateWithForum: 'create-and-associate-with-forum',
-			requiresApproval : 'requires-approval'
+			requiresApproval : 'requires-approval',
+			saveToCreatespace: 'save-to-createspace'
 		},
 		groupSectionRestrictions: {
 			startUpdateRestrictions: 'start-update-restrictions',

--- a/test/activities/discussions/DiscussionTopicEntity.test.js
+++ b/test/activities/discussions/DiscussionTopicEntity.test.js
@@ -285,6 +285,35 @@ describe('DiscussionTopicEntity', () => {
 
 			expect(fetchMock.called()).to.be.false;
 		});
+
+		it('saves to Createspace when the action is present', async() => {
+			const createspaceHref = 'https://f5aa43d7-c082-485c-84f5-4808147fe98a.discussions.api.dev.brightspace.com/6613/forums/10003/topics/10004/save-to-createspace';
+			fetchMock.postOnce(createspaceHref, {});
+
+			const discussionTopic = new DiscussionTopicEntity(SirenParse({
+				...editableDiscussionTopic,
+				actions: [
+					...editableDiscussionTopic.actions,
+					{
+						href: createspaceHref,
+						name: 'save-to-createspace',
+						method: 'POST'
+					}
+				]
+			}));
+
+			await discussionTopic.save({
+				name: 'New name',
+			});
+
+			const calls = fetchMock.calls();
+			expect(calls.length).to.equal(2);
+			const form = await getFormData(calls[0].request);
+			if (!form.notSupported) {
+				expect(form.get('name')).to.equal('New name');
+			}
+			expect(calls[1][0]).to.equal(createspaceHref);
+		});
 	});
 
 	describe('recommendAlignments', () => {


### PR DESCRIPTION
Similar to assignments, creating a discussion in Createspace creates two initial versions so I'm applying the same fix as done here: https://github.com/BrightspaceHypermediaComponents/siren-sdk/pull/809

Work to do: 
- add a new `save-to-createspace` action to SirenDiscussionsSerializer
- add a new route to the discussions controller to handle the new action and remove other `SaveObjectToCreateSpace` calls in the discussions code